### PR TITLE
Assigned values to DeviceCyclerTypeEnum and NotificationTypeEnum entries.

### DIFF
--- a/SoundSwitch/Framework/DeviceCyclerManager/DeviceCyclerTypeEnum.cs
+++ b/SoundSwitch/Framework/DeviceCyclerManager/DeviceCyclerTypeEnum.cs
@@ -16,7 +16,7 @@ namespace SoundSwitch.Framework.DeviceCyclerManager
 {
     public enum DeviceCyclerTypeEnum
     {
-        All,
-        Available
+        All = 0,
+        Available = 1
     }
 }

--- a/SoundSwitch/Framework/NotificationManager/NotificationTypeEnum.cs
+++ b/SoundSwitch/Framework/NotificationManager/NotificationTypeEnum.cs
@@ -16,10 +16,10 @@ namespace SoundSwitch.Framework.NotificationManager
 {
     public enum NotificationTypeEnum
     {
-        DefaultWindowsNotification,
-        SoundNotification,
-        CustomNotification,
-        ToastNotification,
-        NoNotification
+        DefaultWindowsNotification = 0,
+        SoundNotification = 1,
+        NoNotification = 2,
+        CustomNotification = 3,
+        ToastNotification = 4
     }
 }


### PR DESCRIPTION
These values are used inside the configuration.

Fixes #161 .