### PR TITLE
Improved the update system to support three different modes

### DIFF
--- a/SoundSwitch/Framework/Configuration/ISoundSwitchConfiguration.cs
+++ b/SoundSwitch/Framework/Configuration/ISoundSwitchConfiguration.cs
@@ -1,11 +1,11 @@
 ﻿/********************************************************************
 * Copyright (C) 2015 Antoine Aflalo
-* 
+*
 * This program is free software; you can redistribute it and/or
 * modify it under the terms of the GNU General Public License
 * as published by the Free Software Foundation; either version 2
 * of the License, or (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -37,9 +37,9 @@ namespace SoundSwitch.Framework.Configuration
 
         bool MigratedSelectedDeviceLists { get; set; }
         NotificationTypeEnum NotificationSettings { get; set; }
-        bool SubscribedBetaVersion { get; set; }
+        bool IncludeBetaVersions { get; set; }
         string CustomNotificationFilePath { get; set; }
-        UpdateState UpdateState { get; set; }
+        UpdateMode UpdateMode { get; set; }
         TooltipInfoTypeEnum TooltipInfo { get; set; }
         DeviceCyclerTypeEnum CyclerType { get; set; }
         bool KeepSystrayIcon { get; set; }

--- a/SoundSwitch/Framework/Configuration/SoundSwitchConfiguration.cs
+++ b/SoundSwitch/Framework/Configuration/SoundSwitchConfiguration.cs
@@ -1,11 +1,11 @@
 ﻿/********************************************************************
 * Copyright (C) 2015 Antoine Aflalo
-* 
+*
 * This program is free software; you can redistribute it and/or
 * modify it under the terms of the GNU General Public License
 * as published by the Free Software Foundation; either version 2
 * of the License, or (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -36,10 +36,10 @@ namespace SoundSwitch.Framework.Configuration
             SelectedRecordingDeviceListId = new HashSet<string>();
             PlaybackHotKeys = new HotKeys(Keys.F11, HotKeys.ModifierKeys.Alt | HotKeys.ModifierKeys.Control);
             RecordingHotKeys = new HotKeys(Keys.F7, HotKeys.ModifierKeys.Alt | HotKeys.ModifierKeys.Control);
-            //12 hours
-            UpdateCheckInterval = 3600 * 12;
-            UpdateState = UpdateState.Steath;
-            SubscribedBetaVersion = false;
+            // 24 hours
+            UpdateCheckInterval = 3600 * 24;
+            UpdateMode = UpdateMode.Notify;
+            IncludeBetaVersions = false;
             TooltipInfo = TooltipInfoTypeEnum.Playback;
             CyclerType = DeviceCyclerTypeEnum.Available;
             KeepSystrayIcon = false;
@@ -58,11 +58,11 @@ namespace SoundSwitch.Framework.Configuration
         public HotKeys RecordingHotKeys { get; set; }
         public bool ChangeCommunications { get; set; }
         public uint UpdateCheckInterval { get; set; }
-        public UpdateState UpdateState { get; set; }
+        public UpdateMode UpdateMode { get; set; }
         public TooltipInfoTypeEnum TooltipInfo { get; set; }
         public DeviceCyclerTypeEnum CyclerType { get; set; }
         public NotificationTypeEnum NotificationSettings { get; set; }
-        public bool SubscribedBetaVersion { get; set; }
+        public bool IncludeBetaVersions { get; set; }
         public string CustomNotificationFilePath { get; set; }
         public bool KeepSystrayIcon { get; set; }
 

--- a/SoundSwitch/Framework/Updater/UpdateMode.cs
+++ b/SoundSwitch/Framework/Updater/UpdateMode.cs
@@ -1,0 +1,20 @@
+﻿namespace SoundSwitch.Framework.Updater
+{
+    public enum UpdateMode
+    {
+        /// <summary>
+        /// Updates are installed in the background automatically without asking the user anything
+        /// </summary>
+        Silent,
+
+        /// <summary>
+        /// If an update exists, the user will be notified
+        /// </summary>
+        Notify,
+
+        /// <summary>
+        /// Update mechanism is disabled
+        /// </summary>
+        Never
+    }
+}

--- a/SoundSwitch/Framework/Updater/UpdateState.cs
+++ b/SoundSwitch/Framework/Updater/UpdateState.cs
@@ -1,8 +1,0 @@
-﻿namespace SoundSwitch.Framework.Updater
-{
-    public enum UpdateState
-    {
-        Normal,
-        Steath
-    }
-}

--- a/SoundSwitch/Model/Events.cs
+++ b/SoundSwitch/Model/Events.cs
@@ -1,11 +1,11 @@
 ﻿/********************************************************************
 * Copyright (C) 2015 Antoine Aflalo
-* 
+*
 * This program is free software; you can redistribute it and/or
 * modify it under the terms of the GNU General Public License
 * as published by the Free Software Foundation; either version 2
 * of the License, or (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -70,11 +70,11 @@ namespace SoundSwitch.Model
 
     public class NewReleaseAvailableEvent : UpdateChecker.NewReleaseEvent
     {
-        public UpdateState UpdateState { get; }
+        public UpdateMode UpdateMode { get; }
 
-        public NewReleaseAvailableEvent(Release release, UpdateState updateState) : base(release)
+        public NewReleaseAvailableEvent(Release release, UpdateMode updateMode) : base(release)
         {
-            UpdateState = updateState;
+            UpdateMode = updateMode;
         }
     }
 }

--- a/SoundSwitch/Model/IAppModel.cs
+++ b/SoundSwitch/Model/IAppModel.cs
@@ -1,12 +1,12 @@
 /********************************************************************
 * Copyright (C) 2015 Jeroen Pelgrims
 * Copyright (C) 2015 Antoine Aflalo
-* 
+*
 * This program is free software; you can redistribute it and/or
 * modify it under the terms of the GNU General Public License
 * as published by the Free Software Foundation; either version 2
 * of the License, or (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -77,18 +77,18 @@ namespace SoundSwitch.Model
         /// <summary>
         /// Beta or Stable channel.
         /// </summary>
-        bool SubscribedBetaVersions { get; set; }
+        bool IncludeBetaVersions { get; set; }
 
         /// <summary>
         /// The sound to be played for a Custom notification
-        /// <exception cref="CachedSoundFileNotExistsException">Sound file doens't exists or not set</exception>
+        /// <exception cref="CachedSoundFileNotExistsException">Sound file doesn't exists or not set</exception>
         /// </summary>
         CachedSound CustomNotificationSound { get; set; }
 
         /// <summary>
-        /// Application update itselve in the background without asking the user
+        /// Specifies how the application searches for updates and installs them
         /// </summary>
-        bool StealthUpdate { get; set; }
+        UpdateMode UpdateMode { get; set; }
 
         #endregion
 

--- a/SoundSwitch/Program.cs
+++ b/SoundSwitch/Program.cs
@@ -1,12 +1,12 @@
 ﻿/********************************************************************
 * Copyright (C) 2015 Jeroen Pelgrims
 * Copyright (C) 2015 Antoine Aflalo
-* 
+*
 * This program is free software; you can redistribute it and/or
 * modify it under the terms of the GNU General Public License
 * as published by the Free Software Foundation; either version 2
 * of the License, or (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -85,7 +85,7 @@ namespace SoundSwitch
                 Application.SetCompatibleTextRenderingDefault(false);
 
                 //Manage the Closing events send by Windows
-                //Since this app don't use a Form as "main window" the app doesn't close 
+                //Since this app don't use a Form as "main window" the app doesn't close
                 //when it should without this.
                 WindowsAPIAdapter.RestartManagerTriggered += (sender, @event) =>
                 {
@@ -127,17 +127,16 @@ namespace SoundSwitch
                         {
                             Thread.Sleep(250);
                         }
-                        
+
                     }
                     AppModel.Instance.TrayIcon = icon;
                     AppModel.Instance.InitializeMain();
                     AppModel.Instance.NewVersionReleased += (sender, @event) =>
                     {
-                        if (@event.UpdateState != UpdateState.Steath)
+                        if (@event.UpdateMode == UpdateMode.Silent)
                         {
-                            return;
+                            new AutoUpdater("/VERYSILENT /NOCANCEL /NORESTART", ApplicationPath.Default).Update(@event.Release, true);
                         }
-                        new AutoUpdater("/VERYSILENT /NOCANCEL /NORESTART", ApplicationPath.Default).Update(@event.Release, true);
                     };
                     if (AppConfigs.Configuration.FirstRun)
                     {
@@ -149,7 +148,7 @@ namespace SoundSwitch
                 }
 #if !DEBUG
                 }
-               
+
                 catch (Exception ex)
                 {
                     HandleException(ex);
@@ -212,7 +211,7 @@ namespace SoundSwitch
                         {
                             File.Delete(zipFile);
                         }
-                        
+
                         ZipFile.CreateFromDirectory(ApplicationPath.Default, zipFile);
                     }
                     Process.Start("explorer.exe", "/select," + @zipFile);

--- a/SoundSwitch/Properties/AssemblyInfo.cs
+++ b/SoundSwitch/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("SoundSwitch")]
@@ -12,8 +12,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
@@ -29,10 +29,10 @@ using System.Runtime.InteropServices;
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
-//      Minor Version 
+//      Minor Version
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Build and Revision Numbers 
+// You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 [assembly: AssemblyVersion("3.12.8.*")]

--- a/SoundSwitch/Properties/TrayIconStrings.fr.resx
+++ b/SoundSwitch/Properties/TrayIconStrings.fr.resx
@@ -122,7 +122,7 @@
 		<value>MàJ Disponible ({0})</value>
 	</data>
 	<data name="versionAvailable" xml:space="preserve">
-		<value>MàJ pour{0}({1}) est disponible.</value>
+		<value>MàJ pour{0} ({1}) est disponible.</value>
 	</data>
 	<data name="howDownloadUpdate" xml:space="preserve">
 		<value>Cliquer ici pour mettre à jour.</value>

--- a/SoundSwitch/Properties/TrayIconStrings.resx
+++ b/SoundSwitch/Properties/TrayIconStrings.resx
@@ -142,7 +142,7 @@
     <value>Update Available ({0})</value>
   </data>
 	<data name="versionAvailable" xml:space="preserve">
-    <value>Update for {0}({1}) is available.</value>
+    <value>Update for {0} ({1}) is available.</value>
   </data>
 	<data name="howDownloadUpdate" xml:space="preserve">
     <value>Click here to update.</value>

--- a/SoundSwitch/SoundSwitch.csproj
+++ b/SoundSwitch/SoundSwitch.csproj
@@ -296,7 +296,7 @@
     <Compile Include="Framework\Updater\Release.cs" />
     <Compile Include="Framework\Updater\SignatureChecker.cs" />
     <Compile Include="Framework\Updater\UpdateChecker.cs" />
-    <Compile Include="Framework\Updater\UpdateState.cs" />
+    <Compile Include="Framework\Updater\UpdateMode.cs" />
     <Compile Include="Framework\Updater\WebFile.cs" />
     <Compile Include="Framework\WindowsAPIAdapter.cs">
       <SubType>Form</SubType>

--- a/SoundSwitch/UI/Forms/Settings.Designer.cs
+++ b/SoundSwitch/UI/Forms/Settings.Designer.cs
@@ -42,9 +42,10 @@ namespace SoundSwitch.UI.Forms
             this.recordingListView = new System.Windows.Forms.ListView();
             this.appSettingTabPage = new System.Windows.Forms.TabPage();
             this.updateSettingsGroup = new System.Windows.Forms.GroupBox();
-            this.checkForUpdateRadio = new System.Windows.Forms.RadioButton();
-            this.autoInstallRadio = new System.Windows.Forms.RadioButton();
-            this.betaVersionCheckbox = new System.Windows.Forms.CheckBox();
+            this.updateNeverRadioButton = new System.Windows.Forms.RadioButton();
+            this.updateNotifyRadioButton = new System.Windows.Forms.RadioButton();
+            this.updateSilentRadioButton = new System.Windows.Forms.RadioButton();
+            this.includeBetaVersionsCheckbox = new System.Windows.Forms.CheckBox();
             this.audioSettingsGroup = new System.Windows.Forms.GroupBox();
             this.cyclerLabel = new System.Windows.Forms.Label();
             this.cyclerComboBox = new System.Windows.Forms.ComboBox();
@@ -196,9 +197,10 @@ namespace SoundSwitch.UI.Forms
             // 
             this.updateSettingsGroup.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.updateSettingsGroup.Controls.Add(this.checkForUpdateRadio);
-            this.updateSettingsGroup.Controls.Add(this.autoInstallRadio);
-            this.updateSettingsGroup.Controls.Add(this.betaVersionCheckbox);
+            this.updateSettingsGroup.Controls.Add(this.updateNeverRadioButton);
+            this.updateSettingsGroup.Controls.Add(this.updateNotifyRadioButton);
+            this.updateSettingsGroup.Controls.Add(this.updateSilentRadioButton);
+            this.updateSettingsGroup.Controls.Add(this.includeBetaVersionsCheckbox);
             this.updateSettingsGroup.Location = new System.Drawing.Point(321, 3);
             this.updateSettingsGroup.Name = "updateSettingsGroup";
             this.updateSettingsGroup.Size = new System.Drawing.Size(209, 123);
@@ -206,41 +208,53 @@ namespace SoundSwitch.UI.Forms
             this.updateSettingsGroup.TabStop = false;
             this.updateSettingsGroup.Text = "Update Settings";
             // 
-            // checkForUpdateRadio
+            // updateNeverRadioButton
             // 
-            this.checkForUpdateRadio.AutoSize = true;
-            this.checkForUpdateRadio.Location = new System.Drawing.Point(7, 43);
-            this.checkForUpdateRadio.Name = "checkForUpdateRadio";
-            this.checkForUpdateRadio.Size = new System.Drawing.Size(109, 17);
-            this.checkForUpdateRadio.TabIndex = 20;
-            this.checkForUpdateRadio.TabStop = true;
-            this.checkForUpdateRadio.Text = global::SoundSwitch.Properties.SettingsString.checkUpdate;
-            this.checkForUpdateRadio.UseVisualStyleBackColor = true;
-            this.checkForUpdateRadio.CheckedChanged += new System.EventHandler(this.checkForUpdateRadio_CheckedChanged);
+            this.updateNeverRadioButton.AutoSize = true;
+            this.updateNeverRadioButton.Location = new System.Drawing.Point(7, 66);
+            this.updateNeverRadioButton.Name = "updateNeverRadioButton";
+            this.updateNeverRadioButton.Size = new System.Drawing.Size(143, 17);
+            this.updateNeverRadioButton.TabIndex = 21;
+            this.updateNeverRadioButton.TabStop = true;
+            this.updateNeverRadioButton.Text = "Never check for updates";
+            this.updateNeverRadioButton.UseVisualStyleBackColor = true;
+            this.updateNeverRadioButton.CheckedChanged += new System.EventHandler(this.updateNeverRadioButton_CheckedChanged);
             // 
-            // autoInstallRadio
+            // updateNotifyRadioButton
             // 
-            this.autoInstallRadio.AutoSize = true;
-            this.autoInstallRadio.Location = new System.Drawing.Point(7, 20);
-            this.autoInstallRadio.Name = "autoInstallRadio";
-            this.autoInstallRadio.Size = new System.Drawing.Size(77, 17);
-            this.autoInstallRadio.TabIndex = 19;
-            this.autoInstallRadio.TabStop = true;
-            this.autoInstallRadio.Text = global::SoundSwitch.Properties.SettingsString.autoInstall;
-            this.autoInstallRadio.UseVisualStyleBackColor = true;
-            this.autoInstallRadio.CheckedChanged += new System.EventHandler(this.autoInstallRadio_CheckedChanged);
+            this.updateNotifyRadioButton.AutoSize = true;
+            this.updateNotifyRadioButton.Location = new System.Drawing.Point(7, 43);
+            this.updateNotifyRadioButton.Name = "updateNotifyRadioButton";
+            this.updateNotifyRadioButton.Size = new System.Drawing.Size(202, 17);
+            this.updateNotifyRadioButton.TabIndex = 20;
+            this.updateNotifyRadioButton.TabStop = true;
+            this.updateNotifyRadioButton.Text = "Notify me when updates are available";
+            this.updateNotifyRadioButton.UseVisualStyleBackColor = true;
+            this.updateNotifyRadioButton.CheckedChanged += new System.EventHandler(this.updateNotifyRadioButton_CheckedChanged);
             // 
-            // betaVersionCheckbox
+            // updateSilentRadioButton
             // 
-            this.betaVersionCheckbox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.betaVersionCheckbox.AutoSize = true;
-            this.betaVersionCheckbox.Location = new System.Drawing.Point(6, 80);
-            this.betaVersionCheckbox.Name = "betaVersionCheckbox";
-            this.betaVersionCheckbox.Size = new System.Drawing.Size(91, 17);
-            this.betaVersionCheckbox.TabIndex = 18;
-            this.betaVersionCheckbox.Text = global::SoundSwitch.Properties.SettingsString.beta;
-            this.betaVersionCheckbox.UseVisualStyleBackColor = true;
-            this.betaVersionCheckbox.CheckedChanged += new System.EventHandler(this.betaVersionCheckbox_CheckedChanged);
+            this.updateSilentRadioButton.AutoSize = true;
+            this.updateSilentRadioButton.Location = new System.Drawing.Point(7, 20);
+            this.updateSilentRadioButton.Name = "updateSilentRadioButton";
+            this.updateSilentRadioButton.Size = new System.Drawing.Size(157, 17);
+            this.updateSilentRadioButton.TabIndex = 19;
+            this.updateSilentRadioButton.TabStop = true;
+            this.updateSilentRadioButton.Text = "Install updates automatically";
+            this.updateSilentRadioButton.UseVisualStyleBackColor = true;
+            this.updateSilentRadioButton.CheckedChanged += new System.EventHandler(this.updateSilentRadioButton_CheckedChanged);
+            // 
+            // includeBetaVersionsCheckbox
+            // 
+            this.includeBetaVersionsCheckbox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.includeBetaVersionsCheckbox.AutoSize = true;
+            this.includeBetaVersionsCheckbox.Location = new System.Drawing.Point(7, 100);
+            this.includeBetaVersionsCheckbox.Name = "includeBetaVersionsCheckbox";
+            this.includeBetaVersionsCheckbox.Size = new System.Drawing.Size(127, 17);
+            this.includeBetaVersionsCheckbox.TabIndex = 18;
+            this.includeBetaVersionsCheckbox.Text = "Include beta versions";
+            this.includeBetaVersionsCheckbox.UseVisualStyleBackColor = true;
+            this.includeBetaVersionsCheckbox.CheckedChanged += new System.EventHandler(this.betaVersionCheckbox_CheckedChanged);
             // 
             // audioSettingsGroup
             // 
@@ -257,7 +271,7 @@ namespace SoundSwitch.UI.Forms
             this.audioSettingsGroup.Size = new System.Drawing.Size(312, 179);
             this.audioSettingsGroup.TabIndex = 13;
             this.audioSettingsGroup.TabStop = false;
-            this.audioSettingsGroup.Text = SettingsString.audioSettings;
+            this.audioSettingsGroup.Text = "Audio Settings";
             // 
             // cyclerLabel
             // 
@@ -267,7 +281,7 @@ namespace SoundSwitch.UI.Forms
             this.cyclerLabel.Name = "cyclerLabel";
             this.cyclerLabel.Size = new System.Drawing.Size(72, 13);
             this.cyclerLabel.TabIndex = 23;
-            this.cyclerLabel.Text = global::SoundSwitch.Properties.SettingsString.cycleDevice;
+            this.cyclerLabel.Text = "Cycle through";
             // 
             // cyclerComboBox
             // 
@@ -321,7 +335,7 @@ namespace SoundSwitch.UI.Forms
             this.notifLabel.Name = "notifLabel";
             this.notifLabel.Size = new System.Drawing.Size(60, 13);
             this.notifLabel.TabIndex = 17;
-            this.notifLabel.Text = global::SoundSwitch.Properties.SettingsString.notification;
+            this.notifLabel.Text = "Notification";
             // 
             // notificationComboBox
             // 
@@ -343,7 +357,7 @@ namespace SoundSwitch.UI.Forms
             this.basicSettingsGroup.Size = new System.Drawing.Size(312, 62);
             this.basicSettingsGroup.TabIndex = 0;
             this.basicSettingsGroup.TabStop = false;
-            this.basicSettingsGroup.Text = global::SoundSwitch.Properties.SettingsString.basicSettings;
+            this.basicSettingsGroup.Text = "Basic Settings";
             // 
             // checkboxSystrayIcon
             // 
@@ -432,7 +446,7 @@ namespace SoundSwitch.UI.Forms
         private System.Windows.Forms.Label hotkeysLabel;
         private System.Windows.Forms.ComboBox notificationComboBox;
         private System.Windows.Forms.Label notifLabel;
-        private System.Windows.Forms.CheckBox betaVersionCheckbox;
+        private System.Windows.Forms.CheckBox includeBetaVersionsCheckbox;
         private System.Windows.Forms.OpenFileDialog selectSoundFileDialog;
         private System.Windows.Forms.Button selectSoundButton;
         private System.Windows.Forms.CheckBox hotkeysCheckbox;
@@ -445,7 +459,8 @@ namespace SoundSwitch.UI.Forms
         private System.Windows.Forms.Label cyclerLabel;
         private System.Windows.Forms.ComboBox cyclerComboBox;
         private System.Windows.Forms.CheckBox checkboxSystrayIcon;
-        private System.Windows.Forms.RadioButton checkForUpdateRadio;
-        private System.Windows.Forms.RadioButton autoInstallRadio;
+        private System.Windows.Forms.RadioButton updateNotifyRadioButton;
+        private System.Windows.Forms.RadioButton updateSilentRadioButton;
+        private System.Windows.Forms.RadioButton updateNeverRadioButton;
     }
 }

--- a/SoundSwitch/UI/Forms/Settings.cs
+++ b/SoundSwitch/UI/Forms/Settings.cs
@@ -1,12 +1,12 @@
 ﻿/********************************************************************
 * Copyright (C) 2015 Jeroen Pelgrims
 * Copyright (C) 2015 Antoine Aflalo
-* 
+*
 * This program is free software; you can redistribute it and/or
 * modify it under the terms of the GNU General Public License
 * as published by the Free Software Foundation; either version 2
 * of the License, or (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -28,6 +28,7 @@ using SoundSwitch.Framework.DeviceCyclerManager;
 using SoundSwitch.Framework.NotificationManager;
 using SoundSwitch.Framework.TooltipInfoManager;
 using SoundSwitch.Framework.TooltipInfoManager.TootipInfo;
+using SoundSwitch.Framework.Updater;
 using SoundSwitch.Model;
 using SoundSwitch.Properties;
 using SoundSwitch.Util;
@@ -78,9 +79,9 @@ namespace SoundSwitch.UI.Forms
             new NotificationFactory().ConfigureListControl(notificationComboBox);
             notificationComboBox.SelectedValue = AppModel.Instance.NotificationSettings;
 
-            betaVersionCheckbox.Checked = AppModel.Instance.SubscribedBetaVersions;
+            includeBetaVersionsCheckbox.Checked = AppModel.Instance.IncludeBetaVersions;
             var toolTipBeta = new ToolTip();
-            toolTipBeta.SetToolTip(betaVersionCheckbox, SettingsString.betaExplanation);
+            toolTipBeta.SetToolTip(includeBetaVersionsCheckbox, SettingsString.betaExplanation);
 
             selectSoundFileDialog.Filter = SettingsString.supportedAudio + @" (*.wav;*.mp3)|*.wav;*.mp3;*.aiff";
             selectSoundFileDialog.FileOk += SelectSoundFileDialogOnFileOk;
@@ -93,20 +94,26 @@ namespace SoundSwitch.UI.Forms
                                         NotificationTypeEnum.CustomNotification ||
                                         AppModel.Instance.NotificationSettings == NotificationTypeEnum.ToastNotification;
 
-            if (AppModel.Instance.StealthUpdate)
+            switch (AppModel.Instance.UpdateMode)
             {
-                autoInstallRadio.Checked = true;
-            }
-            else
-            {
-                checkForUpdateRadio.Checked = true;
+                case UpdateMode.Silent:
+                    updateSilentRadioButton.Checked = true;
+                    break;
+                case UpdateMode.Notify:
+                    updateNotifyRadioButton.Checked = true;
+                    break;
+                case UpdateMode.Never:
+                    updateNeverRadioButton.Checked = true;
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
             }
 
             var toolTipAutoInstall = new ToolTip();
-            toolTipAutoInstall.SetToolTip(autoInstallRadio, SettingsString.autoInstallHelp);
+            toolTipAutoInstall.SetToolTip(updateSilentRadioButton, SettingsString.autoInstallHelp);
 
             var toolTipCheckUpdate = new ToolTip();
-            toolTipCheckUpdate.SetToolTip(checkForUpdateRadio, SettingsString.checkUpdateHelp);
+            toolTipCheckUpdate.SetToolTip(updateNotifyRadioButton, SettingsString.checkUpdateHelp);
 
             new TooltipInfoFactory().ConfigureListControl(tooltipInfoComboBox);
             tooltipInfoComboBox.SelectedValue = TooltipInfoManager.CurrentTooltipInfo;
@@ -324,7 +331,7 @@ namespace SoundSwitch.UI.Forms
 
         private void betaVersionCheckbox_CheckedChanged(object sender, EventArgs e)
         {
-            AppModel.Instance.SubscribedBetaVersions = betaVersionCheckbox.Checked;
+            AppModel.Instance.IncludeBetaVersions = includeBetaVersionsCheckbox.Checked;
         }
 
         #endregion
@@ -464,19 +471,27 @@ namespace SoundSwitch.UI.Forms
             AppModel.Instance.TrayIcon.UpdateIcon();
         }
 
-        private void autoInstallRadio_CheckedChanged(object sender, EventArgs e)
+        private void updateSilentRadioButton_CheckedChanged(object sender, EventArgs e)
         {
-            if (autoInstallRadio.Checked)
+            if (updateSilentRadioButton.Checked)
             {
-                AppModel.Instance.StealthUpdate = true;
+                AppModel.Instance.UpdateMode = UpdateMode.Silent;
             }
         }
 
-        private void checkForUpdateRadio_CheckedChanged(object sender, EventArgs e)
+        private void updateNotifyRadioButton_CheckedChanged(object sender, EventArgs e)
         {
-            if (checkForUpdateRadio.Checked)
+            if (updateNotifyRadioButton.Checked)
             {
-                AppModel.Instance.StealthUpdate = false;
+                AppModel.Instance.UpdateMode = UpdateMode.Notify;
+            }
+        }
+
+        private void updateNeverRadioButton_CheckedChanged(object sender, EventArgs e)
+        {
+            if (updateNeverRadioButton.Checked)
+            {
+                AppModel.Instance.UpdateMode = UpdateMode.Never;
             }
         }
     }

--- a/SoundSwitch/Util/TrayIcon.cs
+++ b/SoundSwitch/Util/TrayIcon.cs
@@ -198,7 +198,7 @@ namespace SoundSwitch.Util
                  (sender, @event) => { _needToUpdateList = true; };
             AppModel.Instance.NewVersionReleased += (sender, @event) =>
             {
-                if (@event.UpdateState == UpdateState.Normal)
+                if (@event.UpdateMode == UpdateMode.Notify)
                     _context.Send(s => { NewReleaseAvailable(sender, @event); }, null);
             };
 


### PR DESCRIPTION
- Silent (auto-update in background without any prompts)
- Notify (if an update exists, show a notification message)
- Never (never search for an update)

The default update mode is now notify, because if it would be silent an older version would instantly update itself to a newer one. This would break the possibility for the user to stay on that older version without disconnecting from the world wide web.
The default update check interval was set to 24h from 12h - that's often enough.
Some typos fixed.

- [x] Fixes #102 - Ability to disable auto update checker