### PR TITLE
TrayIcon is correctly selected after startup

### DIFF
--- a/SoundSwitch/Util/TrayIcon.cs
+++ b/SoundSwitch/Util/TrayIcon.cs
@@ -105,6 +105,8 @@ namespace SoundSwitch.Util
 
         private void InitIcon()
         {
+            if (AppConfigs.Configuration.KeepSystrayIcon)
+                return;
             try
             {
                 IAudioDevice defaultDevice = AppModel.Instance.ActiveAudioDeviceLister.GetPlaybackDevices()

--- a/SoundSwitch/Util/TrayIcon.cs
+++ b/SoundSwitch/Util/TrayIcon.cs
@@ -54,6 +54,7 @@ namespace SoundSwitch.Util
 
         public TrayIcon()
         {
+            InitIcon();
             _tooltipInfoManager = new TooltipInfoManager(NotifyIcon);
             _updateMenuItem = new ToolStripMenuItem(TrayIconStrings.NoUpdate, Resources.Update, OnUpdateClick)
             {
@@ -100,6 +101,19 @@ namespace SoundSwitch.Util
             _settingsMenu.Dispose();
             NotifyIcon.Dispose();
             _updateMenuItem.Dispose();
+        }
+
+        private void InitIcon()
+        {
+            try
+            {
+                IAudioDevice defaultDevice = AppModel.Instance.ActiveAudioDeviceLister.GetPlaybackDevices()
+                    .First(device => device.IsDefault(Role.Console));
+                NotifyIcon.Icon = AudioDeviceIconExtractor.ExtractIconFromAudioDevice(defaultDevice, false);
+            }
+            catch (InvalidOperationException)
+            {
+            }
         }
 
         private void PopulateSettingsMenu()


### PR DESCRIPTION
The current audio device specific icon is used as tray icon after SoundSwitch is started and no switch has been performed