### PR TITLE
Fix crash at startup when all playback devices are disabled

### DIFF
--- a/SoundSwitch/Framework/TrayIcon/Icon/Changer/AlwaysIconChanger.cs
+++ b/SoundSwitch/Framework/TrayIcon/Icon/Changer/AlwaysIconChanger.cs
@@ -1,6 +1,7 @@
 ﻿using NAudio.CoreAudioApi;
 using SoundSwitch.Common.Framework.Audio.Device;
 using SoundSwitch.Localization;
+using SoundSwitch.Properties;
 
 namespace SoundSwitch.Framework.TrayIcon.Icon.Changer
 {
@@ -8,6 +9,7 @@ namespace SoundSwitch.Framework.TrayIcon.Icon.Changer
     {
         public override IconChangerFactory.ActionEnum TypeEnum => IconChangerFactory.ActionEnum.Always;
         public override string Label => TrayIconStrings.iconChanger_both;
+        internal const int E_NOT_SET = unchecked((int)0x80070490);
         public override bool NeedsToChangeIcon(DeviceInfo deviceInfo)
         {
             return true;
@@ -16,9 +18,25 @@ namespace SoundSwitch.Framework.TrayIcon.Icon.Changer
         public override void ChangeIcon(Util.TrayIcon trayIcon)
         {
             using var enumerator = new MMDeviceEnumerator();
-            using var defaultAudio = enumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Console);
-            
-            trayIcon.ReplaceIcon(new DeviceFullInfo(defaultAudio).SmallIcon);
+            try
+            {
+                using var defaultAudio = enumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Console);
+                trayIcon.ReplaceIcon(new DeviceFullInfo(defaultAudio).SmallIcon);
+            }
+            catch (System.Runtime.InteropServices.COMException e)
+            {
+                // Only handle "Element Not Found"
+                if (e.ErrorCode == E_NOT_SET)
+                {
+                    // Set to app icon
+                    trayIcon.ReplaceIcon(Resources.Switch_SoundWave);
+                }
+                else
+                {
+                    // Throw other ErrorCodes
+                    throw e;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This is a fix for issue #427 

Simply uses a try-catch to check for COMException/E_NOT_SET.

The code could be simplier by removing the ErrorCode checking. But it becomes less robust that way since there might be other COMExceptions that we don't wanna ignore.

Please kindly review. :)