### PR TITLE
Add Force Selected Profile option

### DIFF
--- a/SoundSwitch/Framework/Configuration/ISoundSwitchConfiguration.cs
+++ b/SoundSwitch/Framework/Configuration/ISoundSwitchConfiguration.cs
@@ -58,6 +58,8 @@ namespace SoundSwitch.Framework.Configuration
         
         bool AutoAddNewConnectedDevices { get; set; }
 
+        bool ForceSelectedProfile { get; set; }
+
         /// <summary>
         /// What to do with the TrayIcon when changing default device
         /// </summary>

--- a/SoundSwitch/Framework/Configuration/SoundSwitchConfiguration.cs
+++ b/SoundSwitch/Framework/Configuration/SoundSwitchConfiguration.cs
@@ -40,6 +40,7 @@ namespace SoundSwitch.Framework.Configuration
             // Basic Settings
             FirstRun = true;
             SwitchForegroundProgram = false;
+            ForceSelectedProfile = false;
 
             // Audio Settings
             ChangeCommunications = false;
@@ -100,6 +101,8 @@ namespace SoundSwitch.Framework.Configuration
 
         public bool SwitchForegroundProgram { get; set; }
         public IconChangerFactory.ActionEnum SwitchIcon { get; set; }
+
+        public bool ForceSelectedProfile { get; set; }
 
         [Obsolete]
         public HashSet<ProfileSetting> ProfileSettings { get; set; } = new();

--- a/SoundSwitch/Framework/Profile/ProfileManager.cs
+++ b/SoundSwitch/Framework/Profile/ProfileManager.cs
@@ -364,6 +364,12 @@ namespace SoundSwitch.Framework.Profile
         private void SwitchAudio(Profile profile, uint processId)
         {
             _notificationManager.NotifyProfileChanged(profile, processId);
+			
+            if (AppModel.Instance.ForceSelectedProfile)
+            {
+                _forcedProfile = profile;
+            }
+            
             foreach (var device in profile.Devices)
             {
                 var deviceToUse = CheckDeviceAvailable(device.DeviceInfo);
@@ -390,6 +396,12 @@ namespace SoundSwitch.Framework.Profile
         public void SwitchAudio(Profile profile)
         {
             _notificationManager.NotifyProfileChanged(profile, null);
+			
+            if (AppModel.Instance.ForceSelectedProfile)
+            {
+                _forcedProfile = profile;
+            }
+			
             foreach (var device in profile.Devices)
             {
                 var deviceToUse = CheckDeviceAvailable(device.DeviceInfo);

--- a/SoundSwitch/Model/AppModel.cs
+++ b/SoundSwitch/Model/AppModel.cs
@@ -269,6 +269,16 @@ namespace SoundSwitch.Model
             }
         }
 
+        public bool ForceSelectedProfile
+        {
+            get => AppConfigs.Configuration.ForceSelectedProfile;
+            set
+            {
+                AppConfigs.Configuration.ForceSelectedProfile = value;
+                AppConfigs.Configuration.Save();
+            }
+        }
+
         #region Misc settings
 
         /// <summary>

--- a/SoundSwitch/Model/IAppModel.cs
+++ b/SoundSwitch/Model/IAppModel.cs
@@ -99,6 +99,12 @@ namespace SoundSwitch.Model
         bool SwitchForegroundProgram { get; set; }
 
         /// <summary>
+        /// Behaves same as Having a frofile trigger set to force, but maintains it on the selected profile.
+        /// Allows changing between desired profiles, while preventing other programs from changing sound settings.
+        /// </summary>
+        bool ForceSelectedProfile { get; set; }
+
+        /// <summary>
         /// Always show banner on primary screen instead of active screen
         /// </summary>
         bool NotifyUsingPrimaryScreen { get; set; }

--- a/SoundSwitch/UI/Forms/Settings.Designer.cs
+++ b/SoundSwitch/UI/Forms/Settings.Designer.cs
@@ -43,6 +43,7 @@ namespace SoundSwitch.UI.Forms
             this.recordingTabPage = new System.Windows.Forms.TabPage();
             this.recordingListView = new SoundSwitch.UI.Component.ListView.ListViewExtended();
             this.tabProfile = new System.Windows.Forms.TabPage();
+            this.forceSelectedProfileCheckbox = new System.Windows.Forms.CheckBox();
             this.editProfileButton = new System.Windows.Forms.Button();
             this.deleteProfileButton = new System.Windows.Forms.Button();
             this.profileExplanationLabel = new System.Windows.Forms.Label();
@@ -201,6 +202,7 @@ namespace SoundSwitch.UI.Forms
             // 
             // tabProfile
             // 
+            this.tabProfile.Controls.Add(this.forceSelectedProfileCheckbox);
             this.tabProfile.Controls.Add(this.editProfileButton);
             this.tabProfile.Controls.Add(this.deleteProfileButton);
             this.tabProfile.Controls.Add(this.profileExplanationLabel);
@@ -213,6 +215,17 @@ namespace SoundSwitch.UI.Forms
             this.tabProfile.TabIndex = 3;
             this.tabProfile.Text = "Profiles";
             this.tabProfile.UseVisualStyleBackColor = true;
+            // 
+            // forceSelectedProfileCheckbox
+            // 
+            this.forceSelectedProfileCheckbox.AutoSize = true;
+            this.forceSelectedProfileCheckbox.Location = new System.Drawing.Point(6, 342);
+            this.forceSelectedProfileCheckbox.Name = "forceSelectedProfileCheckbox";
+            this.forceSelectedProfileCheckbox.Size = new System.Drawing.Size(139, 19);
+            this.forceSelectedProfileCheckbox.TabIndex = 6;
+            this.forceSelectedProfileCheckbox.Text = "Force Selected Profile";
+            this.forceSelectedProfileCheckbox.UseVisualStyleBackColor = true;
+            this.forceSelectedProfileCheckbox.CheckedChanged += new System.EventHandler(this.forceSelectedProfileCheckbox_CheckedChanged);
             // 
             // editProfileButton
             // 
@@ -639,6 +652,7 @@ namespace SoundSwitch.UI.Forms
             this.playbackTabPage.ResumeLayout(false);
             this.recordingTabPage.ResumeLayout(false);
             this.tabProfile.ResumeLayout(false);
+            this.tabProfile.PerformLayout();
             this.appSettingTabPage.ResumeLayout(false);
             this.languageGroupBox.ResumeLayout(false);
             this.updateSettingsGroupBox.ResumeLayout(false);
@@ -700,5 +714,6 @@ namespace SoundSwitch.UI.Forms
         private System.Windows.Forms.CheckBox telemetryCheckbox;
         private System.Windows.Forms.CheckBox quickMenuCheckbox;
         private System.Windows.Forms.CheckBox autoAddDeviceCheckbox;
+        private System.Windows.Forms.CheckBox forceSelectedProfileCheckbox;
     }
 }

--- a/SoundSwitch/UI/Forms/Settings.cs
+++ b/SoundSwitch/UI/Forms/Settings.cs
@@ -77,6 +77,8 @@ namespace SoundSwitch.UI.Forms
             var hotkeysToolTip = new ToolTip();
             hotkeysToolTip.SetToolTip(hotkeysCheckBox, SettingsStrings.hotkeysTooltip);
 
+            forceSelectedProfileCheckbox.Checked = AppConfigs.Configuration.ForceSelectedProfile;
+
             // Settings - Basic
             startWithWindowsCheckBox.Checked = AppModel.Instance.RunAtStartup;
 
@@ -807,5 +809,11 @@ namespace SoundSwitch.UI.Forms
         {
             forceSetHotkeys(sender, muteHotKey);
         }
+
+        private void forceSelectedProfileCheckbox_CheckedChanged(object sender, EventArgs e)
+        {
+            AppModel.Instance.ForceSelectedProfile = forceSelectedProfileCheckbox.Checked;
+        }
+
     }
 }


### PR DESCRIPTION
Add Force Selected Profile option, which causes SoundSwitch to behave as if the current profile has the "Force Profile" trigger enabled.  However, can still use other trigger methods to change profiles freely.  Effectively allows user to switch between defined profiles, but keeps Windows, or other programs from changing the devices.

I made this mod as I have a monitor with a speaker in it that when it wakes up, windows auto-switches to (regardless of default).  Using the Force Profile Trigger fixes this, however I have 2 different profiles that I like to use depending on what I am doing.  This solution allows me to use my profiles freely, but lock down any other change to the system.

The only annoyance I have found, that will be a bit more involved for me to solve, is if a profile is selected, and some part of it can't be applied (say missing microphone) you will get the error for that every time the profile is applied.  It still functions correctly, but could be a nuisance.

No attachment to the location of the setting in the GUI.  Just wanted a quick and easy edit option.  100% open to moving it.
