### PR TITLE
Fix NullReferenceException when the last playback device is disabled

### DIFF
--- a/SoundSwitch/Framework/NotificationManager/MMNotificationClient.cs
+++ b/SoundSwitch/Framework/NotificationManager/MMNotificationClient.cs
@@ -51,6 +51,9 @@ namespace SoundSwitch.Framework.NotificationManager
 
         public void OnDefaultDeviceChanged(DataFlow flow, Role role, string defaultDeviceId)
         {
+            if (defaultDeviceId == null)
+                return;
+
             Task.Factory.StartNew(() =>
             {
                 var device = _enumerator.GetDevice(defaultDeviceId);


### PR DESCRIPTION
Fix issue https://github.com/Belphemur/SoundSwitch/issues/432

Checking if `defaultDeviceId` avoids `NullReferenceException`.
I also wanted to add an `else` clause to set the tray icon to default in this case, but didn't find an easy way. Any hints? @Belphemur 

Please kindly review. :D