### PR TITLE
Maybe fix memory leak caused by not disposing Icons and Bitmaps.

### DIFF
--- a/SoundSwitch/Framework/NotificationManager/Notification/NotificationBanner.cs
+++ b/SoundSwitch/Framework/NotificationManager/Notification/NotificationBanner.cs
@@ -32,11 +32,13 @@ namespace SoundSwitch.Framework.NotificationManager.Notification
 
         public void NotifyDefaultChanged(MMDevice audioDevice)
         {
+            var Icon = AudioDeviceIconExtractor.ExtractIconFromAudioDevice(audioDevice, true);
             var toastData = new BannerData
             {
-                Image = AudioDeviceIconExtractor.ExtractIconFromAudioDevice(audioDevice, true).ToBitmap(),
+                Image = Icon.ToBitmap(),
                 Text = audioDevice.FriendlyName
             };
+            Icon.Dispose();
             if (Configuration.CustomSound != null && File.Exists(Configuration.CustomSound.FilePath))
             {
                 toastData.SoundFile = Configuration.CustomSound;

--- a/SoundSwitch/UI/Forms/About.cs
+++ b/SoundSwitch/UI/Forms/About.cs
@@ -22,11 +22,12 @@ namespace SoundSwitch.UI.Forms
 {
     public partial class About : Form
     {
+        private static readonly System.Drawing.Icon helpIcon = Resources.HelpIcon;
 
         public About()
         {
             InitializeComponent();
-            Icon = Resources.HelpIcon;
+            Icon = helpIcon;
         }
 
         private void About_Load(object sender, System.EventArgs e)

--- a/SoundSwitch/UI/Forms/Settings.cs
+++ b/SoundSwitch/UI/Forms/Settings.cs
@@ -38,13 +38,15 @@ namespace SoundSwitch.UI.Forms
 {
     public sealed partial class SettingsForm : Form
     {
+        private static readonly Icon settingsIcon = Resources.SettingsIcon;
+
         private readonly bool _loaded;
 
         public SettingsForm()
         {
             // Form itself
             InitializeComponent();
-            Icon = Resources.SettingsIcon;
+            Icon = settingsIcon;
             Text = AssemblyUtils.GetReleaseState() == AssemblyUtils.ReleaseState.Beta ?
                    $"{SettingsStrings.settings} {AssemblyUtils.GetReleaseState()}" :
                    SettingsStrings.settings;
@@ -232,6 +234,25 @@ namespace SoundSwitch.UI.Forms
         private void closeButton_Click(object sender, EventArgs e)
         {
             Close();
+        }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            base.OnClosed(e);
+            foreach (var i in playbackListView.SmallImageList.Images)
+            {
+                if (i is IDisposable)
+                {
+                    ((IDisposable)i).Dispose();
+                }
+            }
+            foreach (var i in recordingListView.SmallImageList.Images)
+            {
+                if (i is IDisposable)
+                {
+                    ((IDisposable)i).Dispose();
+                }
+            }
         }
 
         private void tabControl_SelectedIndexChanged(object sender, EventArgs e)

--- a/SoundSwitch/UI/Forms/UpdateDownloadForm.cs
+++ b/SoundSwitch/UI/Forms/UpdateDownloadForm.cs
@@ -26,13 +26,15 @@ namespace SoundSwitch.UI.Forms
 {
     public sealed partial class UpdateDownloadForm : Form
     {
+        private static readonly System.Drawing.Icon updateIcon = Resources.UpdateIcon;
+
         private readonly bool _redirectLinks = false;
         private readonly WebFile _releaseFile;
 
         public UpdateDownloadForm(Release release)
         {
             InitializeComponent();
-            Icon = Resources.UpdateIcon;
+            Icon = updateIcon;
             Text = release.Name;
             LocalizeForm();
             Focus();

--- a/SoundSwitch/Util/AudioDeviceIconExtractor.cs
+++ b/SoundSwitch/Util/AudioDeviceIconExtractor.cs
@@ -24,51 +24,8 @@ namespace SoundSwitch.Util
 {
     internal class AudioDeviceIconExtractor
     {
-        private class IconKey : IEquatable<IconKey>
-        {
-            private string FilePath { get; }
-            private bool Large { get; }
-
-            public IconKey(string filePath, bool large)
-            {
-                FilePath = filePath;
-                Large = large;
-            }
-
-            public override int GetHashCode()
-            {
-                unchecked
-                {
-                    return (FilePath.GetHashCode()*397) ^ Large.GetHashCode();
-                }
-            }
-
-            public override bool Equals(object obj)
-            {
-                if (ReferenceEquals(null, obj)) return false;
-                if (ReferenceEquals(this, obj)) return true;
-                if (obj.GetType() != this.GetType()) return false;
-                return Equals((IconKey) obj);
-            }
-
-            public static bool operator ==(IconKey left, IconKey right)
-            {
-                return Equals(left, right);
-            }
-
-            public static bool operator !=(IconKey left, IconKey right)
-            {
-                return !Equals(left, right);
-            }
-
-            public bool Equals(IconKey other)
-            {
-                if (ReferenceEquals(null, other)) return false;
-                if (ReferenceEquals(this, other)) return true;
-                return string.Equals(FilePath, other.FilePath) && Large == other.Large;
-            }
-        }
-        private static readonly Dictionary<IconKey, Icon> IconCache = new Dictionary<IconKey, Icon>();
+        private static readonly Icon defaultSpeakers = Resources.defaultSpeakers;
+        private static readonly Icon defaultMicrophone = Resources.defaultMicrophone;
 
         /// <summary>
         ///     Extract the Icon out of an AudioDevice
@@ -78,24 +35,18 @@ namespace SoundSwitch.Util
         /// <returns></returns>
         public static Icon ExtractIconFromAudioDevice(MMDevice audioDevice, bool largeIcon)
         {
-            Icon ico;
-            var iconKey = new IconKey(audioDevice.IconPath, largeIcon);
-            if (IconCache.TryGetValue(iconKey, out ico))
-            {
-                return ico;
-            }
             try
             {
                 if (audioDevice.IconPath.EndsWith(".ico"))
                 {
-                    ico = Icon.ExtractAssociatedIcon(audioDevice.IconPath);
+                    return Icon.ExtractAssociatedIcon(audioDevice.IconPath);
                 }
                 else
                 {
                     var iconInfo = audioDevice.IconPath.Split(',');
                     var dllPath = iconInfo[0];
                     var iconIndex = int.Parse(iconInfo[1]);
-                    ico = IconExtractor.Extract(dllPath, iconIndex, largeIcon);
+                    return IconExtractor.Extract(dllPath, iconIndex, largeIcon);
                 }
             }
             catch (Exception e)
@@ -104,18 +55,13 @@ namespace SoundSwitch.Util
                 switch (audioDevice.DataFlow)
                 {
                     case DataFlow.Capture:
-                        ico = Resources.defaultSpeakers;
-                        break;
+                        return defaultSpeakers;
                     case DataFlow.Render:
-                        ico = Resources.defaultMicrophone;
-                        break;
+                        return defaultMicrophone;
                     default:
                         throw new ArgumentOutOfRangeException();
                 }
             }
-
-            IconCache.Add(iconKey, ico);
-            return ico;
         }
     }
 }

--- a/SoundSwitch/Util/ToolStripDeviceItem.cs
+++ b/SoundSwitch/Util/ToolStripDeviceItem.cs
@@ -24,6 +24,8 @@ namespace SoundSwitch.Util
 {
     internal class ToolStripDeviceItem : ToolStripMenuItem
     {
+        private static readonly Bitmap check = Resources.Check;
+
         public ToolStripDeviceItem(EventHandler onClick, MMDevice audioDevice)
             : base(audioDevice.FriendlyName, null, onClick)
         {
@@ -35,7 +37,7 @@ namespace SoundSwitch.Util
             get
             {
                 if (AudioDevice !=null && AudioController.IsDefault(AudioDevice.ID, (DeviceType) AudioDevice.DataFlow, DeviceRole.Console))
-                    return Resources.Check;
+                    return check;
 
                 return null;
             }


### PR DESCRIPTION
Icon implements IDisposable and must therefore be disposed.
AudioDeviceIconExtractor creates and caches a lot of icons but never
frees old cache entries. TrayIcon.UpdateIcon also creates many copies of
Resources.SoundSwitch16. Getters in the generated Resource class always
return new instances of Bitmaps and Icons.
This commit removes the caching and adds code to manually dispose icons
used in various locations. Some uses of the Resource class are cached
instead (where the resource is not disposed anyways) to avoid loading
the same resource multiple times from disk. I didn't touch generated
files, though.

This commit is untested since I cannot compile the project.