### PR TITLE
Reconnected devices are not added back to the selected list

### DIFF
--- a/SoundSwitch.Common/Framework/Audio/Device/DeviceInfo.cs
+++ b/SoundSwitch.Common/Framework/Audio/Device/DeviceInfo.cs
@@ -29,7 +29,7 @@ namespace SoundSwitch.Common.Framework.Audio.Device
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
-            return Id == other.Id && Type == other.Type;
+            return (Id == other.Id || Name == other.Name) && Type == other.Type;
         }
 
         public override bool Equals(object obj)

--- a/SoundSwitch/UI/Forms/Settings.cs
+++ b/SoundSwitch/UI/Forms/Settings.cs
@@ -530,7 +530,7 @@ namespace SoundSwitch.UI.Forms
                 Tag = device
             };
             var selectedDevice = device;
-            if (selected.Contains(selectedDevice))
+            if (selectedDevice.State == DeviceState.Active && selected.Contains(selectedDevice))
             {
                 listViewItem.Checked = true;
                 listViewItem.Group = listView.Groups["selectedGroup"];


### PR DESCRIPTION
The issue was created here: https://github.com/Belphemur/SoundSwitch/issues/425 by me.

Reconnected devices are not added back into the selected list because the id changes when the device is reconnected. I added another condition so that the name is also checked to be added in. Due to this change, any device with the same name or id is added to the selected list, which is not ideal, and so another change is made so that only the active devices are added to the selected list in the UI.