### PR TITLE
Added new trigger for On Device Changed

### DIFF
--- a/SoundSwitch/Framework/Profile/Trigger/TriggerEnumExtensions.cs
+++ b/SoundSwitch/Framework/Profile/Trigger/TriggerEnumExtensions.cs
@@ -8,9 +8,9 @@ namespace SoundSwitch.Framework.Profile.Trigger
         /// Switch on the given enum
         /// </summary>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public static void Switch(this TriggerFactory.Enum @enum, Action hotkey, Action window, Action process, Action steam, Action startup, Action uwpApp, Action trayMenu)
+        public static void Switch(this TriggerFactory.Enum @enum, Action hotkey, Action window, Action process, Action steam, Action startup, Action uwpApp, Action trayMenu, Action changed)
         {
-            Match(@enum, () => hotkey, () => window, () => process, () => steam, () => startup, () => uwpApp, () => trayMenu)();
+            Match(@enum, () => hotkey, () => window, () => process, () => steam, () => startup, () => uwpApp, () => trayMenu, () => changed)();
         }
 
         /// <summary>
@@ -18,7 +18,7 @@ namespace SoundSwitch.Framework.Profile.Trigger
         /// </summary>
         /// <returns></returns>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public static T Match<T>(this TriggerFactory.Enum @enum, Func<T> hotkey, Func<T> window, Func<T> process, Func<T> steam, Func<T> startup, Func<T> uwpApp, Func<T> trayMenu)
+        public static T Match<T>(this TriggerFactory.Enum @enum, Func<T> hotkey, Func<T> window, Func<T> process, Func<T> steam, Func<T> startup, Func<T> uwpApp, Func<T> trayMenu, Func<T> changed)
         {
             return @enum switch
             {
@@ -29,6 +29,7 @@ namespace SoundSwitch.Framework.Profile.Trigger
                 TriggerFactory.Enum.Startup  => startup(),
                 TriggerFactory.Enum.UwpApp   => uwpApp(),
                 TriggerFactory.Enum.TrayMenu => trayMenu(),
+                TriggerFactory.Enum.Changed  => changed(),
                 _                            => throw new ArgumentOutOfRangeException(nameof(@enum), @enum, null)
             };
         }

--- a/SoundSwitch/Framework/Profile/Trigger/TriggerFactory.cs
+++ b/SoundSwitch/Framework/Profile/Trigger/TriggerFactory.cs
@@ -13,7 +13,8 @@ namespace SoundSwitch.Framework.Profile.Trigger
             Steam,
             Startup,
             UwpApp,
-            TrayMenu
+            TrayMenu,
+            Changed
         }
 
         private static readonly IEnumImplList<Enum, ITriggerDefinition> Impl =
@@ -25,7 +26,8 @@ namespace SoundSwitch.Framework.Profile.Trigger
                 new SteamBigPictureTrigger(),
                 new Startup(),
                 new UwpApp(),
-                new TrayMenu()
+                new TrayMenu(),
+                new DeviceChanged()
             };
 
         public TriggerFactory() : base(Impl)
@@ -136,5 +138,16 @@ namespace SoundSwitch.Framework.Profile.Trigger
         public override TriggerFactory.Enum TypeEnum => TriggerFactory.Enum.TrayMenu;
         public override string Label => SettingsStrings.profile_trigger_trayMenu;
         public override int MaxOccurence => 1;
+    }
+
+    public class DeviceChanged : BaseTrigger
+    {
+        public override TriggerFactory.Enum TypeEnum => TriggerFactory.Enum.Changed;
+        public override string Label => SettingsStrings.profile_trigger_deviceChanged;
+
+        public override int MaxOccurence => 1;
+        public override int MaxGlobalOccurence => 1;
+
+        public override string Description { get; } = SettingsStrings.profile_trigger_deviceChanged_desc;
     }
 }

--- a/SoundSwitch/Localization/SettingsStrings.Designer.cs
+++ b/SoundSwitch/Localization/SettingsStrings.Designer.cs
@@ -19,7 +19,7 @@ namespace SoundSwitch.Localization {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class SettingsStrings {
@@ -548,6 +548,15 @@ namespace SoundSwitch.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to You can only have one profile for On Device Changed..
+        /// </summary>
+        internal static string profile_error_deviceChanged {
+            get {
+                return ResourceManager.GetString("profile.error.deviceChanged", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to This hotkey {0} is already registered..
         /// </summary>
         internal static string profile_error_hotkey {
@@ -742,6 +751,24 @@ namespace SoundSwitch.Localization {
         internal static string profile_trigger_available {
             get {
                 return ResourceManager.GetString("profile.trigger.available", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to On Device Change.
+        /// </summary>
+        internal static string profile_trigger_deviceChanged {
+            get {
+                return ResourceManager.GetString("profile.trigger.deviceChanged", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The profile will be triggered automatically when the current sound device changes.
+        /// </summary>
+        internal static string profile_trigger_deviceChanged_desc {
+            get {
+                return ResourceManager.GetString("profile.trigger.deviceChanged.desc", resourceCulture);
             }
         }
         

--- a/SoundSwitch/Localization/SettingsStrings.resx
+++ b/SoundSwitch/Localization/SettingsStrings.resx
@@ -465,6 +465,15 @@ Restore the state of the system when the application is closed.</value>
   <data name="profile.trigger.trayMenu.desc" xml:space="preserve">
     <value>This trigger make the profile visible in the tray icon menu. Left-click on the systray icon to see your profile.</value>
   </data>
+  <data name="profile.trigger.deviceChanged" xml:space="preserve">
+    <value>On Device Change</value>
+  </data>
+  <data name="profile.trigger.deviceChanged.desc" xml:space="preserve">
+    <value>The profile will be triggered automatically when the current sound device changes</value>
+  </data>
+  <data name="profile.error.deviceChanged" xml:space="preserve">
+    <value>You can only have one profile for On Device Changed.</value>
+  </data>
   <data name="telemetry" xml:space="preserve">
     <value>Telemetry</value>
   </data>

--- a/SoundSwitch/UI/Forms/UpsertProfileExtended.cs
+++ b/SoundSwitch/UI/Forms/UpsertProfileExtended.cs
@@ -218,6 +218,7 @@ namespace SoundSwitch.UI.Forms
                     textInput.DataBindings.Add(nameof(TextBox.Text), trigger, nameof(Trigger.WindowName), true, DataSourceUpdateMode.OnPropertyChanged);
                     textInput.Show();
                 },
+                () => { },
                 () => { });
         }
 


### PR DESCRIPTION
I'm not sure if this is desired upstream. But I added a new trigger for when the Default Sound Device changes. Many people on Windows 10 hate how plugging in new devices will automatically change the Default Device. This change will ensure that a device of the user's choosing will always be the active sound device.

This has not been tested extensively in conjunction with other triggers and profiles.  But this change suits my needs and if it is helpful upstream, you're free to use it and tailor it to whatever end. It also is missing Localization for non-English languages.

Resolves #648 