### PR TITLE
Close the log file before packing to zip

### DIFF
--- a/SoundSwitch/Program.cs
+++ b/SoundSwitch/Program.cs
@@ -245,6 +245,8 @@ namespace SoundSwitch
                         File.Delete(zipFile);
                     }
 
+                    Log.CloseAndFlush();
+
                     ZipFile.CreateFromDirectory(ApplicationPath.Default, zipFile);
                 }
 


### PR DESCRIPTION
Fix issue https://github.com/Belphemur/SoundSwitch/issues/434

Simply `CloseAndFlush` before packing to zip.

Tested locally (without #428), the resulting zip file won't be corrupted anymore.