### PR TITLE
Adding in setting to always use primary screen for banner notifications.

### DIFF
--- a/SoundSwitch/Framework/Banner/BannerForm.cs
+++ b/SoundSwitch/Framework/Banner/BannerForm.cs
@@ -19,6 +19,7 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using NAudio.Wave;
 using SoundSwitch.Framework.Audio;
+using SoundSwitch.Model;
 using Timer = System.Windows.Forms.Timer;
 
 namespace SoundSwitch.Framework.Banner
@@ -41,7 +42,7 @@ namespace SoundSwitch.Framework.Banner
         public BannerForm()
         {
             InitializeComponent();
-            var screen = Screen.FromPoint(Cursor.Position);
+            var screen = AppModel.Instance.NotifyUsingPrimaryScreen ? Screen.PrimaryScreen : Screen.FromPoint(Cursor.Position);
             StartPosition = FormStartPosition.Manual;
             Bounds = screen.Bounds;
 

--- a/SoundSwitch/Framework/Configuration/ISoundSwitchConfiguration.cs
+++ b/SoundSwitch/Framework/Configuration/ISoundSwitchConfiguration.cs
@@ -53,6 +53,7 @@ namespace SoundSwitch.Framework.Configuration
         bool KeepSystrayIcon { get; set; }
 
         bool SwitchForegroundProgram { get; set; }
+        bool NotifyUsingPrimaryScreen { get; set; }
 
         /// <summary>
         /// What to do with the TrayIcon when changing default device

--- a/SoundSwitch/Framework/Configuration/SoundSwitchConfiguration.cs
+++ b/SoundSwitch/Framework/Configuration/SoundSwitchConfiguration.cs
@@ -81,6 +81,8 @@ namespace SoundSwitch.Framework.Configuration
         public Language             Language                      { get; set; }
         public bool                 IncludeBetaVersions           { get; set; }
         public string               CustomNotificationFilePath    { get; set; }
+        public bool                 NotifyUsingPrimaryScreen      { get; set; }
+
 
         public DateTime LastDonationNagTime { get; set; }
 

--- a/SoundSwitch/Localization/SettingsStrings.Designer.cs
+++ b/SoundSwitch/Localization/SettingsStrings.Designer.cs
@@ -142,7 +142,7 @@ namespace SoundSwitch.Localization {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Communication.
+        ///   Looks up a localized string similar to Default Communication Device.
         /// </summary>
         internal static string communication {
             get {
@@ -976,6 +976,24 @@ namespace SoundSwitch.Localization {
         internal static string updateSettings {
             get {
                 return ResourceManager.GetString("updateSettings", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Always Use Primary Screen.
+        /// </summary>
+        internal static string usePrimaryScreen {
+            get {
+                return ResourceManager.GetString("usePrimaryScreen", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Display banner on primary screen instead of currently active screen..
+        /// </summary>
+        internal static string usePrimaryScreenTooltip {
+            get {
+                return ResourceManager.GetString("usePrimaryScreenTooltip", resourceCulture);
             }
         }
     }

--- a/SoundSwitch/Localization/SettingsStrings.resx
+++ b/SoundSwitch/Localization/SettingsStrings.resx
@@ -59,49 +59,49 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
-					<xsd:element name="metadata">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" />
-							</xsd:sequence>
-							<xsd:attribute name="name" use="required" type="xsd:string" />
-							<xsd:attribute name="type" type="xsd:string" />
-							<xsd:attribute name="mimetype" type="xsd:string" />
-							<xsd:attribute ref="xml:space" />
-						</xsd:complexType>
-					</xsd:element>
-					<xsd:element name="assembly">
-						<xsd:complexType>
-							<xsd:attribute name="alias" type="xsd:string" />
-							<xsd:attribute name="name" type="xsd:string" />
-						</xsd:complexType>
-					</xsd:element>
-					<xsd:element name="data">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-								<xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
-							</xsd:sequence>
-							<xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
-							<xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-							<xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-							<xsd:attribute ref="xml:space" />
-						</xsd:complexType>
-					</xsd:element>
-					<xsd:element name="resheader">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-							</xsd:sequence>
-							<xsd:attribute name="name" type="xsd:string" use="required" />
-						</xsd:complexType>
-					</xsd:element>
-				</xsd:choice>
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
       </xsd:complexType>
     </xsd:element>
   </xsd:schema>
@@ -260,38 +260,38 @@ Banner: Uses a custom always-on-top frame, useful for in-game usage.</value>
     <value>Play: {0}</value>
   </data>
   <data name="language" xml:space="preserve">
-		<value>Language</value>
+    <value>Language</value>
   </data>
   <data name="languageRestartRequired" xml:space="preserve">
-		<value>The language will change after restarting SoundSwitch.
+    <value>The language will change after restarting SoundSwitch.
 Do you want to restart now?</value>
   </data>
   <data name="languageRestartRequiredCaption" xml:space="preserve">
-		<value>Need a restart</value>
+    <value>Need a restart</value>
   </data>
   <data name="updateNeverTooltip" xml:space="preserve">
-		<value>Don't update the program unless you do it manually.</value>
+    <value>Don't update the program unless you do it manually.</value>
   </data>
   <data name="updateNotifyTooltip" xml:space="preserve">
-		<value>SoundSwitch will notify you when there is a new update available. When clicking on the notification, you'll get a popup downloading the update for you and asking if you want to install it.</value>
+    <value>SoundSwitch will notify you when there is a new update available. When clicking on the notification, you'll get a popup downloading the update for you and asking if you want to install it.</value>
   </data>
   <data name="notificationOptionBanner" xml:space="preserve">
-        <value>Banner</value>
+    <value>Banner</value>
   </data>
   <data name="disableCustomSoundTooltip" xml:space="preserve">
-		<value>Disable the set Custom Sound.</value>
+    <value>Disable the set Custom Sound.</value>
   </data>
   <data name="foregroundApp" xml:space="preserve">
-		<value>Also switch the foreground program</value>
+    <value>Also switch the foreground program</value>
   </data>
   <data name="foregroundAppTooltip" xml:space="preserve">
-		<value>Switch also the sound of the currently in use application. Useful with video games.</value>
+    <value>Switch also the sound of the currently in use application. Useful with video games.</value>
   </data>
   <data name="iconChange" xml:space="preserve">
-		<value>Systray Icon</value>
+    <value>Systray Icon</value>
   </data>
   <data name="iconChange.tooltip" xml:space="preserve">
-		<value>Choose when to change the systray Icon of SoundSwitch.
+    <value>Choose when to change the systray Icon of SoundSwitch.
 
 Default: Don't change it. Keep SoundSwitch Icon.
 Playback: When a playback device is switched.
@@ -299,135 +299,141 @@ Recording: When a recording device is switched.
 Both: Change when any type of device is switched.</value>
   </data>
   <data name="profile.tab" xml:space="preserve">
-		<value>Profiles</value>
+    <value>Profiles</value>
   </data>
   <data name="profile.addButton" xml:space="preserve">
-		<value>Add</value>
+    <value>Add</value>
   </data>
   <data name="profile.program" xml:space="preserve">
-		<value>Application</value>
+    <value>Application</value>
   </data>
   <data name="profile.name" xml:space="preserve">
-		<value>Name</value>
+    <value>Name</value>
   </data>
   <data name="profile.error.hotkey" xml:space="preserve">
-		<value>This hotkey {0} is already registered.</value>
+    <value>This hotkey {0} is already registered.</value>
   </data>
   <data name="profile.error.application" xml:space="preserve">
-		<value>This application {0} already has a linked profile.</value>
+    <value>This application {0} already has a linked profile.</value>
   </data>
   <data name="profile.error.name" xml:space="preserve">
-		<value>There is already a profile named {0}.</value>
+    <value>There is already a profile named {0}.</value>
   </data>
   <data name="profile.error.needHKOrPath" xml:space="preserve">
-		<value>You need to set the hotkey or/and the application.</value>
+    <value>You need to set the hotkey or/and the application.</value>
   </data>
   <data name="profile.error.needPlaybackOrRecording" xml:space="preserve">
-		<value>You need to set a playback-, or recording device.</value>
+    <value>You need to set a playback-, or recording device.</value>
   </data>
   <data name="profile.explanation" xml:space="preserve">
-		<value>Add a profile to switch to a certain playback or recording device, when a specific application is started or focused.</value>
+    <value>Add a profile to switch to a certain playback or recording device, when a specific application is started or focused.</value>
   </data>
   <data name="profile.error.registerHotkeys" xml:space="preserve">
-		<value>Couldn't register hotkey for the following profiles: {0}</value>
+    <value>Couldn't register hotkey for the following profiles: {0}</value>
   </data>
   <data name="profile.error.registerHotkeys.title" xml:space="preserve">
-		<value>Already used hotkey</value>
+    <value>Already used hotkey</value>
   </data>
   <data name="profile.feature.add" xml:space="preserve">
-		<value>Add Profile</value>
+    <value>Add Profile</value>
   </data>
   <data name="profile.feature.executable" xml:space="preserve">
-		<value>Executable (*.exe)</value>
+    <value>Executable (*.exe)</value>
   </data>
   <data name="profile.error.title" xml:space="preserve">
-		<value>Profile Error</value>
+    <value>Profile Error</value>
   </data>
   <data name="profile.deleteButton" xml:space="preserve">
-		<value>Delete</value>
+    <value>Delete</value>
   </data>
   <data name="profile.error.delete" xml:space="preserve">
-		<value>Can't find the profile.</value>
+    <value>Can't find the profile.</value>
   </data>
   <data name="profile.error.no-name" xml:space="preserve">
-		<value>A profile needs a name.</value>
+    <value>A profile needs a name.</value>
   </data>
   <data name="profile.feature.profile" xml:space="preserve">
-		<value>Profile</value>
+    <value>Profile</value>
   </data>
   <data name="profile.defaultDevice.checkbox" xml:space="preserve">
-		<value>Also switch default device</value>
+    <value>Also switch default device</value>
   </data>
   <data name="profile.defaultDevice.checkbox.tooltip" xml:space="preserve">
-		<value>When the application is detected, SoundSwitch will change also the current default device.</value>
+    <value>When the application is detected, SoundSwitch will change also the current default device.</value>
   </data>
   <data name="hotkeyEnabled" xml:space="preserve">
-		<value>Hotkey enabled</value>
+    <value>Hotkey enabled</value>
   </data>
   <data name="profile.error.device-not-found" xml:space="preserve">
-		<value>Device {0} couldn't be found.</value>
+    <value>Device {0} couldn't be found.</value>
   </data>
   <data name="profile.trigger.window" xml:space="preserve">
-		<value>Name of the program</value>
+    <value>Name of the program</value>
   </data>
   <data name="profile.trigger.process" xml:space="preserve">
-		<value>Application path</value>
+    <value>Application path</value>
   </data>
   <data name="profile.trigger.steam" xml:space="preserve">
-		<value>Steam Big Picture</value>
+    <value>Steam Big Picture</value>
   </data>
   <data name="profile.trigger.hotkey.desc" xml:space="preserve">
-		<value>Hotkey used to activate the profile</value>
+    <value>Hotkey used to activate the profile</value>
   </data>
   <data name="profile.trigger.window.desc" xml:space="preserve">
-		<value>Activate the profile if the foregound program contains the following characters</value>
+    <value>Activate the profile if the foregound program contains the following characters</value>
   </data>
   <data name="profile.trigger.process.desc" xml:space="preserve">
-		<value>Activate the profile when the selected application is in the foreground</value>
+    <value>Activate the profile when the selected application is in the foreground</value>
   </data>
   <data name="profile.trigger.steam.desc" xml:space="preserve">
-		<value>Activate when Steam Big Picture is detected. Will restore the state when Big Picture is closed.</value>
+    <value>Activate when Steam Big Picture is detected. Will restore the state when Big Picture is closed.</value>
   </data>
   <data name="profile.desc" xml:space="preserve">
-		<value>Description</value>
+    <value>Description</value>
   </data>
   <data name="profile.trigger.actives" xml:space="preserve">
-		<value>Active Triggers</value>
+    <value>Active Triggers</value>
   </data>
   <data name="profile.trigger.available" xml:space="preserve">
-		<value>Available Triggers</value>
+    <value>Available Triggers</value>
   </data>
   <data name="communication" xml:space="preserve">
-		<value>Default Communication Device</value>
+    <value>Default Communication Device</value>
   </data>
   <data name="profile.error.triggers.min" xml:space="preserve">
-		<value>You need minimum one trigger.</value>
+    <value>You need minimum one trigger.</value>
   </data>
   <data name="profile.error.steam" xml:space="preserve">
-		<value>You can only have one profile for Steam Big Picture.</value>
+    <value>You can only have one profile for Steam Big Picture.</value>
   </data>
   <data name="profile.error.window" xml:space="preserve">
-		<value>There is already a profile with this window name: {0}.</value>
+    <value>There is already a profile with this window name: {0}.</value>
   </data>
   <data name="profile.notify-on-activation" xml:space="preserve">
-		<value>Notify when profile is triggered</value>
+    <value>Notify when profile is triggered</value>
   </data>
   <data name="profile.notification.text" xml:space="preserve">
-		<value>Profile {0} triggered</value>
+    <value>Profile {0} triggered</value>
   </data>
   <data name="profile.button.save" xml:space="preserve">
-		<value>Save</value>
+    <value>Save</value>
   </data>
   <data name="profile.button.edit" xml:space="preserve">
-		<value>Edit</value>
+    <value>Edit</value>
   </data>
   <data name="profile.trigger.steam.msg" xml:space="preserve">
-		<value>Steam Big Picture closed</value>
+    <value>Steam Big Picture closed</value>
   </data>
   <data name="profile.trigger.startup" xml:space="preserve">
-		<value>On Startup</value>
+    <value>On Startup</value>
   </data>
   <data name="profile.trigger.startup.desc" xml:space="preserve">
-		<value>The profile will be triggered automatically when SoundSwitch starts</value>
+    <value>The profile will be triggered automatically when SoundSwitch starts</value>
+  </data>
+  <data name="usePrimaryScreen" xml:space="preserve">
+    <value>Always Use Primary Screen</value>
+  </data>
+  <data name="usePrimaryScreenTooltip" xml:space="preserve">
+    <value>Display banner on primary screen instead of currently active screen.</value>
   </data>
 </root>

--- a/SoundSwitch/Model/AppModel.cs
+++ b/SoundSwitch/Model/AppModel.cs
@@ -160,6 +160,16 @@ namespace SoundSwitch.Model
             }
         }
 
+        public bool NotifyUsingPrimaryScreen
+        {
+            get => AppConfigs.Configuration.NotifyUsingPrimaryScreen;
+            set
+            {
+                AppConfigs.Configuration.NotifyUsingPrimaryScreen = value;
+                AppConfigs.Configuration.Save();
+            }
+        }
+
         #region Misc settings
 
         /// <summary>

--- a/SoundSwitch/Model/IAppModel.cs
+++ b/SoundSwitch/Model/IAppModel.cs
@@ -99,6 +99,10 @@ namespace SoundSwitch.Model
         /// </summary>
         bool SwitchForegroundProgram { get; set; }
         /// <summary>
+        /// Always show banner on primary screen instead of active screen
+        /// </summary>
+        bool NotifyUsingPrimaryScreen { get; set; }
+        /// <summary>
         /// Manage the profile in the application
         /// </summary>
         ProfileManager ProfileManager { get; }

--- a/SoundSwitch/UI/Forms/Settings.Designer.cs
+++ b/SoundSwitch/UI/Forms/Settings.Designer.cs
@@ -34,44 +34,45 @@ namespace SoundSwitch.UI.Forms
         {
             System.Windows.Forms.ListViewGroup listViewGroup1 = new System.Windows.Forms.ListViewGroup("Selected", System.Windows.Forms.HorizontalAlignment.Center);
             System.Windows.Forms.ListViewGroup listViewGroup2 = new System.Windows.Forms.ListViewGroup("Selected", System.Windows.Forms.HorizontalAlignment.Center);
-            this.startWithWindowsCheckBox          = new System.Windows.Forms.CheckBox();
-            this.closeButton                       = new System.Windows.Forms.Button();
+            this.startWithWindowsCheckBox = new System.Windows.Forms.CheckBox();
+            this.closeButton = new System.Windows.Forms.Button();
             this.switchCommunicationDeviceCheckBox = new System.Windows.Forms.CheckBox();
-            this.tabControl                        = new System.Windows.Forms.TabControl();
-            this.playbackTabPage                   = new System.Windows.Forms.TabPage();
-            this.playbackListView                  = new SoundSwitch.UI.Component.ListView.ListViewExtended();
-            this.recordingTabPage                  = new System.Windows.Forms.TabPage();
-            this.recordingListView                 = new SoundSwitch.UI.Component.ListView.ListViewExtended();
-            this.tabProfile                        = new System.Windows.Forms.TabPage();
-            this.editProfileButton                 = new System.Windows.Forms.Button();
-            this.deleteProfileButton               = new System.Windows.Forms.Button();
-            this.profileExplanationLabel           = new System.Windows.Forms.Label();
-            this.profilesListView                  = new SoundSwitch.UI.Component.ListView.IconListView();
-            this.addProfileButton                  = new System.Windows.Forms.Button();
-            this.appSettingTabPage                 = new System.Windows.Forms.TabPage();
-            this.languageGroupBox                  = new System.Windows.Forms.GroupBox();
-            this.languageComboBox                  = new System.Windows.Forms.ComboBox();
-            this.updateSettingsGroupBox            = new System.Windows.Forms.GroupBox();
-            this.updateNeverRadioButton            = new System.Windows.Forms.RadioButton();
-            this.updateNotifyRadioButton           = new System.Windows.Forms.RadioButton();
-            this.updateSilentRadioButton           = new System.Windows.Forms.RadioButton();
-            this.includeBetaVersionsCheckBox       = new System.Windows.Forms.CheckBox();
-            this.audioSettingsGroupBox             = new System.Windows.Forms.GroupBox();
-            this.foregroundAppCheckbox             = new System.Windows.Forms.CheckBox();
-            this.deleteSoundButton                 = new System.Windows.Forms.Button();
-            this.cycleThroughLabel                 = new System.Windows.Forms.Label();
-            this.cycleThroughComboBox              = new System.Windows.Forms.ComboBox();
-            this.tooltipOnHoverLabel               = new System.Windows.Forms.Label();
-            this.tooltipInfoComboBox               = new System.Windows.Forms.ComboBox();
-            this.selectSoundButton                 = new System.Windows.Forms.Button();
-            this.notificationLabel                 = new System.Windows.Forms.Label();
-            this.notificationComboBox              = new System.Windows.Forms.ComboBox();
-            this.basicSettingsGroupBox             = new System.Windows.Forms.GroupBox();
-            this.iconChangeLabel                   = new System.Windows.Forms.Label();
-            this.iconChangeChoicesComboBox         = new System.Windows.Forms.ComboBox();
-            this.selectSoundFileDialog             = new System.Windows.Forms.OpenFileDialog();
-            this.hotkeysCheckBox                   = new System.Windows.Forms.CheckBox();
-            this.hotKeyControl                     = new SoundSwitch.UI.Component.HotKeyTextBox();
+            this.tabControl = new System.Windows.Forms.TabControl();
+            this.playbackTabPage = new System.Windows.Forms.TabPage();
+            this.playbackListView = new SoundSwitch.UI.Component.ListView.ListViewExtended();
+            this.recordingTabPage = new System.Windows.Forms.TabPage();
+            this.recordingListView = new SoundSwitch.UI.Component.ListView.ListViewExtended();
+            this.tabProfile = new System.Windows.Forms.TabPage();
+            this.editProfileButton = new System.Windows.Forms.Button();
+            this.deleteProfileButton = new System.Windows.Forms.Button();
+            this.profileExplanationLabel = new System.Windows.Forms.Label();
+            this.profilesListView = new SoundSwitch.UI.Component.ListView.IconListView();
+            this.addProfileButton = new System.Windows.Forms.Button();
+            this.appSettingTabPage = new System.Windows.Forms.TabPage();
+            this.languageGroupBox = new System.Windows.Forms.GroupBox();
+            this.languageComboBox = new System.Windows.Forms.ComboBox();
+            this.updateSettingsGroupBox = new System.Windows.Forms.GroupBox();
+            this.updateNeverRadioButton = new System.Windows.Forms.RadioButton();
+            this.updateNotifyRadioButton = new System.Windows.Forms.RadioButton();
+            this.updateSilentRadioButton = new System.Windows.Forms.RadioButton();
+            this.includeBetaVersionsCheckBox = new System.Windows.Forms.CheckBox();
+            this.audioSettingsGroupBox = new System.Windows.Forms.GroupBox();
+            this.usePrimaryScreenCheckbox = new System.Windows.Forms.CheckBox();
+            this.foregroundAppCheckbox = new System.Windows.Forms.CheckBox();
+            this.deleteSoundButton = new System.Windows.Forms.Button();
+            this.cycleThroughLabel = new System.Windows.Forms.Label();
+            this.cycleThroughComboBox = new System.Windows.Forms.ComboBox();
+            this.tooltipOnHoverLabel = new System.Windows.Forms.Label();
+            this.tooltipInfoComboBox = new System.Windows.Forms.ComboBox();
+            this.selectSoundButton = new System.Windows.Forms.Button();
+            this.notificationLabel = new System.Windows.Forms.Label();
+            this.notificationComboBox = new System.Windows.Forms.ComboBox();
+            this.basicSettingsGroupBox = new System.Windows.Forms.GroupBox();
+            this.iconChangeLabel = new System.Windows.Forms.Label();
+            this.iconChangeChoicesComboBox = new System.Windows.Forms.ComboBox();
+            this.selectSoundFileDialog = new System.Windows.Forms.OpenFileDialog();
+            this.hotkeysCheckBox = new System.Windows.Forms.CheckBox();
+            this.hotKeyControl = new SoundSwitch.UI.Component.HotKeyTextBox();
             this.tabControl.SuspendLayout();
             this.playbackTabPage.SuspendLayout();
             this.recordingTabPage.SuspendLayout();
@@ -85,110 +86,114 @@ namespace SoundSwitch.UI.Forms
             // 
             // startWithWindowsCheckBox
             // 
-            this.startWithWindowsCheckBox.AutoSize                =  true;
-            this.startWithWindowsCheckBox.Location                =  new System.Drawing.Point(6, 23);
-            this.startWithWindowsCheckBox.Name                    =  "startWithWindowsCheckBox";
-            this.startWithWindowsCheckBox.Size                    =  new System.Drawing.Size(181, 17);
-            this.startWithWindowsCheckBox.TabIndex                =  7;
-            this.startWithWindowsCheckBox.Text                    =  "Start automatically with Windows";
-            this.startWithWindowsCheckBox.UseVisualStyleBackColor =  true;
-            this.startWithWindowsCheckBox.CheckedChanged          += new System.EventHandler(this.RunAtStartup_CheckedChanged);
+            this.startWithWindowsCheckBox.AutoSize = true;
+            this.startWithWindowsCheckBox.Location = new System.Drawing.Point(6, 23);
+            this.startWithWindowsCheckBox.Name = "startWithWindowsCheckBox";
+            this.startWithWindowsCheckBox.Size = new System.Drawing.Size(181, 17);
+            this.startWithWindowsCheckBox.TabIndex = 7;
+            this.startWithWindowsCheckBox.Text = "Start automatically with Windows";
+            this.startWithWindowsCheckBox.UseVisualStyleBackColor = true;
+            this.startWithWindowsCheckBox.CheckedChanged += new System.EventHandler(this.RunAtStartup_CheckedChanged);
             // 
             // closeButton
             // 
-            this.closeButton.Anchor                  =  ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.closeButton.DialogResult            =  System.Windows.Forms.DialogResult.Cancel;
-            this.closeButton.Location                =  new System.Drawing.Point(673, 367);
-            this.closeButton.Name                    =  "closeButton";
-            this.closeButton.Size                    =  new System.Drawing.Size(75, 23);
-            this.closeButton.TabIndex                =  11;
-            this.closeButton.Text                    =  "Close";
-            this.closeButton.UseVisualStyleBackColor =  true;
-            this.closeButton.Click                   += new System.EventHandler(this.closeButton_Click);
+            this.closeButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.closeButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.closeButton.Location = new System.Drawing.Point(673, 367);
+            this.closeButton.Name = "closeButton";
+            this.closeButton.Size = new System.Drawing.Size(75, 23);
+            this.closeButton.TabIndex = 11;
+            this.closeButton.Text = "Close";
+            this.closeButton.UseVisualStyleBackColor = true;
+            this.closeButton.Click += new System.EventHandler(this.closeButton_Click);
             // 
             // switchCommunicationDeviceCheckBox
             // 
-            this.switchCommunicationDeviceCheckBox.AutoSize                =  true;
-            this.switchCommunicationDeviceCheckBox.Location                =  new System.Drawing.Point(6, 23);
-            this.switchCommunicationDeviceCheckBox.Name                    =  "switchCommunicationDeviceCheckBox";
-            this.switchCommunicationDeviceCheckBox.Size                    =  new System.Drawing.Size(207, 17);
-            this.switchCommunicationDeviceCheckBox.TabIndex                =  12;
-            this.switchCommunicationDeviceCheckBox.Text                    =  "Switch Default Communication Device";
-            this.switchCommunicationDeviceCheckBox.UseVisualStyleBackColor =  true;
-            this.switchCommunicationDeviceCheckBox.CheckedChanged          += new System.EventHandler(this.communicationCheckbox_CheckedChanged);
+            this.switchCommunicationDeviceCheckBox.AutoSize = true;
+            this.switchCommunicationDeviceCheckBox.Location = new System.Drawing.Point(6, 23);
+            this.switchCommunicationDeviceCheckBox.Name = "switchCommunicationDeviceCheckBox";
+            this.switchCommunicationDeviceCheckBox.Size = new System.Drawing.Size(207, 17);
+            this.switchCommunicationDeviceCheckBox.TabIndex = 12;
+            this.switchCommunicationDeviceCheckBox.Text = "Switch Default Communication Device";
+            this.switchCommunicationDeviceCheckBox.UseVisualStyleBackColor = true;
+            this.switchCommunicationDeviceCheckBox.CheckedChanged += new System.EventHandler(this.communicationCheckbox_CheckedChanged);
             // 
             // tabControl
             // 
-            this.tabControl.Anchor = ((System.Windows.Forms.AnchorStyles) ((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
+            this.tabControl.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.tabControl.Controls.Add(this.playbackTabPage);
             this.tabControl.Controls.Add(this.recordingTabPage);
             this.tabControl.Controls.Add(this.tabProfile);
             this.tabControl.Controls.Add(this.appSettingTabPage);
-            this.tabControl.Location             =  new System.Drawing.Point(12, 6);
-            this.tabControl.Name                 =  "tabControl";
-            this.tabControl.SelectedIndex        =  0;
-            this.tabControl.Size                 =  new System.Drawing.Size(743, 353);
-            this.tabControl.TabIndex             =  13;
+            this.tabControl.Location = new System.Drawing.Point(12, 6);
+            this.tabControl.Name = "tabControl";
+            this.tabControl.SelectedIndex = 0;
+            this.tabControl.Size = new System.Drawing.Size(743, 353);
+            this.tabControl.TabIndex = 13;
             this.tabControl.SelectedIndexChanged += new System.EventHandler(this.tabControl_SelectedIndexChanged);
             // 
             // playbackTabPage
             // 
             this.playbackTabPage.Controls.Add(this.playbackListView);
-            this.playbackTabPage.Location                = new System.Drawing.Point(4, 22);
-            this.playbackTabPage.Name                    = "playbackTabPage";
-            this.playbackTabPage.Padding                 = new System.Windows.Forms.Padding(3);
-            this.playbackTabPage.Size                    = new System.Drawing.Size(735, 327);
-            this.playbackTabPage.TabIndex                = 0;
-            this.playbackTabPage.Text                    = "Playback";
+            this.playbackTabPage.Location = new System.Drawing.Point(4, 22);
+            this.playbackTabPage.Name = "playbackTabPage";
+            this.playbackTabPage.Padding = new System.Windows.Forms.Padding(3);
+            this.playbackTabPage.Size = new System.Drawing.Size(735, 327);
+            this.playbackTabPage.TabIndex = 0;
+            this.playbackTabPage.Text = "Playback";
             this.playbackTabPage.UseVisualStyleBackColor = true;
             // 
             // playbackListView
             // 
             this.playbackListView.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.playbackListView.CheckBoxes  = true;
-            this.playbackListView.Dock        = System.Windows.Forms.DockStyle.Fill;
-            listViewGroup1.Header             = "Selected";
-            listViewGroup1.HeaderAlignment    = System.Windows.Forms.HorizontalAlignment.Center;
-            listViewGroup1.Name               = "selectedGroup";
-            this.playbackListView.Groups.AddRange(new System.Windows.Forms.ListViewGroup[] {listViewGroup1});
-            this.playbackListView.HeaderStyle                     = System.Windows.Forms.ColumnHeaderStyle.None;
-            this.playbackListView.HideSelection                   = false;
-            this.playbackListView.Location                        = new System.Drawing.Point(3, 3);
-            this.playbackListView.Name                            = "playbackListView";
-            this.playbackListView.Size                            = new System.Drawing.Size(729, 321);
-            this.playbackListView.TabIndex                        = 14;
+            this.playbackListView.CheckBoxes = true;
+            this.playbackListView.Dock = System.Windows.Forms.DockStyle.Fill;
+            listViewGroup1.Header = "Selected";
+            listViewGroup1.HeaderAlignment = System.Windows.Forms.HorizontalAlignment.Center;
+            listViewGroup1.Name = "selectedGroup";
+            this.playbackListView.Groups.AddRange(new System.Windows.Forms.ListViewGroup[] {
+            listViewGroup1});
+            this.playbackListView.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.None;
+            this.playbackListView.HideSelection = false;
+            this.playbackListView.Location = new System.Drawing.Point(3, 3);
+            this.playbackListView.Name = "playbackListView";
+            this.playbackListView.Size = new System.Drawing.Size(729, 321);
+            this.playbackListView.TabIndex = 14;
             this.playbackListView.UseCompatibleStateImageBehavior = false;
-            this.playbackListView.View                            = System.Windows.Forms.View.Details;
+            this.playbackListView.View = System.Windows.Forms.View.Details;
             // 
             // recordingTabPage
             // 
             this.recordingTabPage.Controls.Add(this.recordingListView);
-            this.recordingTabPage.Location                = new System.Drawing.Point(4, 22);
-            this.recordingTabPage.Name                    = "recordingTabPage";
-            this.recordingTabPage.Padding                 = new System.Windows.Forms.Padding(3);
-            this.recordingTabPage.Size                    = new System.Drawing.Size(735, 327);
-            this.recordingTabPage.TabIndex                = 1;
-            this.recordingTabPage.Text                    = "Recording";
+            this.recordingTabPage.Location = new System.Drawing.Point(4, 22);
+            this.recordingTabPage.Name = "recordingTabPage";
+            this.recordingTabPage.Padding = new System.Windows.Forms.Padding(3);
+            this.recordingTabPage.Size = new System.Drawing.Size(735, 327);
+            this.recordingTabPage.TabIndex = 1;
+            this.recordingTabPage.Text = "Recording";
             this.recordingTabPage.UseVisualStyleBackColor = true;
             // 
             // recordingListView
             // 
             this.recordingListView.AccessibleName = "recordingListView";
-            this.recordingListView.BorderStyle    = System.Windows.Forms.BorderStyle.None;
-            this.recordingListView.CheckBoxes     = true;
-            this.recordingListView.Dock           = System.Windows.Forms.DockStyle.Fill;
-            listViewGroup2.Header                 = "Selected";
-            listViewGroup2.HeaderAlignment        = System.Windows.Forms.HorizontalAlignment.Center;
-            listViewGroup2.Name                   = "selectedGroup";
-            this.recordingListView.Groups.AddRange(new System.Windows.Forms.ListViewGroup[] {listViewGroup2});
-            this.recordingListView.HeaderStyle                     = System.Windows.Forms.ColumnHeaderStyle.None;
-            this.recordingListView.HideSelection                   = false;
-            this.recordingListView.Location                        = new System.Drawing.Point(3, 3);
-            this.recordingListView.Name                            = "recordingListView";
-            this.recordingListView.Size                            = new System.Drawing.Size(729, 321);
-            this.recordingListView.TabIndex                        = 17;
+            this.recordingListView.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.recordingListView.CheckBoxes = true;
+            this.recordingListView.Dock = System.Windows.Forms.DockStyle.Fill;
+            listViewGroup2.Header = "Selected";
+            listViewGroup2.HeaderAlignment = System.Windows.Forms.HorizontalAlignment.Center;
+            listViewGroup2.Name = "selectedGroup";
+            this.recordingListView.Groups.AddRange(new System.Windows.Forms.ListViewGroup[] {
+            listViewGroup2});
+            this.recordingListView.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.None;
+            this.recordingListView.HideSelection = false;
+            this.recordingListView.Location = new System.Drawing.Point(3, 3);
+            this.recordingListView.Name = "recordingListView";
+            this.recordingListView.Size = new System.Drawing.Size(729, 321);
+            this.recordingListView.TabIndex = 17;
             this.recordingListView.UseCompatibleStateImageBehavior = false;
-            this.recordingListView.View                            = System.Windows.Forms.View.Details;
+            this.recordingListView.View = System.Windows.Forms.View.Details;
             // 
             // tabProfile
             // 
@@ -197,78 +202,80 @@ namespace SoundSwitch.UI.Forms
             this.tabProfile.Controls.Add(this.profileExplanationLabel);
             this.tabProfile.Controls.Add(this.profilesListView);
             this.tabProfile.Controls.Add(this.addProfileButton);
-            this.tabProfile.Location                = new System.Drawing.Point(4, 22);
-            this.tabProfile.Name                    = "tabProfile";
-            this.tabProfile.Padding                 = new System.Windows.Forms.Padding(3);
-            this.tabProfile.Size                    = new System.Drawing.Size(735, 327);
-            this.tabProfile.TabIndex                = 3;
-            this.tabProfile.Text                    = "Profiles";
+            this.tabProfile.Location = new System.Drawing.Point(4, 22);
+            this.tabProfile.Name = "tabProfile";
+            this.tabProfile.Padding = new System.Windows.Forms.Padding(3);
+            this.tabProfile.Size = new System.Drawing.Size(735, 327);
+            this.tabProfile.TabIndex = 3;
+            this.tabProfile.Text = "Profiles";
             this.tabProfile.UseVisualStyleBackColor = true;
             // 
             // editProfileButton
             // 
-            this.editProfileButton.Anchor                  =  ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.editProfileButton.Enabled                 =  false;
-            this.editProfileButton.ImageAlign              =  System.Drawing.ContentAlignment.MiddleLeft;
-            this.editProfileButton.Location                =  new System.Drawing.Point(518, 296);
-            this.editProfileButton.Name                    =  "editProfileButton";
-            this.editProfileButton.Size                    =  new System.Drawing.Size(100, 26);
-            this.editProfileButton.TabIndex                =  5;
-            this.editProfileButton.Text                    =  "Edit";
-            this.editProfileButton.TextImageRelation       =  System.Windows.Forms.TextImageRelation.ImageBeforeText;
-            this.editProfileButton.UseVisualStyleBackColor =  true;
-            this.editProfileButton.Click                   += new System.EventHandler(this.editProfileButton_Click);
+            this.editProfileButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.editProfileButton.Enabled = false;
+            this.editProfileButton.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.editProfileButton.Location = new System.Drawing.Point(518, 296);
+            this.editProfileButton.Name = "editProfileButton";
+            this.editProfileButton.Size = new System.Drawing.Size(100, 26);
+            this.editProfileButton.TabIndex = 5;
+            this.editProfileButton.Text = "Edit";
+            this.editProfileButton.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
+            this.editProfileButton.UseVisualStyleBackColor = true;
+            this.editProfileButton.Click += new System.EventHandler(this.editProfileButton_Click);
             // 
             // deleteProfileButton
             // 
-            this.deleteProfileButton.Anchor                  =  ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.deleteProfileButton.Enabled                 =  false;
-            this.deleteProfileButton.ImageAlign              =  System.Drawing.ContentAlignment.MiddleLeft;
-            this.deleteProfileButton.Location                =  new System.Drawing.Point(624, 296);
-            this.deleteProfileButton.Name                    =  "deleteProfileButton";
-            this.deleteProfileButton.Size                    =  new System.Drawing.Size(100, 26);
-            this.deleteProfileButton.TabIndex                =  4;
-            this.deleteProfileButton.Text                    =  "Delete";
-            this.deleteProfileButton.TextImageRelation       =  System.Windows.Forms.TextImageRelation.ImageBeforeText;
-            this.deleteProfileButton.UseVisualStyleBackColor =  true;
-            this.deleteProfileButton.Click                   += new System.EventHandler(this.deleteProfileButton_Click);
+            this.deleteProfileButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.deleteProfileButton.Enabled = false;
+            this.deleteProfileButton.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.deleteProfileButton.Location = new System.Drawing.Point(624, 296);
+            this.deleteProfileButton.Name = "deleteProfileButton";
+            this.deleteProfileButton.Size = new System.Drawing.Size(100, 26);
+            this.deleteProfileButton.TabIndex = 4;
+            this.deleteProfileButton.Text = "Delete";
+            this.deleteProfileButton.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
+            this.deleteProfileButton.UseVisualStyleBackColor = true;
+            this.deleteProfileButton.Click += new System.EventHandler(this.deleteProfileButton_Click);
             // 
             // profileExplanationLabel
             // 
-            this.profileExplanationLabel.Anchor   = ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.profileExplanationLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.profileExplanationLabel.Location = new System.Drawing.Point(6, 264);
-            this.profileExplanationLabel.Name     = "profileExplanationLabel";
-            this.profileExplanationLabel.Size     = new System.Drawing.Size(718, 30);
+            this.profileExplanationLabel.Name = "profileExplanationLabel";
+            this.profileExplanationLabel.Size = new System.Drawing.Size(718, 30);
             this.profileExplanationLabel.TabIndex = 3;
-            this.profileExplanationLabel.Text     = "Explanation line 1\r\nOptional line 2";
+            this.profileExplanationLabel.Text = "Explanation line 1\r\nOptional line 2";
             // 
             // profilesListView
             // 
-            this.profilesListView.Anchor                          =  ((System.Windows.Forms.AnchorStyles) ((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
-            this.profilesListView.FullRowSelect                   =  true;
-            this.profilesListView.HideSelection                   =  false;
-            this.profilesListView.Location                        =  new System.Drawing.Point(6, 3);
-            this.profilesListView.Name                            =  "profilesListView";
-            this.profilesListView.OwnerDraw                       =  true;
-            this.profilesListView.ShowGroups                      =  false;
-            this.profilesListView.Size                            =  new System.Drawing.Size(721, 254);
-            this.profilesListView.TabIndex                        =  2;
-            this.profilesListView.UseCompatibleStateImageBehavior =  false;
-            this.profilesListView.View                            =  System.Windows.Forms.View.Details;
-            this.profilesListView.SelectedIndexChanged            += new System.EventHandler(this.profilesListView_SelectedIndexChanged);
-            this.profilesListView.DoubleClick                     += new System.EventHandler(this.profilesListView_DoubleClick);
+            this.profilesListView.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.profilesListView.FullRowSelect = true;
+            this.profilesListView.HideSelection = false;
+            this.profilesListView.Location = new System.Drawing.Point(6, 3);
+            this.profilesListView.Name = "profilesListView";
+            this.profilesListView.OwnerDraw = true;
+            this.profilesListView.ShowGroups = false;
+            this.profilesListView.Size = new System.Drawing.Size(721, 254);
+            this.profilesListView.TabIndex = 2;
+            this.profilesListView.UseCompatibleStateImageBehavior = false;
+            this.profilesListView.View = System.Windows.Forms.View.Details;
+            this.profilesListView.SelectedIndexChanged += new System.EventHandler(this.profilesListView_SelectedIndexChanged);
+            this.profilesListView.DoubleClick += new System.EventHandler(this.profilesListView_DoubleClick);
             // 
             // addProfileButton
             // 
-            this.addProfileButton.Anchor                  =  ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.addProfileButton.Location                =  new System.Drawing.Point(412, 296);
-            this.addProfileButton.Name                    =  "addProfileButton";
-            this.addProfileButton.Size                    =  new System.Drawing.Size(100, 26);
-            this.addProfileButton.TabIndex                =  1;
-            this.addProfileButton.Text                    =  "Add";
-            this.addProfileButton.TextImageRelation       =  System.Windows.Forms.TextImageRelation.ImageBeforeText;
-            this.addProfileButton.UseVisualStyleBackColor =  true;
-            this.addProfileButton.Click                   += new System.EventHandler(this.addProfileButton_Click);
+            this.addProfileButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.addProfileButton.Location = new System.Drawing.Point(412, 296);
+            this.addProfileButton.Name = "addProfileButton";
+            this.addProfileButton.Size = new System.Drawing.Size(100, 26);
+            this.addProfileButton.TabIndex = 1;
+            this.addProfileButton.Text = "Add";
+            this.addProfileButton.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
+            this.addProfileButton.UseVisualStyleBackColor = true;
+            this.addProfileButton.Click += new System.EventHandler(this.addProfileButton_Click);
             // 
             // appSettingTabPage
             // 
@@ -276,97 +283,100 @@ namespace SoundSwitch.UI.Forms
             this.appSettingTabPage.Controls.Add(this.updateSettingsGroupBox);
             this.appSettingTabPage.Controls.Add(this.audioSettingsGroupBox);
             this.appSettingTabPage.Controls.Add(this.basicSettingsGroupBox);
-            this.appSettingTabPage.Location                = new System.Drawing.Point(4, 22);
-            this.appSettingTabPage.Name                    = "appSettingTabPage";
-            this.appSettingTabPage.Size                    = new System.Drawing.Size(735, 327);
-            this.appSettingTabPage.TabIndex                = 2;
-            this.appSettingTabPage.Text                    = "Settings";
+            this.appSettingTabPage.Location = new System.Drawing.Point(4, 22);
+            this.appSettingTabPage.Name = "appSettingTabPage";
+            this.appSettingTabPage.Size = new System.Drawing.Size(735, 327);
+            this.appSettingTabPage.TabIndex = 2;
+            this.appSettingTabPage.Text = "Settings";
             this.appSettingTabPage.UseVisualStyleBackColor = true;
             // 
             // languageGroupBox
             // 
-            this.languageGroupBox.Anchor = ((System.Windows.Forms.AnchorStyles) (((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
+            this.languageGroupBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.languageGroupBox.Controls.Add(this.languageComboBox);
             this.languageGroupBox.Location = new System.Drawing.Point(434, 156);
-            this.languageGroupBox.Name     = "languageGroupBox";
-            this.languageGroupBox.Size     = new System.Drawing.Size(298, 61);
+            this.languageGroupBox.Name = "languageGroupBox";
+            this.languageGroupBox.Size = new System.Drawing.Size(298, 61);
             this.languageGroupBox.TabIndex = 15;
-            this.languageGroupBox.TabStop  = false;
-            this.languageGroupBox.Text     = "Language";
+            this.languageGroupBox.TabStop = false;
+            this.languageGroupBox.Text = "Language";
             // 
             // languageComboBox
             // 
-            this.languageComboBox.DropDownStyle        =  System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.languageComboBox.FormattingEnabled    =  true;
-            this.languageComboBox.Location             =  new System.Drawing.Point(8, 23);
-            this.languageComboBox.Name                 =  "languageComboBox";
-            this.languageComboBox.Size                 =  new System.Drawing.Size(247, 21);
-            this.languageComboBox.TabIndex             =  17;
+            this.languageComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.languageComboBox.FormattingEnabled = true;
+            this.languageComboBox.Location = new System.Drawing.Point(8, 23);
+            this.languageComboBox.Name = "languageComboBox";
+            this.languageComboBox.Size = new System.Drawing.Size(247, 21);
+            this.languageComboBox.TabIndex = 17;
             this.languageComboBox.SelectedIndexChanged += new System.EventHandler(this.languageComboBox_SelectedIndexChanged);
             // 
             // updateSettingsGroupBox
             // 
-            this.updateSettingsGroupBox.Anchor = ((System.Windows.Forms.AnchorStyles) (((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
+            this.updateSettingsGroupBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.updateSettingsGroupBox.Controls.Add(this.updateNeverRadioButton);
             this.updateSettingsGroupBox.Controls.Add(this.updateNotifyRadioButton);
             this.updateSettingsGroupBox.Controls.Add(this.updateSilentRadioButton);
             this.updateSettingsGroupBox.Controls.Add(this.includeBetaVersionsCheckBox);
             this.updateSettingsGroupBox.Location = new System.Drawing.Point(434, 12);
-            this.updateSettingsGroupBox.Name     = "updateSettingsGroupBox";
-            this.updateSettingsGroupBox.Size     = new System.Drawing.Size(298, 132);
+            this.updateSettingsGroupBox.Name = "updateSettingsGroupBox";
+            this.updateSettingsGroupBox.Size = new System.Drawing.Size(298, 132);
             this.updateSettingsGroupBox.TabIndex = 14;
-            this.updateSettingsGroupBox.TabStop  = false;
-            this.updateSettingsGroupBox.Text     = "Update Settings";
+            this.updateSettingsGroupBox.TabStop = false;
+            this.updateSettingsGroupBox.Text = "Update Settings";
             // 
             // updateNeverRadioButton
             // 
-            this.updateNeverRadioButton.AutoSize                =  true;
-            this.updateNeverRadioButton.Location                =  new System.Drawing.Point(7, 71);
-            this.updateNeverRadioButton.Name                    =  "updateNeverRadioButton";
-            this.updateNeverRadioButton.Size                    =  new System.Drawing.Size(143, 17);
-            this.updateNeverRadioButton.TabIndex                =  21;
-            this.updateNeverRadioButton.TabStop                 =  true;
-            this.updateNeverRadioButton.Text                    =  "Never check for updates";
-            this.updateNeverRadioButton.UseVisualStyleBackColor =  true;
-            this.updateNeverRadioButton.CheckedChanged          += new System.EventHandler(this.updateNeverRadioButton_CheckedChanged);
+            this.updateNeverRadioButton.AutoSize = true;
+            this.updateNeverRadioButton.Location = new System.Drawing.Point(7, 71);
+            this.updateNeverRadioButton.Name = "updateNeverRadioButton";
+            this.updateNeverRadioButton.Size = new System.Drawing.Size(143, 17);
+            this.updateNeverRadioButton.TabIndex = 21;
+            this.updateNeverRadioButton.TabStop = true;
+            this.updateNeverRadioButton.Text = "Never check for updates";
+            this.updateNeverRadioButton.UseVisualStyleBackColor = true;
+            this.updateNeverRadioButton.CheckedChanged += new System.EventHandler(this.updateNeverRadioButton_CheckedChanged);
             // 
             // updateNotifyRadioButton
             // 
-            this.updateNotifyRadioButton.AutoSize                =  true;
-            this.updateNotifyRadioButton.Location                =  new System.Drawing.Point(7, 46);
-            this.updateNotifyRadioButton.Name                    =  "updateNotifyRadioButton";
-            this.updateNotifyRadioButton.Size                    =  new System.Drawing.Size(202, 17);
-            this.updateNotifyRadioButton.TabIndex                =  20;
-            this.updateNotifyRadioButton.TabStop                 =  true;
-            this.updateNotifyRadioButton.Text                    =  "Notify me when updates are available";
-            this.updateNotifyRadioButton.UseVisualStyleBackColor =  true;
-            this.updateNotifyRadioButton.CheckedChanged          += new System.EventHandler(this.updateNotifyRadioButton_CheckedChanged);
+            this.updateNotifyRadioButton.AutoSize = true;
+            this.updateNotifyRadioButton.Location = new System.Drawing.Point(7, 46);
+            this.updateNotifyRadioButton.Name = "updateNotifyRadioButton";
+            this.updateNotifyRadioButton.Size = new System.Drawing.Size(202, 17);
+            this.updateNotifyRadioButton.TabIndex = 20;
+            this.updateNotifyRadioButton.TabStop = true;
+            this.updateNotifyRadioButton.Text = "Notify me when updates are available";
+            this.updateNotifyRadioButton.UseVisualStyleBackColor = true;
+            this.updateNotifyRadioButton.CheckedChanged += new System.EventHandler(this.updateNotifyRadioButton_CheckedChanged);
             // 
             // updateSilentRadioButton
             // 
-            this.updateSilentRadioButton.AutoSize                =  true;
-            this.updateSilentRadioButton.Location                =  new System.Drawing.Point(7, 21);
-            this.updateSilentRadioButton.Name                    =  "updateSilentRadioButton";
-            this.updateSilentRadioButton.Size                    =  new System.Drawing.Size(157, 17);
-            this.updateSilentRadioButton.TabIndex                =  19;
-            this.updateSilentRadioButton.TabStop                 =  true;
-            this.updateSilentRadioButton.Text                    =  "Install updates automatically";
-            this.updateSilentRadioButton.UseVisualStyleBackColor =  true;
-            this.updateSilentRadioButton.CheckedChanged          += new System.EventHandler(this.updateSilentRadioButton_CheckedChanged);
+            this.updateSilentRadioButton.AutoSize = true;
+            this.updateSilentRadioButton.Location = new System.Drawing.Point(7, 21);
+            this.updateSilentRadioButton.Name = "updateSilentRadioButton";
+            this.updateSilentRadioButton.Size = new System.Drawing.Size(157, 17);
+            this.updateSilentRadioButton.TabIndex = 19;
+            this.updateSilentRadioButton.TabStop = true;
+            this.updateSilentRadioButton.Text = "Install updates automatically";
+            this.updateSilentRadioButton.UseVisualStyleBackColor = true;
+            this.updateSilentRadioButton.CheckedChanged += new System.EventHandler(this.updateSilentRadioButton_CheckedChanged);
             // 
             // includeBetaVersionsCheckBox
             // 
-            this.includeBetaVersionsCheckBox.AutoSize                =  true;
-            this.includeBetaVersionsCheckBox.Location                =  new System.Drawing.Point(7, 103);
-            this.includeBetaVersionsCheckBox.Name                    =  "includeBetaVersionsCheckBox";
-            this.includeBetaVersionsCheckBox.Size                    =  new System.Drawing.Size(128, 17);
-            this.includeBetaVersionsCheckBox.TabIndex                =  18;
-            this.includeBetaVersionsCheckBox.Text                    =  "Include Beta versions";
-            this.includeBetaVersionsCheckBox.UseVisualStyleBackColor =  true;
-            this.includeBetaVersionsCheckBox.CheckedChanged          += new System.EventHandler(this.betaVersionCheckbox_CheckedChanged);
+            this.includeBetaVersionsCheckBox.AutoSize = true;
+            this.includeBetaVersionsCheckBox.Location = new System.Drawing.Point(7, 103);
+            this.includeBetaVersionsCheckBox.Name = "includeBetaVersionsCheckBox";
+            this.includeBetaVersionsCheckBox.Size = new System.Drawing.Size(128, 17);
+            this.includeBetaVersionsCheckBox.TabIndex = 18;
+            this.includeBetaVersionsCheckBox.Text = "Include Beta versions";
+            this.includeBetaVersionsCheckBox.UseVisualStyleBackColor = true;
+            this.includeBetaVersionsCheckBox.CheckedChanged += new System.EventHandler(this.betaVersionCheckbox_CheckedChanged);
             // 
             // audioSettingsGroupBox
             // 
+            this.audioSettingsGroupBox.Controls.Add(this.usePrimaryScreenCheckbox);
             this.audioSettingsGroupBox.Controls.Add(this.foregroundAppCheckbox);
             this.audioSettingsGroupBox.Controls.Add(this.deleteSoundButton);
             this.audioSettingsGroupBox.Controls.Add(this.cycleThroughLabel);
@@ -378,100 +388,112 @@ namespace SoundSwitch.UI.Forms
             this.audioSettingsGroupBox.Controls.Add(this.notificationLabel);
             this.audioSettingsGroupBox.Controls.Add(this.notificationComboBox);
             this.audioSettingsGroupBox.Location = new System.Drawing.Point(3, 117);
-            this.audioSettingsGroupBox.Name     = "audioSettingsGroupBox";
-            this.audioSettingsGroupBox.Size     = new System.Drawing.Size(425, 193);
+            this.audioSettingsGroupBox.Name = "audioSettingsGroupBox";
+            this.audioSettingsGroupBox.Size = new System.Drawing.Size(425, 193);
             this.audioSettingsGroupBox.TabIndex = 13;
-            this.audioSettingsGroupBox.TabStop  = false;
-            this.audioSettingsGroupBox.Text     = "Audio Settings";
+            this.audioSettingsGroupBox.TabStop = false;
+            this.audioSettingsGroupBox.Text = "Audio Settings";
+            // 
+            // usePrimaryScreenCheckbox
+            // 
+            this.usePrimaryScreenCheckbox.AutoSize = true;
+            this.usePrimaryScreenCheckbox.Location = new System.Drawing.Point(259, 48);
+            this.usePrimaryScreenCheckbox.Name = "usePrimaryScreenCheckbox";
+            this.usePrimaryScreenCheckbox.Size = new System.Drawing.Size(155, 17);
+            this.usePrimaryScreenCheckbox.TabIndex = 26;
+            this.usePrimaryScreenCheckbox.Text = "Always Use Primary Screen";
+            this.usePrimaryScreenCheckbox.UseVisualStyleBackColor = true;
+            this.usePrimaryScreenCheckbox.Visible = false;
+            this.usePrimaryScreenCheckbox.CheckedChanged += new System.EventHandler(this.usePrimaryScreenCheckbox_CheckedChanged);
             // 
             // foregroundAppCheckbox
             // 
-            this.foregroundAppCheckbox.AutoSize                =  true;
-            this.foregroundAppCheckbox.Location                =  new System.Drawing.Point(6, 48);
-            this.foregroundAppCheckbox.Name                    =  "foregroundAppCheckbox";
-            this.foregroundAppCheckbox.Size                    =  new System.Drawing.Size(136, 17);
-            this.foregroundAppCheckbox.TabIndex                =  25;
-            this.foregroundAppCheckbox.Text                    =  "Switch Foreground app";
-            this.foregroundAppCheckbox.UseVisualStyleBackColor =  true;
-            this.foregroundAppCheckbox.CheckedChanged          += new System.EventHandler(this.ForegroundAppCheckbox_CheckedChanged);
+            this.foregroundAppCheckbox.AutoSize = true;
+            this.foregroundAppCheckbox.Location = new System.Drawing.Point(6, 48);
+            this.foregroundAppCheckbox.Name = "foregroundAppCheckbox";
+            this.foregroundAppCheckbox.Size = new System.Drawing.Size(136, 17);
+            this.foregroundAppCheckbox.TabIndex = 25;
+            this.foregroundAppCheckbox.Text = "Switch Foreground app";
+            this.foregroundAppCheckbox.UseVisualStyleBackColor = true;
+            this.foregroundAppCheckbox.CheckedChanged += new System.EventHandler(this.ForegroundAppCheckbox_CheckedChanged);
             // 
             // deleteSoundButton
             // 
-            this.deleteSoundButton.Image                   =  global::SoundSwitch.Properties.Resources.delete;
-            this.deleteSoundButton.Location                =  new System.Drawing.Point(391, 77);
-            this.deleteSoundButton.Name                    =  "deleteSoundButton";
-            this.deleteSoundButton.Size                    =  new System.Drawing.Size(23, 23);
-            this.deleteSoundButton.TabIndex                =  24;
-            this.deleteSoundButton.UseVisualStyleBackColor =  true;
-            this.deleteSoundButton.Visible                 =  false;
-            this.deleteSoundButton.Click                   += new System.EventHandler(this.deleteSoundButton_Click);
+            this.deleteSoundButton.Image = global::SoundSwitch.Properties.Resources.delete;
+            this.deleteSoundButton.Location = new System.Drawing.Point(391, 77);
+            this.deleteSoundButton.Name = "deleteSoundButton";
+            this.deleteSoundButton.Size = new System.Drawing.Size(23, 23);
+            this.deleteSoundButton.TabIndex = 24;
+            this.deleteSoundButton.UseVisualStyleBackColor = true;
+            this.deleteSoundButton.Visible = false;
+            this.deleteSoundButton.Click += new System.EventHandler(this.deleteSoundButton_Click);
             // 
             // cycleThroughLabel
             // 
-            this.cycleThroughLabel.Location  = new System.Drawing.Point(2, 153);
-            this.cycleThroughLabel.Name      = "cycleThroughLabel";
-            this.cycleThroughLabel.Size      = new System.Drawing.Size(100, 15);
-            this.cycleThroughLabel.TabIndex  = 23;
-            this.cycleThroughLabel.Text      = "Cycle through";
+            this.cycleThroughLabel.Location = new System.Drawing.Point(2, 153);
+            this.cycleThroughLabel.Name = "cycleThroughLabel";
+            this.cycleThroughLabel.Size = new System.Drawing.Size(100, 15);
+            this.cycleThroughLabel.TabIndex = 23;
+            this.cycleThroughLabel.Text = "Cycle through";
             this.cycleThroughLabel.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // cycleThroughComboBox
             // 
-            this.cycleThroughComboBox.DropDownStyle        =  System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cycleThroughComboBox.FormattingEnabled    =  true;
-            this.cycleThroughComboBox.Location             =  new System.Drawing.Point(108, 151);
-            this.cycleThroughComboBox.Name                 =  "cycleThroughComboBox";
-            this.cycleThroughComboBox.Size                 =  new System.Drawing.Size(247, 21);
-            this.cycleThroughComboBox.TabIndex             =  22;
+            this.cycleThroughComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cycleThroughComboBox.FormattingEnabled = true;
+            this.cycleThroughComboBox.Location = new System.Drawing.Point(108, 151);
+            this.cycleThroughComboBox.Name = "cycleThroughComboBox";
+            this.cycleThroughComboBox.Size = new System.Drawing.Size(247, 21);
+            this.cycleThroughComboBox.TabIndex = 22;
             this.cycleThroughComboBox.SelectedValueChanged += new System.EventHandler(this.cyclerComboBox_SelectedValueChanged);
             // 
             // tooltipOnHoverLabel
             // 
-            this.tooltipOnHoverLabel.Location  = new System.Drawing.Point(2, 117);
-            this.tooltipOnHoverLabel.Name      = "tooltipOnHoverLabel";
-            this.tooltipOnHoverLabel.Size      = new System.Drawing.Size(100, 15);
-            this.tooltipOnHoverLabel.TabIndex  = 21;
-            this.tooltipOnHoverLabel.Text      = "Tooltip on Hover";
+            this.tooltipOnHoverLabel.Location = new System.Drawing.Point(2, 117);
+            this.tooltipOnHoverLabel.Name = "tooltipOnHoverLabel";
+            this.tooltipOnHoverLabel.Size = new System.Drawing.Size(100, 15);
+            this.tooltipOnHoverLabel.TabIndex = 21;
+            this.tooltipOnHoverLabel.Text = "Tooltip on Hover";
             this.tooltipOnHoverLabel.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // tooltipInfoComboBox
             // 
-            this.tooltipInfoComboBox.DropDownStyle        =  System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.tooltipInfoComboBox.FormattingEnabled    =  true;
-            this.tooltipInfoComboBox.Location             =  new System.Drawing.Point(108, 115);
-            this.tooltipInfoComboBox.Name                 =  "tooltipInfoComboBox";
-            this.tooltipInfoComboBox.Size                 =  new System.Drawing.Size(247, 21);
-            this.tooltipInfoComboBox.TabIndex             =  20;
+            this.tooltipInfoComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.tooltipInfoComboBox.FormattingEnabled = true;
+            this.tooltipInfoComboBox.Location = new System.Drawing.Point(108, 115);
+            this.tooltipInfoComboBox.Name = "tooltipInfoComboBox";
+            this.tooltipInfoComboBox.Size = new System.Drawing.Size(247, 21);
+            this.tooltipInfoComboBox.TabIndex = 20;
             this.tooltipInfoComboBox.SelectedValueChanged += new System.EventHandler(this.tooltipInfoComboBox_SelectedValueChanged);
             // 
             // selectSoundButton
             // 
-            this.selectSoundButton.Location                =  new System.Drawing.Point(361, 77);
-            this.selectSoundButton.Name                    =  "selectSoundButton";
-            this.selectSoundButton.Size                    =  new System.Drawing.Size(24, 23);
-            this.selectSoundButton.TabIndex                =  19;
-            this.selectSoundButton.Text                    =  "...";
-            this.selectSoundButton.UseVisualStyleBackColor =  true;
-            this.selectSoundButton.Visible                 =  false;
-            this.selectSoundButton.Click                   += new System.EventHandler(this.selectSoundButton_Click);
+            this.selectSoundButton.Location = new System.Drawing.Point(361, 77);
+            this.selectSoundButton.Name = "selectSoundButton";
+            this.selectSoundButton.Size = new System.Drawing.Size(24, 23);
+            this.selectSoundButton.TabIndex = 19;
+            this.selectSoundButton.Text = "...";
+            this.selectSoundButton.UseVisualStyleBackColor = true;
+            this.selectSoundButton.Visible = false;
+            this.selectSoundButton.Click += new System.EventHandler(this.selectSoundButton_Click);
             // 
             // notificationLabel
             // 
-            this.notificationLabel.Location  = new System.Drawing.Point(2, 81);
-            this.notificationLabel.Name      = "notificationLabel";
-            this.notificationLabel.Size      = new System.Drawing.Size(100, 15);
-            this.notificationLabel.TabIndex  = 17;
-            this.notificationLabel.Text      = "Notification";
+            this.notificationLabel.Location = new System.Drawing.Point(2, 81);
+            this.notificationLabel.Name = "notificationLabel";
+            this.notificationLabel.Size = new System.Drawing.Size(100, 15);
+            this.notificationLabel.TabIndex = 17;
+            this.notificationLabel.Text = "Notification";
             this.notificationLabel.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // notificationComboBox
             // 
-            this.notificationComboBox.DropDownStyle        =  System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.notificationComboBox.FormattingEnabled    =  true;
-            this.notificationComboBox.Location             =  new System.Drawing.Point(108, 79);
-            this.notificationComboBox.Name                 =  "notificationComboBox";
-            this.notificationComboBox.Size                 =  new System.Drawing.Size(247, 21);
-            this.notificationComboBox.TabIndex             =  16;
+            this.notificationComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.notificationComboBox.FormattingEnabled = true;
+            this.notificationComboBox.Location = new System.Drawing.Point(108, 79);
+            this.notificationComboBox.Name = "notificationComboBox";
+            this.notificationComboBox.Size = new System.Drawing.Size(247, 21);
+            this.notificationComboBox.TabIndex = 16;
             this.notificationComboBox.SelectedValueChanged += new System.EventHandler(this.notificationComboBox_SelectedValueChanged);
             // 
             // basicSettingsGroupBox
@@ -480,29 +502,29 @@ namespace SoundSwitch.UI.Forms
             this.basicSettingsGroupBox.Controls.Add(this.startWithWindowsCheckBox);
             this.basicSettingsGroupBox.Controls.Add(this.iconChangeChoicesComboBox);
             this.basicSettingsGroupBox.Location = new System.Drawing.Point(3, 12);
-            this.basicSettingsGroupBox.Name     = "basicSettingsGroupBox";
-            this.basicSettingsGroupBox.Size     = new System.Drawing.Size(425, 93);
+            this.basicSettingsGroupBox.Name = "basicSettingsGroupBox";
+            this.basicSettingsGroupBox.Size = new System.Drawing.Size(425, 93);
             this.basicSettingsGroupBox.TabIndex = 0;
-            this.basicSettingsGroupBox.TabStop  = false;
-            this.basicSettingsGroupBox.Text     = "Basic Settings";
+            this.basicSettingsGroupBox.TabStop = false;
+            this.basicSettingsGroupBox.Text = "Basic Settings";
             // 
             // iconChangeLabel
             // 
-            this.iconChangeLabel.Location  = new System.Drawing.Point(2, 53);
-            this.iconChangeLabel.Name      = "iconChangeLabel";
-            this.iconChangeLabel.Size      = new System.Drawing.Size(100, 15);
-            this.iconChangeLabel.TabIndex  = 27;
-            this.iconChangeLabel.Text      = "Systray Icon";
+            this.iconChangeLabel.Location = new System.Drawing.Point(2, 53);
+            this.iconChangeLabel.Name = "iconChangeLabel";
+            this.iconChangeLabel.Size = new System.Drawing.Size(100, 15);
+            this.iconChangeLabel.TabIndex = 27;
+            this.iconChangeLabel.Text = "Systray Icon";
             this.iconChangeLabel.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // iconChangeChoicesComboBox
             // 
-            this.iconChangeChoicesComboBox.DropDownStyle        =  System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.iconChangeChoicesComboBox.FormattingEnabled    =  true;
-            this.iconChangeChoicesComboBox.Location             =  new System.Drawing.Point(108, 51);
-            this.iconChangeChoicesComboBox.Name                 =  "iconChangeChoicesComboBox";
-            this.iconChangeChoicesComboBox.Size                 =  new System.Drawing.Size(247, 21);
-            this.iconChangeChoicesComboBox.TabIndex             =  26;
+            this.iconChangeChoicesComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.iconChangeChoicesComboBox.FormattingEnabled = true;
+            this.iconChangeChoicesComboBox.Location = new System.Drawing.Point(108, 51);
+            this.iconChangeChoicesComboBox.Name = "iconChangeChoicesComboBox";
+            this.iconChangeChoicesComboBox.Size = new System.Drawing.Size(247, 21);
+            this.iconChangeChoicesComboBox.TabIndex = 26;
             this.iconChangeChoicesComboBox.SelectedIndexChanged += new System.EventHandler(this.iconChangeChoicesComboBox_SelectedIndexChanged);
             // 
             // selectSoundFileDialog
@@ -511,39 +533,39 @@ namespace SoundSwitch.UI.Forms
             // 
             // hotkeysCheckBox
             // 
-            this.hotkeysCheckBox.Anchor                  =  ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.hotkeysCheckBox.AutoSize                =  true;
-            this.hotkeysCheckBox.Location                =  new System.Drawing.Point(163, 372);
-            this.hotkeysCheckBox.Name                    =  "hotkeysCheckBox";
-            this.hotkeysCheckBox.Size                    =  new System.Drawing.Size(94, 17);
-            this.hotkeysCheckBox.TabIndex                =  20;
-            this.hotkeysCheckBox.Text                    =  "Enable hotkey";
-            this.hotkeysCheckBox.UseVisualStyleBackColor =  true;
-            this.hotkeysCheckBox.CheckedChanged          += new System.EventHandler(this.hotkeysCheckbox_CheckedChanged);
+            this.hotkeysCheckBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.hotkeysCheckBox.AutoSize = true;
+            this.hotkeysCheckBox.Location = new System.Drawing.Point(163, 372);
+            this.hotkeysCheckBox.Name = "hotkeysCheckBox";
+            this.hotkeysCheckBox.Size = new System.Drawing.Size(94, 17);
+            this.hotkeysCheckBox.TabIndex = 20;
+            this.hotkeysCheckBox.Text = "Enable hotkey";
+            this.hotkeysCheckBox.UseVisualStyleBackColor = true;
+            this.hotkeysCheckBox.CheckedChanged += new System.EventHandler(this.hotkeysCheckbox_CheckedChanged);
             // 
             // hotKeyControl
             // 
-            this.hotKeyControl.Anchor        =  ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.hotKeyControl.Location      =  new System.Drawing.Point(19, 369);
-            this.hotKeyControl.Name          =  "hotKeyControl";
-            this.hotKeyControl.Size          =  new System.Drawing.Size(138, 20);
-            this.hotKeyControl.TabIndex      =  21;
-            this.hotKeyControl.TextAlign     =  System.Windows.Forms.HorizontalAlignment.Center;
+            this.hotKeyControl.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.hotKeyControl.Location = new System.Drawing.Point(19, 369);
+            this.hotKeyControl.Name = "hotKeyControl";
+            this.hotKeyControl.Size = new System.Drawing.Size(138, 20);
+            this.hotKeyControl.TabIndex = 21;
+            this.hotKeyControl.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
             this.hotKeyControl.HotKeyChanged += new System.EventHandler<SoundSwitch.UI.Component.HotKeyTextBox.Event>(this.hotKeyControl_HotKeyChanged);
             // 
             // SettingsForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
-            this.AutoScaleMode       = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.CancelButton        = this.closeButton;
-            this.ClientSize          = new System.Drawing.Size(771, 404);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+            this.CancelButton = this.closeButton;
+            this.ClientSize = new System.Drawing.Size(771, 404);
             this.Controls.Add(this.hotKeyControl);
             this.Controls.Add(this.hotkeysCheckBox);
             this.Controls.Add(this.tabControl);
             this.Controls.Add(this.closeButton);
             this.MinimumSize = new System.Drawing.Size(787, 443);
-            this.Name        = "SettingsForm";
-            this.Text        = "Settings";
+            this.Name = "SettingsForm";
+            this.Text = "Settings";
             this.tabControl.ResumeLayout(false);
             this.playbackTabPage.ResumeLayout(false);
             this.recordingTabPage.ResumeLayout(false);
@@ -558,6 +580,7 @@ namespace SoundSwitch.UI.Forms
             this.basicSettingsGroupBox.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
+
         }
 
         private System.Windows.Forms.Button addProfileButton;
@@ -600,5 +623,7 @@ namespace SoundSwitch.UI.Forms
         private System.Windows.Forms.RadioButton updateSilentRadioButton;
 
         #endregion
+
+        private System.Windows.Forms.CheckBox usePrimaryScreenCheckbox;
     }
 }

--- a/SoundSwitch/UI/Forms/Settings.cs
+++ b/SoundSwitch/UI/Forms/Settings.cs
@@ -130,9 +130,14 @@ namespace SoundSwitch.UI.Forms
             cycleThroughToolTip.SetToolTip(cycleThroughComboBox, SettingsStrings.cycleThroughTooltip);
 
             foregroundAppCheckbox.Checked = AppModel.Instance.SwitchForegroundProgram;
+            usePrimaryScreenCheckbox.Checked = AppModel.Instance.NotifyUsingPrimaryScreen;
+            usePrimaryScreenCheckbox.Visible = AppModel.Instance.NotificationSettings == NotificationTypeEnum.BannerNotification;
 
             var foregroundAppToolTip = new ToolTip();
             foregroundAppToolTip.SetToolTip(foregroundAppCheckbox, SettingsStrings.foregroundAppTooltip);
+
+            var usePrimaryScreenTooltip = new ToolTip();
+            usePrimaryScreenTooltip.SetToolTip(usePrimaryScreenCheckbox, SettingsStrings.usePrimaryScreenTooltip);
 
             // Settings - Update
             includeBetaVersionsCheckBox.Checked = AppModel.Instance.IncludeBetaVersions;
@@ -166,7 +171,7 @@ namespace SoundSwitch.UI.Forms
             // Settings - Language
             new LanguageFactory().ConfigureListControl(languageComboBox);
             languageComboBox.SelectedValue = AppModel.Instance.Language;
-            
+
             PopulateSettings();
 
             _loaded = true;
@@ -197,10 +202,10 @@ namespace SoundSwitch.UI.Forms
         {
             ListViewItem ProfileToListViewItem(Profile profile)
             {
-                var            listViewItem = new ListViewItem(profile.Name) {Tag = profile};
-                Icon           appIcon      = null;
-                DeviceFullInfo recording    = null;
-                DeviceFullInfo playback     = null;
+                var listViewItem = new ListViewItem(profile.Name) { Tag = profile };
+                Icon appIcon = null;
+                DeviceFullInfo recording = null;
+                DeviceFullInfo playback = null;
                 DeviceFullInfo communication = null;
 
                 var applicationTrigger = profile.Triggers.FirstOrDefault(trig => trig.Type == TriggerFactory.Enum.Process);
@@ -229,7 +234,7 @@ namespace SoundSwitch.UI.Forms
                     recording = _audioDeviceLister.RecordingDevices.FirstOrDefault(info =>
                         info.Equals(profile.Recording));
                 }
-                
+
                 if (profile.Communication != null)
                 {
                     communication = _audioDeviceLister.PlaybackDevices.FirstOrDefault(info =>
@@ -302,6 +307,7 @@ namespace SoundSwitch.UI.Forms
             tooltipOnHoverLabel.Text = SettingsStrings.tooltipOnHover;
             cycleThroughLabel.Text = SettingsStrings.cycleThrough;
             foregroundAppCheckbox.Text = SettingsStrings.foregroundApp;
+            usePrimaryScreenCheckbox.Text = SettingsStrings.usePrimaryScreen;
 
             // Settings - Update
             updateSettingsGroupBox.Text = SettingsStrings.updateSettings;
@@ -340,7 +346,7 @@ namespace SoundSwitch.UI.Forms
 
         private void tabControl_SelectedIndexChanged(object sender, EventArgs e)
         {
-            var tabControlSender = (TabControl) sender;
+            var tabControlSender = (TabControl)sender;
             if (tabControlSender.SelectedTab == playbackTabPage)
             {
                 SetHotkeysFieldsVisibility(true);
@@ -373,7 +379,7 @@ namespace SoundSwitch.UI.Forms
         {
             if (!_loaded)
                 return;
-            var value = (DisplayEnumObject<NotificationTypeEnum>) ((ComboBox) sender).SelectedItem;
+            var value = (DisplayEnumObject<NotificationTypeEnum>)((ComboBox)sender).SelectedItem;
 
             if (value == null)
                 return;
@@ -399,6 +405,8 @@ namespace SoundSwitch.UI.Forms
                 }
             }
 
+            usePrimaryScreenCheckbox.Visible = notificationType == NotificationTypeEnum.BannerNotification;
+
             AppModel.Instance.NotificationSettings = notificationType;
         }
 
@@ -406,7 +414,7 @@ namespace SoundSwitch.UI.Forms
         {
             if (!_loaded)
                 return;
-            var value = (DisplayEnumObject<TooltipInfoTypeEnum>) ((ComboBox) sender).SelectedItem;
+            var value = (DisplayEnumObject<TooltipInfoTypeEnum>)((ComboBox)sender).SelectedItem;
 
             if (value == null)
                 return;
@@ -419,7 +427,7 @@ namespace SoundSwitch.UI.Forms
         {
             if (!_loaded)
                 return;
-            var value = (DisplayEnumObject<DeviceCyclerTypeEnum>) ((ComboBox) sender).SelectedItem;
+            var value = (DisplayEnumObject<DeviceCyclerTypeEnum>)((ComboBox)sender).SelectedItem;
 
             if (value == null)
                 return;
@@ -432,7 +440,7 @@ namespace SoundSwitch.UI.Forms
             if (!_loaded)
                 return;
 
-            var value = (DisplayEnumObject<Language>) ((ComboBox) sender).SelectedItem;
+            var value = (DisplayEnumObject<Language>)((ComboBox)sender).SelectedItem;
 
             if (value == null)
                 return;
@@ -458,7 +466,7 @@ namespace SoundSwitch.UI.Forms
 
         private void hotkeysCheckbox_CheckedChanged(object sender, EventArgs e)
         {
-            var tuple = (Tuple<DataFlow, HotKey>) hotKeyControl.Tag;
+            var tuple = (Tuple<DataFlow, HotKey>)hotKeyControl.Tag;
             var currentState = tuple.Item2.Enabled;
             hotKeyControl.Enabled = tuple.Item2.Enabled = hotkeysCheckBox.Checked;
             if (currentState != tuple.Item2.Enabled)
@@ -586,10 +594,10 @@ namespace SoundSwitch.UI.Forms
                 switch (e.NewValue)
                 {
                     case CheckState.Checked:
-                        AppModel.Instance.SelectDevice((DeviceFullInfo) ((ListView) sender).Items[e.Index].Tag);
+                        AppModel.Instance.SelectDevice((DeviceFullInfo)((ListView)sender).Items[e.Index].Tag);
                         break;
                     case CheckState.Unchecked:
-                        AppModel.Instance.UnselectDevice((DeviceFullInfo) ((ListView) sender).Items[e.Index].Tag);
+                        AppModel.Instance.UnselectDevice((DeviceFullInfo)((ListView)sender).Items[e.Index].Tag);
                         break;
                     default:
                         throw new ArgumentOutOfRangeException();
@@ -665,16 +673,21 @@ namespace SoundSwitch.UI.Forms
             AppModel.Instance.SwitchForegroundProgram = foregroundAppCheckbox.Checked;
         }
 
+        private void usePrimaryScreenCheckbox_CheckedChanged(object sender, EventArgs e)
+        {
+            AppModel.Instance.NotifyUsingPrimaryScreen = usePrimaryScreenCheckbox.Checked;
+        }
+
         private void iconChangeChoicesComboBox_SelectedIndexChanged(object sender, EventArgs e)
         {
             if (!_loaded)
                 return;
-            var comboBox = (ComboBox) sender;
+            var comboBox = (ComboBox)sender;
 
             if (comboBox == null)
                 return;
 
-            var item = (DisplayEnumObject<IconChangerFactory.ActionEnum>) iconChangeChoicesComboBox.SelectedItem;
+            var item = (DisplayEnumObject<IconChangerFactory.ActionEnum>)iconChangeChoicesComboBox.SelectedItem;
             AppConfigs.Configuration.SwitchIcon = item.Enum;
             AppConfigs.Configuration.Save();
 
@@ -701,7 +714,7 @@ namespace SoundSwitch.UI.Forms
             }
 
             var profiles = profilesListView.SelectedItems.Cast<ListViewItem>()
-                .Select(item => (Profile) item.Tag);
+                .Select(item => (Profile)item.Tag);
             AppModel.Instance.ProfileManager.DeleteProfiles(profiles);
             deleteProfileButton.Enabled = false;
             editProfileButton.Enabled = false;
@@ -710,7 +723,7 @@ namespace SoundSwitch.UI.Forms
 
         private void hotKeyControl_HotKeyChanged(object sender, HotKeyTextBox.Event e)
         {
-            var tuple = (Tuple<DataFlow, HotKey>) hotKeyControl.Tag;
+            var tuple = (Tuple<DataFlow, HotKey>)hotKeyControl.Tag;
             if (tuple == null)
                 return;
 


### PR DESCRIPTION
This is something I needed. I have multiple monitors and have to search the screens for the banner notification to see which sound I/O is active. Figured maybe it would be useful for someone else.