### PR TITLE
feat: Keep volume level across audio devices

### DIFF
--- a/SoundSwitch.Audio.Manager/AudioSwitcher.cs
+++ b/SoundSwitch.Audio.Manager/AudioSwitcher.cs
@@ -178,6 +178,23 @@ namespace SoundSwitch.Audio.Manager
         }
 
         /// <summary>
+        /// Set the same master volume level from the default audio device to the next device
+        /// </summary>
+        /// <param name="deviceId">Id of the device</param>
+        /// <param name="role">Which role to switch</param>
+        /// <param name="flow">Which flow to switch</param>
+        public void SetVolumeFromDefaultDevice (DeviceInfo device) {
+            MMDeviceEnumerator devEnum = new();
+            MMDevice defaultDevice = devEnum.GetDefaultAudioEndpoint(device.Type, (Role) ERole.eConsole);
+            var currentVolume = defaultDevice.AudioEndpointVolume.MasterVolumeLevelScalar;
+            var IsMute = defaultDevice.AudioEndpointVolume.Mute;
+            
+            var nextDevice = devEnum.GetDevice(device.Id);
+            nextDevice.AudioEndpointVolume.MasterVolumeLevelScalar = currentVolume;
+            nextDevice.AudioEndpointVolume.Mute = IsMute;
+        }
+
+        /// <summary>
         /// Is the given deviceId the default audio device in the system
         /// </summary>
         /// <param name="deviceId"></param>

--- a/SoundSwitch/Framework/Configuration/ISoundSwitchConfiguration.cs
+++ b/SoundSwitch/Framework/Configuration/ISoundSwitchConfiguration.cs
@@ -91,5 +91,10 @@ namespace SoundSwitch.Framework.Configuration
         /// Is the quick menu showed when using a hotkey
         /// </summary>
         bool QuickMenuEnabled { get; set; }
+
+        /// <summary>
+        /// Is keep volume enabled
+        /// </summary>
+        bool KeepVolumeEnabled { get; set; }
     }
 }

--- a/SoundSwitch/Framework/Configuration/SoundSwitchConfiguration.cs
+++ b/SoundSwitch/Framework/Configuration/SoundSwitchConfiguration.cs
@@ -126,6 +126,11 @@ namespace SoundSwitch.Framework.Configuration
         /// </summary>
         public bool QuickMenuEnabled { get; set; } = false;
 
+        /// <summary>
+        /// Is keep volume enabled
+        /// </summary>
+        public bool KeepVolumeEnabled { get; set; } = false;
+
         // Needed by Interface
         [JsonIgnore]
         public string FileLocation { get; set; }

--- a/SoundSwitch/Framework/DeviceCyclerManager/DeviceCycler/ADeviceCycler.cs
+++ b/SoundSwitch/Framework/DeviceCyclerManager/DeviceCycler/ADeviceCycler.cs
@@ -79,6 +79,11 @@ namespace SoundSwitch.Framework.DeviceCyclerManager.DeviceCycler
         /// <param name="device"></param>
         public bool SetActiveDevice(DeviceInfo device)
         {
+            if (device.Type != DataFlow.Capture && AppModel.Instance.KeepVolumeEnabled)
+            {
+                AudioSwitcher.Instance.SetVolumeFromDefaultDevice(device);
+            }
+
             Log.Information("Set Default device: {Device}", device);
             if (!AppModel.Instance.SetCommunications)
             {

--- a/SoundSwitch/Localization/SettingsStrings.Designer.cs
+++ b/SoundSwitch/Localization/SettingsStrings.Designer.cs
@@ -952,6 +952,24 @@ namespace SoundSwitch.Localization {
                 return ResourceManager.GetString("quickMenu.desc", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Keep volume level across devices.
+        /// </summary>
+        internal static string keepVolume {
+            get {
+                return ResourceManager.GetString("keepVolume", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Keep the same volume level when switching audio devices.
+        /// </summary>
+        internal static string keepVolume_desc {
+            get {
+                return ResourceManager.GetString("keepVolume.desc", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Recording.

--- a/SoundSwitch/Localization/SettingsStrings.resx
+++ b/SoundSwitch/Localization/SettingsStrings.resx
@@ -477,14 +477,20 @@ Restore the state of the system when the application is closed.</value>
   <data name="telemetry" xml:space="preserve">
     <value>Telemetry</value>
   </data>
+  <data name="telemetry.desc" xml:space="preserve">
+    <value>Gather anonymously which version of SoundSwitch is in use. Only shared with the developer of SoundSwitch.</value>
+  </data>
   <data name="quickMenu" xml:space="preserve">
     <value>Quick Menu on hotkey</value>
   </data>
   <data name="quickMenu.desc" xml:space="preserve">
     <value>Show a quick menu like Windows language when using a hotkey</value>
   </data>
-  <data name="telemetry.desc" xml:space="preserve">
-    <value>Gather anonymously which version of SoundSwitch is in use. Only shared with the developer of SoundSwitch.</value>
+  <data name="keepVolume" xml:space="preserve">
+    <value>Keep volume level across devices</value>
+  </data>
+  <data name="keepVolume.desc" xml:space="preserve">
+    <value>Keep the same volume level when switching playback devices</value>
   </data>
   <data name="devices.AutoAddNewDevice" xml:space="preserve">
     <value>Auto select new devices</value>

--- a/SoundSwitch/Model/AppModel.cs
+++ b/SoundSwitch/Model/AppModel.cs
@@ -181,6 +181,15 @@ namespace SoundSwitch.Model
             }
         }
 
+        public bool KeepVolumeEnabled
+        {
+            get => AppConfigs.Configuration.KeepVolumeEnabled;
+            set
+            {
+                AppConfigs.Configuration.KeepVolumeEnabled = value;
+                AppConfigs.Configuration.Save();
+            }
+        }
 
         public DeviceCollection<DeviceInfo> SelectedDevices
         {

--- a/SoundSwitch/Model/IAppModel.cs
+++ b/SoundSwitch/Model/IAppModel.cs
@@ -110,6 +110,7 @@ namespace SoundSwitch.Model
 
         bool Telemetry { get; set; }
         bool QuickMenuEnabled { get; set; }
+        bool KeepVolumeEnabled { get; set; }
         bool AutoAddNewDevice { get; set; }
 
         #endregion

--- a/SoundSwitch/UI/Forms/Settings.Designer.cs
+++ b/SoundSwitch/UI/Forms/Settings.Designer.cs
@@ -34,622 +34,626 @@ namespace SoundSwitch.UI.Forms
         {
             System.Windows.Forms.ListViewGroup listViewGroup1 = new System.Windows.Forms.ListViewGroup("Selected", System.Windows.Forms.HorizontalAlignment.Center);
             System.Windows.Forms.ListViewGroup listViewGroup2 = new System.Windows.Forms.ListViewGroup("Selected", System.Windows.Forms.HorizontalAlignment.Center);
-            this.startWithWindowsCheckBox = new System.Windows.Forms.CheckBox();
-            this.closeButton = new System.Windows.Forms.Button();
-            this.switchCommunicationDeviceCheckBox = new System.Windows.Forms.CheckBox();
-            this.tabControl = new System.Windows.Forms.TabControl();
-            this.playbackTabPage = new System.Windows.Forms.TabPage();
-            this.playbackListView = new SoundSwitch.UI.Component.ListView.ListViewExtended();
-            this.recordingTabPage = new System.Windows.Forms.TabPage();
-            this.recordingListView = new SoundSwitch.UI.Component.ListView.ListViewExtended();
-            this.tabProfile = new System.Windows.Forms.TabPage();
-            this.editProfileButton = new System.Windows.Forms.Button();
-            this.deleteProfileButton = new System.Windows.Forms.Button();
-            this.profileExplanationLabel = new System.Windows.Forms.Label();
-            this.profilesListView = new SoundSwitch.UI.Component.ListView.IconListView();
-            this.addProfileButton = new System.Windows.Forms.Button();
-            this.appSettingTabPage = new System.Windows.Forms.TabPage();
-            this.languageGroupBox = new System.Windows.Forms.GroupBox();
-            this.languageComboBox = new System.Windows.Forms.ComboBox();
-            this.updateSettingsGroupBox = new System.Windows.Forms.GroupBox();
-            this.telemetryCheckbox = new System.Windows.Forms.CheckBox();
-            this.updateNeverRadioButton = new System.Windows.Forms.RadioButton();
-            this.updateNotifyRadioButton = new System.Windows.Forms.RadioButton();
-            this.updateSilentRadioButton = new System.Windows.Forms.RadioButton();
-            this.includeBetaVersionsCheckBox = new System.Windows.Forms.CheckBox();
-            this.audioSettingsGroupBox = new System.Windows.Forms.GroupBox();
-            this.quickMenuCheckbox = new System.Windows.Forms.CheckBox();
-            this.usePrimaryScreenCheckbox = new System.Windows.Forms.CheckBox();
-            this.foregroundAppCheckbox = new System.Windows.Forms.CheckBox();
-            this.deleteSoundButton = new System.Windows.Forms.Button();
-            this.cycleThroughLabel = new System.Windows.Forms.Label();
-            this.cycleThroughComboBox = new System.Windows.Forms.ComboBox();
-            this.tooltipOnHoverLabel = new System.Windows.Forms.Label();
-            this.tooltipInfoComboBox = new System.Windows.Forms.ComboBox();
-            this.selectSoundButton = new System.Windows.Forms.Button();
-            this.notificationLabel = new System.Windows.Forms.Label();
-            this.notificationComboBox = new System.Windows.Forms.ComboBox();
-            this.basicSettingsGroupBox = new System.Windows.Forms.GroupBox();
-            this.iconChangeLabel = new System.Windows.Forms.Label();
-            this.iconChangeChoicesComboBox = new System.Windows.Forms.ComboBox();
-            this.selectSoundFileDialog = new System.Windows.Forms.OpenFileDialog();
-            this.hotkeysCheckBox = new System.Windows.Forms.CheckBox();
-            this.hotKeyControl = new SoundSwitch.UI.Component.HotKeyTextBox();
-            this.toggleMuteLabel = new System.Windows.Forms.Label();
-            this.muteHotKey = new SoundSwitch.UI.Component.HotKeyTextBox();
-            this.muteHotKeyCheckbox = new System.Windows.Forms.CheckBox();
-            this.autoAddDeviceCheckbox = new System.Windows.Forms.CheckBox();
-            this.tabControl.SuspendLayout();
-            this.playbackTabPage.SuspendLayout();
-            this.recordingTabPage.SuspendLayout();
-            this.tabProfile.SuspendLayout();
-            this.appSettingTabPage.SuspendLayout();
-            this.languageGroupBox.SuspendLayout();
-            this.updateSettingsGroupBox.SuspendLayout();
-            this.audioSettingsGroupBox.SuspendLayout();
-            this.basicSettingsGroupBox.SuspendLayout();
-            this.SuspendLayout();
+            startWithWindowsCheckBox = new System.Windows.Forms.CheckBox();
+            closeButton = new System.Windows.Forms.Button();
+            switchCommunicationDeviceCheckBox = new System.Windows.Forms.CheckBox();
+            tabControl = new System.Windows.Forms.TabControl();
+            playbackTabPage = new System.Windows.Forms.TabPage();
+            playbackListView = new ListViewExtended();
+            recordingTabPage = new System.Windows.Forms.TabPage();
+            recordingListView = new ListViewExtended();
+            tabProfile = new System.Windows.Forms.TabPage();
+            editProfileButton = new System.Windows.Forms.Button();
+            deleteProfileButton = new System.Windows.Forms.Button();
+            profileExplanationLabel = new System.Windows.Forms.Label();
+            profilesListView = new IconListView();
+            addProfileButton = new System.Windows.Forms.Button();
+            appSettingTabPage = new System.Windows.Forms.TabPage();
+            languageGroupBox = new System.Windows.Forms.GroupBox();
+            languageComboBox = new System.Windows.Forms.ComboBox();
+            updateSettingsGroupBox = new System.Windows.Forms.GroupBox();
+            telemetryCheckbox = new System.Windows.Forms.CheckBox();
+            updateNeverRadioButton = new System.Windows.Forms.RadioButton();
+            updateNotifyRadioButton = new System.Windows.Forms.RadioButton();
+            updateSilentRadioButton = new System.Windows.Forms.RadioButton();
+            includeBetaVersionsCheckBox = new System.Windows.Forms.CheckBox();
+            audioSettingsGroupBox = new System.Windows.Forms.GroupBox();
+            autoAddDeviceCheckbox = new System.Windows.Forms.CheckBox();
+            quickMenuCheckbox = new System.Windows.Forms.CheckBox();
+            keepVolumeCheckbox = new System.Windows.Forms.CheckBox();
+            usePrimaryScreenCheckbox = new System.Windows.Forms.CheckBox();
+            foregroundAppCheckbox = new System.Windows.Forms.CheckBox();
+            deleteSoundButton = new System.Windows.Forms.Button();
+            cycleThroughLabel = new System.Windows.Forms.Label();
+            cycleThroughComboBox = new System.Windows.Forms.ComboBox();
+            tooltipOnHoverLabel = new System.Windows.Forms.Label();
+            tooltipInfoComboBox = new System.Windows.Forms.ComboBox();
+            selectSoundButton = new System.Windows.Forms.Button();
+            notificationLabel = new System.Windows.Forms.Label();
+            notificationComboBox = new System.Windows.Forms.ComboBox();
+            basicSettingsGroupBox = new System.Windows.Forms.GroupBox();
+            iconChangeLabel = new System.Windows.Forms.Label();
+            iconChangeChoicesComboBox = new System.Windows.Forms.ComboBox();
+            selectSoundFileDialog = new System.Windows.Forms.OpenFileDialog();
+            hotkeysCheckBox = new System.Windows.Forms.CheckBox();
+            hotKeyControl = new Component.HotKeyTextBox();
+            toggleMuteLabel = new System.Windows.Forms.Label();
+            muteHotKey = new Component.HotKeyTextBox();
+            muteHotKeyCheckbox = new System.Windows.Forms.CheckBox();
+            tabControl.SuspendLayout();
+            playbackTabPage.SuspendLayout();
+            recordingTabPage.SuspendLayout();
+            tabProfile.SuspendLayout();
+            appSettingTabPage.SuspendLayout();
+            languageGroupBox.SuspendLayout();
+            updateSettingsGroupBox.SuspendLayout();
+            audioSettingsGroupBox.SuspendLayout();
+            basicSettingsGroupBox.SuspendLayout();
+            SuspendLayout();
             // 
             // startWithWindowsCheckBox
             // 
-            this.startWithWindowsCheckBox.AutoSize = true;
-            this.startWithWindowsCheckBox.Location = new System.Drawing.Point(6, 23);
-            this.startWithWindowsCheckBox.Name = "startWithWindowsCheckBox";
-            this.startWithWindowsCheckBox.Size = new System.Drawing.Size(203, 19);
-            this.startWithWindowsCheckBox.TabIndex = 7;
-            this.startWithWindowsCheckBox.Text = "Start automatically with Windows";
-            this.startWithWindowsCheckBox.UseVisualStyleBackColor = true;
-            this.startWithWindowsCheckBox.CheckedChanged += new System.EventHandler(this.RunAtStartup_CheckedChanged);
+            startWithWindowsCheckBox.AutoSize = true;
+            startWithWindowsCheckBox.Location = new System.Drawing.Point(6, 23);
+            startWithWindowsCheckBox.Name = "startWithWindowsCheckBox";
+            startWithWindowsCheckBox.Size = new System.Drawing.Size(203, 19);
+            startWithWindowsCheckBox.TabIndex = 7;
+            startWithWindowsCheckBox.Text = "Start automatically with Windows";
+            startWithWindowsCheckBox.UseVisualStyleBackColor = true;
+            startWithWindowsCheckBox.CheckedChanged += RunAtStartup_CheckedChanged;
             // 
             // closeButton
             // 
-            this.closeButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.closeButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.closeButton.Location = new System.Drawing.Point(795, 453);
-            this.closeButton.Name = "closeButton";
-            this.closeButton.Size = new System.Drawing.Size(100, 26);
-            this.closeButton.TabIndex = 11;
-            this.closeButton.Text = "Close";
-            this.closeButton.UseVisualStyleBackColor = true;
-            this.closeButton.Click += new System.EventHandler(this.closeButton_Click);
+            closeButton.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right;
+            closeButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            closeButton.Location = new System.Drawing.Point(795, 453);
+            closeButton.Name = "closeButton";
+            closeButton.Size = new System.Drawing.Size(100, 26);
+            closeButton.TabIndex = 11;
+            closeButton.Text = "Close";
+            closeButton.UseVisualStyleBackColor = true;
+            closeButton.Click += closeButton_Click;
             // 
             // switchCommunicationDeviceCheckBox
             // 
-            this.switchCommunicationDeviceCheckBox.AutoSize = true;
-            this.switchCommunicationDeviceCheckBox.Location = new System.Drawing.Point(6, 23);
-            this.switchCommunicationDeviceCheckBox.Name = "switchCommunicationDeviceCheckBox";
-            this.switchCommunicationDeviceCheckBox.Size = new System.Drawing.Size(230, 19);
-            this.switchCommunicationDeviceCheckBox.TabIndex = 12;
-            this.switchCommunicationDeviceCheckBox.Text = "Switch Default Communication Device";
-            this.switchCommunicationDeviceCheckBox.UseVisualStyleBackColor = true;
-            this.switchCommunicationDeviceCheckBox.CheckedChanged += new System.EventHandler(this.communicationCheckbox_CheckedChanged);
+            switchCommunicationDeviceCheckBox.AutoSize = true;
+            switchCommunicationDeviceCheckBox.Location = new System.Drawing.Point(6, 23);
+            switchCommunicationDeviceCheckBox.Name = "switchCommunicationDeviceCheckBox";
+            switchCommunicationDeviceCheckBox.Size = new System.Drawing.Size(230, 19);
+            switchCommunicationDeviceCheckBox.TabIndex = 12;
+            switchCommunicationDeviceCheckBox.Text = "Switch Default Communication Device";
+            switchCommunicationDeviceCheckBox.UseVisualStyleBackColor = true;
+            switchCommunicationDeviceCheckBox.CheckedChanged += communicationCheckbox_CheckedChanged;
             // 
             // tabControl
             // 
-            this.tabControl.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.tabControl.Controls.Add(this.playbackTabPage);
-            this.tabControl.Controls.Add(this.recordingTabPage);
-            this.tabControl.Controls.Add(this.tabProfile);
-            this.tabControl.Controls.Add(this.appSettingTabPage);
-            this.tabControl.Location = new System.Drawing.Point(12, 6);
-            this.tabControl.Name = "tabControl";
-            this.tabControl.SelectedIndex = 0;
-            this.tabControl.Size = new System.Drawing.Size(896, 439);
-            this.tabControl.TabIndex = 13;
-            this.tabControl.SelectedIndexChanged += new System.EventHandler(this.tabControl_SelectedIndexChanged);
+            tabControl.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            tabControl.Controls.Add(playbackTabPage);
+            tabControl.Controls.Add(recordingTabPage);
+            tabControl.Controls.Add(tabProfile);
+            tabControl.Controls.Add(appSettingTabPage);
+            tabControl.Location = new System.Drawing.Point(12, 6);
+            tabControl.Name = "tabControl";
+            tabControl.SelectedIndex = 0;
+            tabControl.Size = new System.Drawing.Size(896, 439);
+            tabControl.TabIndex = 13;
+            tabControl.SelectedIndexChanged += tabControl_SelectedIndexChanged;
             // 
             // playbackTabPage
             // 
-            this.playbackTabPage.Controls.Add(this.playbackListView);
-            this.playbackTabPage.Location = new System.Drawing.Point(4, 24);
-            this.playbackTabPage.Name = "playbackTabPage";
-            this.playbackTabPage.Padding = new System.Windows.Forms.Padding(3);
-            this.playbackTabPage.Size = new System.Drawing.Size(888, 411);
-            this.playbackTabPage.TabIndex = 0;
-            this.playbackTabPage.Text = "Playback";
-            this.playbackTabPage.UseVisualStyleBackColor = true;
+            playbackTabPage.Controls.Add(playbackListView);
+            playbackTabPage.Location = new System.Drawing.Point(4, 24);
+            playbackTabPage.Name = "playbackTabPage";
+            playbackTabPage.Padding = new System.Windows.Forms.Padding(3);
+            playbackTabPage.Size = new System.Drawing.Size(888, 411);
+            playbackTabPage.TabIndex = 0;
+            playbackTabPage.Text = "Playback";
+            playbackTabPage.UseVisualStyleBackColor = true;
             // 
             // playbackListView
             // 
-            this.playbackListView.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.playbackListView.CheckBoxes = true;
-            this.playbackListView.Dock = System.Windows.Forms.DockStyle.Fill;
+            playbackListView.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            playbackListView.CheckBoxes = true;
+            playbackListView.Dock = System.Windows.Forms.DockStyle.Fill;
             listViewGroup1.Header = "Selected";
             listViewGroup1.HeaderAlignment = System.Windows.Forms.HorizontalAlignment.Center;
             listViewGroup1.Name = "selectedGroup";
-            this.playbackListView.Groups.AddRange(new System.Windows.Forms.ListViewGroup[] {
-            listViewGroup1});
-            this.playbackListView.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.None;
-            this.playbackListView.Location = new System.Drawing.Point(3, 3);
-            this.playbackListView.Name = "playbackListView";
-            this.playbackListView.Size = new System.Drawing.Size(882, 405);
-            this.playbackListView.TabIndex = 14;
-            this.playbackListView.UseCompatibleStateImageBehavior = false;
-            this.playbackListView.View = System.Windows.Forms.View.Details;
+            playbackListView.Groups.AddRange(new System.Windows.Forms.ListViewGroup[] { listViewGroup1 });
+            playbackListView.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.None;
+            playbackListView.Location = new System.Drawing.Point(3, 3);
+            playbackListView.Name = "playbackListView";
+            playbackListView.Size = new System.Drawing.Size(882, 405);
+            playbackListView.TabIndex = 14;
+            playbackListView.UseCompatibleStateImageBehavior = false;
+            playbackListView.View = System.Windows.Forms.View.Details;
             // 
             // recordingTabPage
             // 
-            this.recordingTabPage.Controls.Add(this.recordingListView);
-            this.recordingTabPage.Location = new System.Drawing.Point(4, 24);
-            this.recordingTabPage.Name = "recordingTabPage";
-            this.recordingTabPage.Padding = new System.Windows.Forms.Padding(3);
-            this.recordingTabPage.Size = new System.Drawing.Size(888, 411);
-            this.recordingTabPage.TabIndex = 1;
-            this.recordingTabPage.Text = "Recording";
-            this.recordingTabPage.UseVisualStyleBackColor = true;
+            recordingTabPage.Controls.Add(recordingListView);
+            recordingTabPage.Location = new System.Drawing.Point(4, 24);
+            recordingTabPage.Name = "recordingTabPage";
+            recordingTabPage.Padding = new System.Windows.Forms.Padding(3);
+            recordingTabPage.Size = new System.Drawing.Size(888, 411);
+            recordingTabPage.TabIndex = 1;
+            recordingTabPage.Text = "Recording";
+            recordingTabPage.UseVisualStyleBackColor = true;
             // 
             // recordingListView
             // 
-            this.recordingListView.AccessibleName = "recordingListView";
-            this.recordingListView.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.recordingListView.CheckBoxes = true;
-            this.recordingListView.Dock = System.Windows.Forms.DockStyle.Fill;
+            recordingListView.AccessibleName = "recordingListView";
+            recordingListView.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            recordingListView.CheckBoxes = true;
+            recordingListView.Dock = System.Windows.Forms.DockStyle.Fill;
             listViewGroup2.Header = "Selected";
             listViewGroup2.HeaderAlignment = System.Windows.Forms.HorizontalAlignment.Center;
             listViewGroup2.Name = "selectedGroup";
-            this.recordingListView.Groups.AddRange(new System.Windows.Forms.ListViewGroup[] {
-            listViewGroup2});
-            this.recordingListView.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.None;
-            this.recordingListView.Location = new System.Drawing.Point(3, 3);
-            this.recordingListView.Name = "recordingListView";
-            this.recordingListView.Size = new System.Drawing.Size(882, 405);
-            this.recordingListView.TabIndex = 17;
-            this.recordingListView.UseCompatibleStateImageBehavior = false;
-            this.recordingListView.View = System.Windows.Forms.View.Details;
+            recordingListView.Groups.AddRange(new System.Windows.Forms.ListViewGroup[] { listViewGroup2 });
+            recordingListView.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.None;
+            recordingListView.Location = new System.Drawing.Point(3, 3);
+            recordingListView.Name = "recordingListView";
+            recordingListView.Size = new System.Drawing.Size(882, 405);
+            recordingListView.TabIndex = 17;
+            recordingListView.UseCompatibleStateImageBehavior = false;
+            recordingListView.View = System.Windows.Forms.View.Details;
             // 
             // tabProfile
             // 
-            this.tabProfile.Controls.Add(this.editProfileButton);
-            this.tabProfile.Controls.Add(this.deleteProfileButton);
-            this.tabProfile.Controls.Add(this.profileExplanationLabel);
-            this.tabProfile.Controls.Add(this.profilesListView);
-            this.tabProfile.Controls.Add(this.addProfileButton);
-            this.tabProfile.Location = new System.Drawing.Point(4, 24);
-            this.tabProfile.Name = "tabProfile";
-            this.tabProfile.Padding = new System.Windows.Forms.Padding(3);
-            this.tabProfile.Size = new System.Drawing.Size(888, 411);
-            this.tabProfile.TabIndex = 3;
-            this.tabProfile.Text = "Profiles";
-            this.tabProfile.UseVisualStyleBackColor = true;
+            tabProfile.Controls.Add(editProfileButton);
+            tabProfile.Controls.Add(deleteProfileButton);
+            tabProfile.Controls.Add(profileExplanationLabel);
+            tabProfile.Controls.Add(profilesListView);
+            tabProfile.Controls.Add(addProfileButton);
+            tabProfile.Location = new System.Drawing.Point(4, 24);
+            tabProfile.Name = "tabProfile";
+            tabProfile.Padding = new System.Windows.Forms.Padding(3);
+            tabProfile.Size = new System.Drawing.Size(888, 411);
+            tabProfile.TabIndex = 3;
+            tabProfile.Text = "Profiles";
+            tabProfile.UseVisualStyleBackColor = true;
             // 
             // editProfileButton
             // 
-            this.editProfileButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.editProfileButton.Enabled = false;
-            this.editProfileButton.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.editProfileButton.Location = new System.Drawing.Point(606, 337);
-            this.editProfileButton.Name = "editProfileButton";
-            this.editProfileButton.Size = new System.Drawing.Size(100, 26);
-            this.editProfileButton.TabIndex = 5;
-            this.editProfileButton.Text = "Edit";
-            this.editProfileButton.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
-            this.editProfileButton.UseVisualStyleBackColor = true;
-            this.editProfileButton.Click += new System.EventHandler(this.editProfileButton_Click);
+            editProfileButton.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right;
+            editProfileButton.Enabled = false;
+            editProfileButton.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            editProfileButton.Location = new System.Drawing.Point(606, 337);
+            editProfileButton.Name = "editProfileButton";
+            editProfileButton.Size = new System.Drawing.Size(100, 26);
+            editProfileButton.TabIndex = 5;
+            editProfileButton.Text = "Edit";
+            editProfileButton.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
+            editProfileButton.UseVisualStyleBackColor = true;
+            editProfileButton.Click += editProfileButton_Click;
             // 
             // deleteProfileButton
             // 
-            this.deleteProfileButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.deleteProfileButton.Enabled = false;
-            this.deleteProfileButton.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.deleteProfileButton.Location = new System.Drawing.Point(712, 337);
-            this.deleteProfileButton.Name = "deleteProfileButton";
-            this.deleteProfileButton.Size = new System.Drawing.Size(100, 26);
-            this.deleteProfileButton.TabIndex = 4;
-            this.deleteProfileButton.Text = "Delete";
-            this.deleteProfileButton.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
-            this.deleteProfileButton.UseVisualStyleBackColor = true;
-            this.deleteProfileButton.Click += new System.EventHandler(this.deleteProfileButton_Click);
+            deleteProfileButton.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right;
+            deleteProfileButton.Enabled = false;
+            deleteProfileButton.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            deleteProfileButton.Location = new System.Drawing.Point(712, 337);
+            deleteProfileButton.Name = "deleteProfileButton";
+            deleteProfileButton.Size = new System.Drawing.Size(100, 26);
+            deleteProfileButton.TabIndex = 4;
+            deleteProfileButton.Text = "Delete";
+            deleteProfileButton.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
+            deleteProfileButton.UseVisualStyleBackColor = true;
+            deleteProfileButton.Click += deleteProfileButton_Click;
             // 
             // profileExplanationLabel
             // 
-            this.profileExplanationLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.profileExplanationLabel.Location = new System.Drawing.Point(6, 304);
-            this.profileExplanationLabel.Name = "profileExplanationLabel";
-            this.profileExplanationLabel.Size = new System.Drawing.Size(718, 30);
-            this.profileExplanationLabel.TabIndex = 3;
-            this.profileExplanationLabel.Text = "Explanation line 1\r\nOptional line 2";
+            profileExplanationLabel.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left;
+            profileExplanationLabel.Location = new System.Drawing.Point(6, 304);
+            profileExplanationLabel.Name = "profileExplanationLabel";
+            profileExplanationLabel.Size = new System.Drawing.Size(718, 30);
+            profileExplanationLabel.TabIndex = 3;
+            profileExplanationLabel.Text = "Explanation line 1\r\nOptional line 2";
             // 
             // profilesListView
             // 
-            this.profilesListView.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.profilesListView.FullRowSelect = true;
-            this.profilesListView.Location = new System.Drawing.Point(3, 3);
-            this.profilesListView.Name = "profilesListView";
-            this.profilesListView.OwnerDraw = true;
-            this.profilesListView.ShowGroups = false;
-            this.profilesListView.Size = new System.Drawing.Size(818, 294);
-            this.profilesListView.Sorting = System.Windows.Forms.SortOrder.Ascending;
-            this.profilesListView.TabIndex = 2;
-            this.profilesListView.UseCompatibleStateImageBehavior = false;
-            this.profilesListView.View = System.Windows.Forms.View.Details;
-            this.profilesListView.SelectedIndexChanged += new System.EventHandler(this.profilesListView_SelectedIndexChanged);
-            this.profilesListView.DoubleClick += new System.EventHandler(this.profilesListView_DoubleClick);
+            profilesListView.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            profilesListView.FullRowSelect = true;
+            profilesListView.Location = new System.Drawing.Point(3, 3);
+            profilesListView.Name = "profilesListView";
+            profilesListView.OwnerDraw = true;
+            profilesListView.ShowGroups = false;
+            profilesListView.Size = new System.Drawing.Size(818, 294);
+            profilesListView.Sorting = System.Windows.Forms.SortOrder.Ascending;
+            profilesListView.TabIndex = 2;
+            profilesListView.UseCompatibleStateImageBehavior = false;
+            profilesListView.View = System.Windows.Forms.View.Details;
+            profilesListView.SelectedIndexChanged += profilesListView_SelectedIndexChanged;
+            profilesListView.DoubleClick += profilesListView_DoubleClick;
             // 
             // addProfileButton
             // 
-            this.addProfileButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.addProfileButton.Location = new System.Drawing.Point(500, 337);
-            this.addProfileButton.Name = "addProfileButton";
-            this.addProfileButton.Size = new System.Drawing.Size(100, 26);
-            this.addProfileButton.TabIndex = 1;
-            this.addProfileButton.Text = "Add";
-            this.addProfileButton.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
-            this.addProfileButton.UseVisualStyleBackColor = true;
-            this.addProfileButton.Click += new System.EventHandler(this.addProfileButton_Click);
+            addProfileButton.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right;
+            addProfileButton.Location = new System.Drawing.Point(500, 337);
+            addProfileButton.Name = "addProfileButton";
+            addProfileButton.Size = new System.Drawing.Size(100, 26);
+            addProfileButton.TabIndex = 1;
+            addProfileButton.Text = "Add";
+            addProfileButton.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
+            addProfileButton.UseVisualStyleBackColor = true;
+            addProfileButton.Click += addProfileButton_Click;
             // 
             // appSettingTabPage
             // 
-            this.appSettingTabPage.Controls.Add(this.languageGroupBox);
-            this.appSettingTabPage.Controls.Add(this.updateSettingsGroupBox);
-            this.appSettingTabPage.Controls.Add(this.audioSettingsGroupBox);
-            this.appSettingTabPage.Controls.Add(this.basicSettingsGroupBox);
-            this.appSettingTabPage.Location = new System.Drawing.Point(4, 24);
-            this.appSettingTabPage.Name = "appSettingTabPage";
-            this.appSettingTabPage.Size = new System.Drawing.Size(888, 411);
-            this.appSettingTabPage.TabIndex = 2;
-            this.appSettingTabPage.Text = "Settings";
-            this.appSettingTabPage.UseVisualStyleBackColor = true;
+            appSettingTabPage.Controls.Add(languageGroupBox);
+            appSettingTabPage.Controls.Add(updateSettingsGroupBox);
+            appSettingTabPage.Controls.Add(audioSettingsGroupBox);
+            appSettingTabPage.Controls.Add(basicSettingsGroupBox);
+            appSettingTabPage.Location = new System.Drawing.Point(4, 24);
+            appSettingTabPage.Name = "appSettingTabPage";
+            appSettingTabPage.Size = new System.Drawing.Size(888, 411);
+            appSettingTabPage.TabIndex = 2;
+            appSettingTabPage.Text = "Settings";
+            appSettingTabPage.UseVisualStyleBackColor = true;
             // 
             // languageGroupBox
             // 
-            this.languageGroupBox.Controls.Add(this.languageComboBox);
-            this.languageGroupBox.Location = new System.Drawing.Point(434, 174);
-            this.languageGroupBox.Name = "languageGroupBox";
-            this.languageGroupBox.Size = new System.Drawing.Size(298, 61);
-            this.languageGroupBox.TabIndex = 15;
-            this.languageGroupBox.TabStop = false;
-            this.languageGroupBox.Text = "Language";
+            languageGroupBox.Controls.Add(languageComboBox);
+            languageGroupBox.Location = new System.Drawing.Point(434, 174);
+            languageGroupBox.Name = "languageGroupBox";
+            languageGroupBox.Size = new System.Drawing.Size(298, 61);
+            languageGroupBox.TabIndex = 15;
+            languageGroupBox.TabStop = false;
+            languageGroupBox.Text = "Language";
             // 
             // languageComboBox
             // 
-            this.languageComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.languageComboBox.FormattingEnabled = true;
-            this.languageComboBox.Location = new System.Drawing.Point(8, 23);
-            this.languageComboBox.Name = "languageComboBox";
-            this.languageComboBox.Size = new System.Drawing.Size(247, 23);
-            this.languageComboBox.TabIndex = 17;
-            this.languageComboBox.SelectedIndexChanged += new System.EventHandler(this.languageComboBox_SelectedIndexChanged);
+            languageComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            languageComboBox.FormattingEnabled = true;
+            languageComboBox.Location = new System.Drawing.Point(8, 23);
+            languageComboBox.Name = "languageComboBox";
+            languageComboBox.Size = new System.Drawing.Size(247, 23);
+            languageComboBox.TabIndex = 17;
+            languageComboBox.SelectedIndexChanged += languageComboBox_SelectedIndexChanged;
             // 
             // updateSettingsGroupBox
             // 
-            this.updateSettingsGroupBox.Controls.Add(this.telemetryCheckbox);
-            this.updateSettingsGroupBox.Controls.Add(this.updateNeverRadioButton);
-            this.updateSettingsGroupBox.Controls.Add(this.updateNotifyRadioButton);
-            this.updateSettingsGroupBox.Controls.Add(this.updateSilentRadioButton);
-            this.updateSettingsGroupBox.Controls.Add(this.includeBetaVersionsCheckBox);
-            this.updateSettingsGroupBox.Location = new System.Drawing.Point(434, 12);
-            this.updateSettingsGroupBox.Name = "updateSettingsGroupBox";
-            this.updateSettingsGroupBox.Size = new System.Drawing.Size(298, 156);
-            this.updateSettingsGroupBox.TabIndex = 14;
-            this.updateSettingsGroupBox.TabStop = false;
-            this.updateSettingsGroupBox.Text = "Update Settings";
+            updateSettingsGroupBox.Controls.Add(telemetryCheckbox);
+            updateSettingsGroupBox.Controls.Add(updateNeverRadioButton);
+            updateSettingsGroupBox.Controls.Add(updateNotifyRadioButton);
+            updateSettingsGroupBox.Controls.Add(updateSilentRadioButton);
+            updateSettingsGroupBox.Controls.Add(includeBetaVersionsCheckBox);
+            updateSettingsGroupBox.Location = new System.Drawing.Point(434, 12);
+            updateSettingsGroupBox.Name = "updateSettingsGroupBox";
+            updateSettingsGroupBox.Size = new System.Drawing.Size(298, 156);
+            updateSettingsGroupBox.TabIndex = 14;
+            updateSettingsGroupBox.TabStop = false;
+            updateSettingsGroupBox.Text = "Update Settings";
             // 
             // telemetryCheckbox
             // 
-            this.telemetryCheckbox.AutoSize = true;
-            this.telemetryCheckbox.Location = new System.Drawing.Point(7, 130);
-            this.telemetryCheckbox.Name = "telemetryCheckbox";
-            this.telemetryCheckbox.Size = new System.Drawing.Size(77, 19);
-            this.telemetryCheckbox.TabIndex = 22;
-            this.telemetryCheckbox.Text = "Telemetry";
-            this.telemetryCheckbox.UseVisualStyleBackColor = true;
+            telemetryCheckbox.AutoSize = true;
+            telemetryCheckbox.Location = new System.Drawing.Point(7, 130);
+            telemetryCheckbox.Name = "telemetryCheckbox";
+            telemetryCheckbox.Size = new System.Drawing.Size(77, 19);
+            telemetryCheckbox.TabIndex = 22;
+            telemetryCheckbox.Text = "Telemetry";
+            telemetryCheckbox.UseVisualStyleBackColor = true;
             // 
             // updateNeverRadioButton
             // 
-            this.updateNeverRadioButton.AutoSize = true;
-            this.updateNeverRadioButton.Location = new System.Drawing.Point(7, 71);
-            this.updateNeverRadioButton.Name = "updateNeverRadioButton";
-            this.updateNeverRadioButton.Size = new System.Drawing.Size(153, 19);
-            this.updateNeverRadioButton.TabIndex = 21;
-            this.updateNeverRadioButton.TabStop = true;
-            this.updateNeverRadioButton.Text = "Never check for updates";
-            this.updateNeverRadioButton.UseVisualStyleBackColor = true;
-            this.updateNeverRadioButton.CheckedChanged += new System.EventHandler(this.updateNeverRadioButton_CheckedChanged);
+            updateNeverRadioButton.AutoSize = true;
+            updateNeverRadioButton.Location = new System.Drawing.Point(7, 71);
+            updateNeverRadioButton.Name = "updateNeverRadioButton";
+            updateNeverRadioButton.Size = new System.Drawing.Size(153, 19);
+            updateNeverRadioButton.TabIndex = 21;
+            updateNeverRadioButton.TabStop = true;
+            updateNeverRadioButton.Text = "Never check for updates";
+            updateNeverRadioButton.UseVisualStyleBackColor = true;
+            updateNeverRadioButton.CheckedChanged += updateNeverRadioButton_CheckedChanged;
             // 
             // updateNotifyRadioButton
             // 
-            this.updateNotifyRadioButton.AutoSize = true;
-            this.updateNotifyRadioButton.Location = new System.Drawing.Point(7, 46);
-            this.updateNotifyRadioButton.Name = "updateNotifyRadioButton";
-            this.updateNotifyRadioButton.Size = new System.Drawing.Size(223, 19);
-            this.updateNotifyRadioButton.TabIndex = 20;
-            this.updateNotifyRadioButton.TabStop = true;
-            this.updateNotifyRadioButton.Text = "Notify me when updates are available";
-            this.updateNotifyRadioButton.UseVisualStyleBackColor = true;
-            this.updateNotifyRadioButton.CheckedChanged += new System.EventHandler(this.updateNotifyRadioButton_CheckedChanged);
+            updateNotifyRadioButton.AutoSize = true;
+            updateNotifyRadioButton.Location = new System.Drawing.Point(7, 46);
+            updateNotifyRadioButton.Name = "updateNotifyRadioButton";
+            updateNotifyRadioButton.Size = new System.Drawing.Size(223, 19);
+            updateNotifyRadioButton.TabIndex = 20;
+            updateNotifyRadioButton.TabStop = true;
+            updateNotifyRadioButton.Text = "Notify me when updates are available";
+            updateNotifyRadioButton.UseVisualStyleBackColor = true;
+            updateNotifyRadioButton.CheckedChanged += updateNotifyRadioButton_CheckedChanged;
             // 
             // updateSilentRadioButton
             // 
-            this.updateSilentRadioButton.AutoSize = true;
-            this.updateSilentRadioButton.Location = new System.Drawing.Point(7, 21);
-            this.updateSilentRadioButton.Name = "updateSilentRadioButton";
-            this.updateSilentRadioButton.Size = new System.Drawing.Size(176, 19);
-            this.updateSilentRadioButton.TabIndex = 19;
-            this.updateSilentRadioButton.TabStop = true;
-            this.updateSilentRadioButton.Text = "Install updates automatically";
-            this.updateSilentRadioButton.UseVisualStyleBackColor = true;
-            this.updateSilentRadioButton.CheckedChanged += new System.EventHandler(this.updateSilentRadioButton_CheckedChanged);
+            updateSilentRadioButton.AutoSize = true;
+            updateSilentRadioButton.Location = new System.Drawing.Point(7, 21);
+            updateSilentRadioButton.Name = "updateSilentRadioButton";
+            updateSilentRadioButton.Size = new System.Drawing.Size(176, 19);
+            updateSilentRadioButton.TabIndex = 19;
+            updateSilentRadioButton.TabStop = true;
+            updateSilentRadioButton.Text = "Install updates automatically";
+            updateSilentRadioButton.UseVisualStyleBackColor = true;
+            updateSilentRadioButton.CheckedChanged += updateSilentRadioButton_CheckedChanged;
             // 
             // includeBetaVersionsCheckBox
             // 
-            this.includeBetaVersionsCheckBox.AutoSize = true;
-            this.includeBetaVersionsCheckBox.Location = new System.Drawing.Point(7, 103);
-            this.includeBetaVersionsCheckBox.Name = "includeBetaVersionsCheckBox";
-            this.includeBetaVersionsCheckBox.Size = new System.Drawing.Size(137, 19);
-            this.includeBetaVersionsCheckBox.TabIndex = 18;
-            this.includeBetaVersionsCheckBox.Text = "Include Beta versions";
-            this.includeBetaVersionsCheckBox.UseVisualStyleBackColor = true;
-            this.includeBetaVersionsCheckBox.CheckedChanged += new System.EventHandler(this.betaVersionCheckbox_CheckedChanged);
+            includeBetaVersionsCheckBox.AutoSize = true;
+            includeBetaVersionsCheckBox.Location = new System.Drawing.Point(7, 103);
+            includeBetaVersionsCheckBox.Name = "includeBetaVersionsCheckBox";
+            includeBetaVersionsCheckBox.Size = new System.Drawing.Size(137, 19);
+            includeBetaVersionsCheckBox.TabIndex = 18;
+            includeBetaVersionsCheckBox.Text = "Include Beta versions";
+            includeBetaVersionsCheckBox.UseVisualStyleBackColor = true;
+            includeBetaVersionsCheckBox.CheckedChanged += betaVersionCheckbox_CheckedChanged;
             // 
             // audioSettingsGroupBox
             // 
-            this.audioSettingsGroupBox.Controls.Add(this.autoAddDeviceCheckbox);
-            this.audioSettingsGroupBox.Controls.Add(this.quickMenuCheckbox);
-            this.audioSettingsGroupBox.Controls.Add(this.usePrimaryScreenCheckbox);
-            this.audioSettingsGroupBox.Controls.Add(this.foregroundAppCheckbox);
-            this.audioSettingsGroupBox.Controls.Add(this.deleteSoundButton);
-            this.audioSettingsGroupBox.Controls.Add(this.cycleThroughLabel);
-            this.audioSettingsGroupBox.Controls.Add(this.cycleThroughComboBox);
-            this.audioSettingsGroupBox.Controls.Add(this.tooltipOnHoverLabel);
-            this.audioSettingsGroupBox.Controls.Add(this.tooltipInfoComboBox);
-            this.audioSettingsGroupBox.Controls.Add(this.switchCommunicationDeviceCheckBox);
-            this.audioSettingsGroupBox.Controls.Add(this.selectSoundButton);
-            this.audioSettingsGroupBox.Controls.Add(this.notificationLabel);
-            this.audioSettingsGroupBox.Controls.Add(this.notificationComboBox);
-            this.audioSettingsGroupBox.Location = new System.Drawing.Point(3, 117);
-            this.audioSettingsGroupBox.Name = "audioSettingsGroupBox";
-            this.audioSettingsGroupBox.Size = new System.Drawing.Size(425, 266);
-            this.audioSettingsGroupBox.TabIndex = 13;
-            this.audioSettingsGroupBox.TabStop = false;
-            this.audioSettingsGroupBox.Text = "Audio Settings";
-            // 
-            // quickMenuCheckbox
-            // 
-            this.quickMenuCheckbox.AutoSize = true;
-            this.quickMenuCheckbox.Location = new System.Drawing.Point(6, 74);
-            this.quickMenuCheckbox.Name = "quickMenuCheckbox";
-            this.quickMenuCheckbox.Size = new System.Drawing.Size(144, 19);
-            this.quickMenuCheckbox.TabIndex = 27;
-            this.quickMenuCheckbox.Text = "QuickMenu on hotkey";
-            this.quickMenuCheckbox.UseVisualStyleBackColor = true;
-            // 
-            // usePrimaryScreenCheckbox
-            // 
-            this.usePrimaryScreenCheckbox.AutoSize = true;
-            this.usePrimaryScreenCheckbox.Location = new System.Drawing.Point(118, 156);
-            this.usePrimaryScreenCheckbox.Name = "usePrimaryScreenCheckbox";
-            this.usePrimaryScreenCheckbox.Size = new System.Drawing.Size(165, 19);
-            this.usePrimaryScreenCheckbox.TabIndex = 26;
-            this.usePrimaryScreenCheckbox.Text = "Always use primary screen";
-            this.usePrimaryScreenCheckbox.UseVisualStyleBackColor = true;
-            this.usePrimaryScreenCheckbox.CheckedChanged += new System.EventHandler(this.usePrimaryScreenCheckbox_CheckedChanged);
-            // 
-            // foregroundAppCheckbox
-            // 
-            this.foregroundAppCheckbox.AutoSize = true;
-            this.foregroundAppCheckbox.Location = new System.Drawing.Point(6, 48);
-            this.foregroundAppCheckbox.Name = "foregroundAppCheckbox";
-            this.foregroundAppCheckbox.Size = new System.Drawing.Size(149, 19);
-            this.foregroundAppCheckbox.TabIndex = 25;
-            this.foregroundAppCheckbox.Text = "Switch Foreground app";
-            this.foregroundAppCheckbox.UseVisualStyleBackColor = true;
-            this.foregroundAppCheckbox.CheckedChanged += new System.EventHandler(this.ForegroundAppCheckbox_CheckedChanged);
-            // 
-            // deleteSoundButton
-            // 
-            this.deleteSoundButton.Image = global::SoundSwitch.Properties.Resources.delete;
-            this.deleteSoundButton.Location = new System.Drawing.Point(391, 127);
-            this.deleteSoundButton.Name = "deleteSoundButton";
-            this.deleteSoundButton.Size = new System.Drawing.Size(24, 24);
-            this.deleteSoundButton.TabIndex = 24;
-            this.deleteSoundButton.UseVisualStyleBackColor = true;
-            this.deleteSoundButton.Visible = false;
-            this.deleteSoundButton.Click += new System.EventHandler(this.deleteSoundButton_Click);
-            // 
-            // cycleThroughLabel
-            // 
-            this.cycleThroughLabel.Location = new System.Drawing.Point(2, 224);
-            this.cycleThroughLabel.Name = "cycleThroughLabel";
-            this.cycleThroughLabel.Size = new System.Drawing.Size(110, 18);
-            this.cycleThroughLabel.TabIndex = 23;
-            this.cycleThroughLabel.Text = "Cycle through";
-            this.cycleThroughLabel.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-            // 
-            // cycleThroughComboBox
-            // 
-            this.cycleThroughComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cycleThroughComboBox.FormattingEnabled = true;
-            this.cycleThroughComboBox.Location = new System.Drawing.Point(118, 222);
-            this.cycleThroughComboBox.Name = "cycleThroughComboBox";
-            this.cycleThroughComboBox.Size = new System.Drawing.Size(237, 23);
-            this.cycleThroughComboBox.TabIndex = 22;
-            this.cycleThroughComboBox.SelectedValueChanged += new System.EventHandler(this.cyclerComboBox_SelectedValueChanged);
-            // 
-            // tooltipOnHoverLabel
-            // 
-            this.tooltipOnHoverLabel.Location = new System.Drawing.Point(2, 188);
-            this.tooltipOnHoverLabel.Name = "tooltipOnHoverLabel";
-            this.tooltipOnHoverLabel.Size = new System.Drawing.Size(110, 18);
-            this.tooltipOnHoverLabel.TabIndex = 21;
-            this.tooltipOnHoverLabel.Text = "Tooltip on Hover";
-            this.tooltipOnHoverLabel.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-            // 
-            // tooltipInfoComboBox
-            // 
-            this.tooltipInfoComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.tooltipInfoComboBox.FormattingEnabled = true;
-            this.tooltipInfoComboBox.Location = new System.Drawing.Point(118, 186);
-            this.tooltipInfoComboBox.Name = "tooltipInfoComboBox";
-            this.tooltipInfoComboBox.Size = new System.Drawing.Size(237, 23);
-            this.tooltipInfoComboBox.TabIndex = 20;
-            this.tooltipInfoComboBox.SelectedValueChanged += new System.EventHandler(this.tooltipInfoComboBox_SelectedValueChanged);
-            // 
-            // selectSoundButton
-            // 
-            this.selectSoundButton.Location = new System.Drawing.Point(361, 127);
-            this.selectSoundButton.Name = "selectSoundButton";
-            this.selectSoundButton.Size = new System.Drawing.Size(24, 24);
-            this.selectSoundButton.TabIndex = 19;
-            this.selectSoundButton.Text = "...";
-            this.selectSoundButton.UseVisualStyleBackColor = true;
-            this.selectSoundButton.Visible = false;
-            this.selectSoundButton.Click += new System.EventHandler(this.selectSoundButton_Click);
-            // 
-            // notificationLabel
-            // 
-            this.notificationLabel.Location = new System.Drawing.Point(2, 131);
-            this.notificationLabel.Name = "notificationLabel";
-            this.notificationLabel.Size = new System.Drawing.Size(110, 18);
-            this.notificationLabel.TabIndex = 17;
-            this.notificationLabel.Text = "Notification";
-            this.notificationLabel.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-            // 
-            // notificationComboBox
-            // 
-            this.notificationComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.notificationComboBox.FormattingEnabled = true;
-            this.notificationComboBox.Location = new System.Drawing.Point(118, 129);
-            this.notificationComboBox.Name = "notificationComboBox";
-            this.notificationComboBox.Size = new System.Drawing.Size(237, 23);
-            this.notificationComboBox.TabIndex = 16;
-            this.notificationComboBox.SelectedValueChanged += new System.EventHandler(this.notificationComboBox_SelectedValueChanged);
-            // 
-            // basicSettingsGroupBox
-            // 
-            this.basicSettingsGroupBox.Controls.Add(this.iconChangeLabel);
-            this.basicSettingsGroupBox.Controls.Add(this.startWithWindowsCheckBox);
-            this.basicSettingsGroupBox.Controls.Add(this.iconChangeChoicesComboBox);
-            this.basicSettingsGroupBox.Location = new System.Drawing.Point(3, 12);
-            this.basicSettingsGroupBox.Name = "basicSettingsGroupBox";
-            this.basicSettingsGroupBox.Size = new System.Drawing.Size(425, 93);
-            this.basicSettingsGroupBox.TabIndex = 0;
-            this.basicSettingsGroupBox.TabStop = false;
-            this.basicSettingsGroupBox.Text = "Basic Settings";
-            // 
-            // iconChangeLabel
-            // 
-            this.iconChangeLabel.Location = new System.Drawing.Point(2, 53);
-            this.iconChangeLabel.Name = "iconChangeLabel";
-            this.iconChangeLabel.Size = new System.Drawing.Size(110, 15);
-            this.iconChangeLabel.TabIndex = 27;
-            this.iconChangeLabel.Text = "Systray Icon";
-            this.iconChangeLabel.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-            // 
-            // iconChangeChoicesComboBox
-            // 
-            this.iconChangeChoicesComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.iconChangeChoicesComboBox.FormattingEnabled = true;
-            this.iconChangeChoicesComboBox.Location = new System.Drawing.Point(118, 51);
-            this.iconChangeChoicesComboBox.Name = "iconChangeChoicesComboBox";
-            this.iconChangeChoicesComboBox.Size = new System.Drawing.Size(237, 23);
-            this.iconChangeChoicesComboBox.TabIndex = 26;
-            this.iconChangeChoicesComboBox.SelectedIndexChanged += new System.EventHandler(this.iconChangeChoicesComboBox_SelectedIndexChanged);
-            // 
-            // selectSoundFileDialog
-            // 
-            this.selectSoundFileDialog.FileName = "customSound";
-            // 
-            // hotkeysCheckBox
-            // 
-            this.hotkeysCheckBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.hotkeysCheckBox.AutoSize = true;
-            this.hotkeysCheckBox.Location = new System.Drawing.Point(163, 458);
-            this.hotkeysCheckBox.Name = "hotkeysCheckBox";
-            this.hotkeysCheckBox.Size = new System.Drawing.Size(100, 19);
-            this.hotkeysCheckBox.TabIndex = 20;
-            this.hotkeysCheckBox.Text = "Enable hotkey";
-            this.hotkeysCheckBox.UseVisualStyleBackColor = true;
-            this.hotkeysCheckBox.CheckedChanged += new System.EventHandler(this.hotkeysCheckbox_CheckedChanged);
-            // 
-            // hotKeyControl
-            // 
-            this.hotKeyControl.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.hotKeyControl.ListenToHotkey = false;
-            this.hotKeyControl.Location = new System.Drawing.Point(19, 455);
-            this.hotKeyControl.Name = "hotKeyControl";
-            this.hotKeyControl.Size = new System.Drawing.Size(138, 23);
-            this.hotKeyControl.TabIndex = 21;
-            this.hotKeyControl.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-            this.hotKeyControl.HotKeyChanged += new System.EventHandler<SoundSwitch.UI.Component.HotKeyTextBox.Event>(this.hotKeyControl_HotKeyChanged);
-            // 
-            // toggleMuteLabel
-            // 
-            this.toggleMuteLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.toggleMuteLabel.AutoSize = true;
-            this.toggleMuteLabel.Location = new System.Drawing.Point(362, 458);
-            this.toggleMuteLabel.Name = "toggleMuteLabel";
-            this.toggleMuteLabel.Size = new System.Drawing.Size(73, 15);
-            this.toggleMuteLabel.TabIndex = 22;
-            this.toggleMuteLabel.Text = "Toggle mute";
-            // 
-            // muteHotKey
-            // 
-            this.muteHotKey.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.muteHotKey.ListenToHotkey = false;
-            this.muteHotKey.Location = new System.Drawing.Point(441, 455);
-            this.muteHotKey.Name = "muteHotKey";
-            this.muteHotKey.Size = new System.Drawing.Size(138, 23);
-            this.muteHotKey.TabIndex = 24;
-            this.muteHotKey.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-            this.muteHotKey.HotKeyChanged += new System.EventHandler<SoundSwitch.UI.Component.HotKeyTextBox.Event>(this.hotKeyControl_HotKeyChanged);
-            // 
-            // muteHotKeyCheckbox
-            // 
-            this.muteHotKeyCheckbox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.muteHotKeyCheckbox.AutoSize = true;
-            this.muteHotKeyCheckbox.Location = new System.Drawing.Point(585, 458);
-            this.muteHotKeyCheckbox.Name = "muteHotKeyCheckbox";
-            this.muteHotKeyCheckbox.Size = new System.Drawing.Size(100, 19);
-            this.muteHotKeyCheckbox.TabIndex = 23;
-            this.muteHotKeyCheckbox.Text = "Enable hotkey";
-            this.muteHotKeyCheckbox.UseVisualStyleBackColor = true;
-            this.muteHotKeyCheckbox.CheckedChanged += new System.EventHandler(this.muteHotKeyCheckbox_CheckedChanged);
+            audioSettingsGroupBox.Controls.Add(autoAddDeviceCheckbox);
+            audioSettingsGroupBox.Controls.Add(quickMenuCheckbox);
+            audioSettingsGroupBox.Controls.Add(keepVolumeCheckbox);
+            audioSettingsGroupBox.Controls.Add(usePrimaryScreenCheckbox);
+            audioSettingsGroupBox.Controls.Add(foregroundAppCheckbox);
+            audioSettingsGroupBox.Controls.Add(deleteSoundButton);
+            audioSettingsGroupBox.Controls.Add(cycleThroughLabel);
+            audioSettingsGroupBox.Controls.Add(cycleThroughComboBox);
+            audioSettingsGroupBox.Controls.Add(tooltipOnHoverLabel);
+            audioSettingsGroupBox.Controls.Add(tooltipInfoComboBox);
+            audioSettingsGroupBox.Controls.Add(switchCommunicationDeviceCheckBox);
+            audioSettingsGroupBox.Controls.Add(selectSoundButton);
+            audioSettingsGroupBox.Controls.Add(notificationLabel);
+            audioSettingsGroupBox.Controls.Add(notificationComboBox);
+            audioSettingsGroupBox.Location = new System.Drawing.Point(3, 117);
+            audioSettingsGroupBox.Name = "audioSettingsGroupBox";
+            audioSettingsGroupBox.Size = new System.Drawing.Size(425, 291);
+            audioSettingsGroupBox.TabIndex = 13;
+            audioSettingsGroupBox.TabStop = false;
+            audioSettingsGroupBox.Text = "Audio Settings";
             // 
             // autoAddDeviceCheckbox
             // 
-            this.autoAddDeviceCheckbox.AutoSize = true;
-            this.autoAddDeviceCheckbox.Location = new System.Drawing.Point(6, 100);
-            this.autoAddDeviceCheckbox.Name = "autoAddDeviceCheckbox";
-            this.autoAddDeviceCheckbox.Size = new System.Drawing.Size(115, 19);
-            this.autoAddDeviceCheckbox.TabIndex = 28;
-            this.autoAddDeviceCheckbox.Text = "Auto Add Device";
-            this.autoAddDeviceCheckbox.UseVisualStyleBackColor = true;
+            autoAddDeviceCheckbox.AutoSize = true;
+            autoAddDeviceCheckbox.Location = new System.Drawing.Point(6, 129);
+            autoAddDeviceCheckbox.Name = "autoAddDeviceCheckbox";
+            autoAddDeviceCheckbox.Size = new System.Drawing.Size(115, 19);
+            autoAddDeviceCheckbox.TabIndex = 28;
+            autoAddDeviceCheckbox.Text = "Auto Add Device";
+            autoAddDeviceCheckbox.UseVisualStyleBackColor = true;
+            // 
+            // quickMenuCheckbox
+            // 
+            quickMenuCheckbox.AutoSize = true;
+            quickMenuCheckbox.Location = new System.Drawing.Point(6, 103);
+            quickMenuCheckbox.Name = "quickMenuCheckbox";
+            quickMenuCheckbox.Size = new System.Drawing.Size(144, 19);
+            quickMenuCheckbox.TabIndex = 27;
+            quickMenuCheckbox.Text = "QuickMenu on hotkey";
+            quickMenuCheckbox.UseVisualStyleBackColor = true;
+            // 
+            // keepVolumeCheckbox
+            // 
+            keepVolumeCheckbox.Location = new System.Drawing.Point(6, 73);
+            keepVolumeCheckbox.Name = "keepVolumeCheckbox";
+            keepVolumeCheckbox.Size = new System.Drawing.Size(277, 24);
+            keepVolumeCheckbox.TabIndex = 29;
+            keepVolumeCheckbox.Text = "Keep volume levels across playback devices";
+            keepVolumeCheckbox.CheckedChanged += keepVolumeCheckbox_CheckedChanged;
+            // 
+            // usePrimaryScreenCheckbox
+            // 
+            usePrimaryScreenCheckbox.AutoSize = true;
+            usePrimaryScreenCheckbox.Location = new System.Drawing.Point(118, 185);
+            usePrimaryScreenCheckbox.Name = "usePrimaryScreenCheckbox";
+            usePrimaryScreenCheckbox.Size = new System.Drawing.Size(165, 19);
+            usePrimaryScreenCheckbox.TabIndex = 26;
+            usePrimaryScreenCheckbox.Text = "Always use primary screen";
+            usePrimaryScreenCheckbox.UseVisualStyleBackColor = true;
+            usePrimaryScreenCheckbox.CheckedChanged += usePrimaryScreenCheckbox_CheckedChanged;
+            // 
+            // foregroundAppCheckbox
+            // 
+            foregroundAppCheckbox.AutoSize = true;
+            foregroundAppCheckbox.Location = new System.Drawing.Point(6, 48);
+            foregroundAppCheckbox.Name = "foregroundAppCheckbox";
+            foregroundAppCheckbox.Size = new System.Drawing.Size(149, 19);
+            foregroundAppCheckbox.TabIndex = 25;
+            foregroundAppCheckbox.Text = "Switch Foreground app";
+            foregroundAppCheckbox.UseVisualStyleBackColor = true;
+            foregroundAppCheckbox.CheckedChanged += ForegroundAppCheckbox_CheckedChanged;
+            // 
+            // deleteSoundButton
+            // 
+            deleteSoundButton.Image = Properties.Resources.delete;
+            deleteSoundButton.Location = new System.Drawing.Point(391, 156);
+            deleteSoundButton.Name = "deleteSoundButton";
+            deleteSoundButton.Size = new System.Drawing.Size(24, 24);
+            deleteSoundButton.TabIndex = 24;
+            deleteSoundButton.UseVisualStyleBackColor = true;
+            deleteSoundButton.Visible = false;
+            deleteSoundButton.Click += deleteSoundButton_Click;
+            // 
+            // cycleThroughLabel
+            // 
+            cycleThroughLabel.Location = new System.Drawing.Point(2, 253);
+            cycleThroughLabel.Name = "cycleThroughLabel";
+            cycleThroughLabel.Size = new System.Drawing.Size(110, 18);
+            cycleThroughLabel.TabIndex = 23;
+            cycleThroughLabel.Text = "Cycle through";
+            cycleThroughLabel.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // cycleThroughComboBox
+            // 
+            cycleThroughComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            cycleThroughComboBox.FormattingEnabled = true;
+            cycleThroughComboBox.Location = new System.Drawing.Point(118, 251);
+            cycleThroughComboBox.Name = "cycleThroughComboBox";
+            cycleThroughComboBox.Size = new System.Drawing.Size(237, 23);
+            cycleThroughComboBox.TabIndex = 22;
+            cycleThroughComboBox.SelectedValueChanged += cyclerComboBox_SelectedValueChanged;
+            // 
+            // tooltipOnHoverLabel
+            // 
+            tooltipOnHoverLabel.Location = new System.Drawing.Point(2, 217);
+            tooltipOnHoverLabel.Name = "tooltipOnHoverLabel";
+            tooltipOnHoverLabel.Size = new System.Drawing.Size(110, 18);
+            tooltipOnHoverLabel.TabIndex = 21;
+            tooltipOnHoverLabel.Text = "Tooltip on Hover";
+            tooltipOnHoverLabel.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // tooltipInfoComboBox
+            // 
+            tooltipInfoComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            tooltipInfoComboBox.FormattingEnabled = true;
+            tooltipInfoComboBox.Location = new System.Drawing.Point(118, 215);
+            tooltipInfoComboBox.Name = "tooltipInfoComboBox";
+            tooltipInfoComboBox.Size = new System.Drawing.Size(237, 23);
+            tooltipInfoComboBox.TabIndex = 20;
+            tooltipInfoComboBox.SelectedValueChanged += tooltipInfoComboBox_SelectedValueChanged;
+            // 
+            // selectSoundButton
+            // 
+            selectSoundButton.Location = new System.Drawing.Point(361, 156);
+            selectSoundButton.Name = "selectSoundButton";
+            selectSoundButton.Size = new System.Drawing.Size(24, 24);
+            selectSoundButton.TabIndex = 19;
+            selectSoundButton.Text = "...";
+            selectSoundButton.UseVisualStyleBackColor = true;
+            selectSoundButton.Visible = false;
+            selectSoundButton.Click += selectSoundButton_Click;
+            // 
+            // notificationLabel
+            // 
+            notificationLabel.Location = new System.Drawing.Point(2, 160);
+            notificationLabel.Name = "notificationLabel";
+            notificationLabel.Size = new System.Drawing.Size(110, 18);
+            notificationLabel.TabIndex = 17;
+            notificationLabel.Text = "Notification";
+            notificationLabel.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // notificationComboBox
+            // 
+            notificationComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            notificationComboBox.FormattingEnabled = true;
+            notificationComboBox.Location = new System.Drawing.Point(118, 158);
+            notificationComboBox.Name = "notificationComboBox";
+            notificationComboBox.Size = new System.Drawing.Size(237, 23);
+            notificationComboBox.TabIndex = 16;
+            notificationComboBox.SelectedValueChanged += notificationComboBox_SelectedValueChanged;
+            // 
+            // basicSettingsGroupBox
+            // 
+            basicSettingsGroupBox.Controls.Add(iconChangeLabel);
+            basicSettingsGroupBox.Controls.Add(startWithWindowsCheckBox);
+            basicSettingsGroupBox.Controls.Add(iconChangeChoicesComboBox);
+            basicSettingsGroupBox.Location = new System.Drawing.Point(3, 12);
+            basicSettingsGroupBox.Name = "basicSettingsGroupBox";
+            basicSettingsGroupBox.Size = new System.Drawing.Size(425, 93);
+            basicSettingsGroupBox.TabIndex = 0;
+            basicSettingsGroupBox.TabStop = false;
+            basicSettingsGroupBox.Text = "Basic Settings";
+            // 
+            // iconChangeLabel
+            // 
+            iconChangeLabel.Location = new System.Drawing.Point(2, 53);
+            iconChangeLabel.Name = "iconChangeLabel";
+            iconChangeLabel.Size = new System.Drawing.Size(110, 15);
+            iconChangeLabel.TabIndex = 27;
+            iconChangeLabel.Text = "Systray Icon";
+            iconChangeLabel.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // iconChangeChoicesComboBox
+            // 
+            iconChangeChoicesComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            iconChangeChoicesComboBox.FormattingEnabled = true;
+            iconChangeChoicesComboBox.Location = new System.Drawing.Point(118, 51);
+            iconChangeChoicesComboBox.Name = "iconChangeChoicesComboBox";
+            iconChangeChoicesComboBox.Size = new System.Drawing.Size(237, 23);
+            iconChangeChoicesComboBox.TabIndex = 26;
+            iconChangeChoicesComboBox.SelectedIndexChanged += iconChangeChoicesComboBox_SelectedIndexChanged;
+            // 
+            // selectSoundFileDialog
+            // 
+            selectSoundFileDialog.FileName = "customSound";
+            // 
+            // hotkeysCheckBox
+            // 
+            hotkeysCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left;
+            hotkeysCheckBox.AutoSize = true;
+            hotkeysCheckBox.Location = new System.Drawing.Point(163, 458);
+            hotkeysCheckBox.Name = "hotkeysCheckBox";
+            hotkeysCheckBox.Size = new System.Drawing.Size(100, 19);
+            hotkeysCheckBox.TabIndex = 20;
+            hotkeysCheckBox.Text = "Enable hotkey";
+            hotkeysCheckBox.UseVisualStyleBackColor = true;
+            hotkeysCheckBox.CheckedChanged += hotkeysCheckbox_CheckedChanged;
+            // 
+            // hotKeyControl
+            // 
+            hotKeyControl.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left;
+            hotKeyControl.ListenToHotkey = false;
+            hotKeyControl.Location = new System.Drawing.Point(19, 455);
+            hotKeyControl.Name = "hotKeyControl";
+            hotKeyControl.Size = new System.Drawing.Size(138, 23);
+            hotKeyControl.TabIndex = 21;
+            hotKeyControl.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            hotKeyControl.HotKeyChanged += hotKeyControl_HotKeyChanged;
+            // 
+            // toggleMuteLabel
+            // 
+            toggleMuteLabel.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left;
+            toggleMuteLabel.AutoSize = true;
+            toggleMuteLabel.Location = new System.Drawing.Point(362, 458);
+            toggleMuteLabel.Name = "toggleMuteLabel";
+            toggleMuteLabel.Size = new System.Drawing.Size(73, 15);
+            toggleMuteLabel.TabIndex = 22;
+            toggleMuteLabel.Text = "Toggle mute";
+            // 
+            // muteHotKey
+            // 
+            muteHotKey.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left;
+            muteHotKey.ListenToHotkey = false;
+            muteHotKey.Location = new System.Drawing.Point(441, 455);
+            muteHotKey.Name = "muteHotKey";
+            muteHotKey.Size = new System.Drawing.Size(138, 23);
+            muteHotKey.TabIndex = 24;
+            muteHotKey.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            muteHotKey.HotKeyChanged += hotKeyControl_HotKeyChanged;
+            // 
+            // muteHotKeyCheckbox
+            // 
+            muteHotKeyCheckbox.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left;
+            muteHotKeyCheckbox.AutoSize = true;
+            muteHotKeyCheckbox.Location = new System.Drawing.Point(585, 458);
+            muteHotKeyCheckbox.Name = "muteHotKeyCheckbox";
+            muteHotKeyCheckbox.Size = new System.Drawing.Size(100, 19);
+            muteHotKeyCheckbox.TabIndex = 23;
+            muteHotKeyCheckbox.Text = "Enable hotkey";
+            muteHotKeyCheckbox.UseVisualStyleBackColor = true;
+            muteHotKeyCheckbox.CheckedChanged += muteHotKeyCheckbox_CheckedChanged;
             // 
             // SettingsForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.CancelButton = this.closeButton;
-            this.ClientSize = new System.Drawing.Size(918, 490);
-            this.Controls.Add(this.muteHotKey);
-            this.Controls.Add(this.muteHotKeyCheckbox);
-            this.Controls.Add(this.toggleMuteLabel);
-            this.Controls.Add(this.hotKeyControl);
-            this.Controls.Add(this.hotkeysCheckBox);
-            this.Controls.Add(this.tabControl);
-            this.Controls.Add(this.closeButton);
-            this.MinimumSize = new System.Drawing.Size(787, 443);
-            this.Name = "SettingsForm";
-            this.Text = "Settings";
-            this.tabControl.ResumeLayout(false);
-            this.playbackTabPage.ResumeLayout(false);
-            this.recordingTabPage.ResumeLayout(false);
-            this.tabProfile.ResumeLayout(false);
-            this.appSettingTabPage.ResumeLayout(false);
-            this.languageGroupBox.ResumeLayout(false);
-            this.updateSettingsGroupBox.ResumeLayout(false);
-            this.updateSettingsGroupBox.PerformLayout();
-            this.audioSettingsGroupBox.ResumeLayout(false);
-            this.audioSettingsGroupBox.PerformLayout();
-            this.basicSettingsGroupBox.ResumeLayout(false);
-            this.basicSettingsGroupBox.PerformLayout();
-            this.ResumeLayout(false);
-            this.PerformLayout();
-
+            AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+            CancelButton = closeButton;
+            ClientSize = new System.Drawing.Size(918, 490);
+            Controls.Add(muteHotKey);
+            Controls.Add(muteHotKeyCheckbox);
+            Controls.Add(toggleMuteLabel);
+            Controls.Add(hotKeyControl);
+            Controls.Add(hotkeysCheckBox);
+            Controls.Add(tabControl);
+            Controls.Add(closeButton);
+            MinimumSize = new System.Drawing.Size(787, 443);
+            Name = "SettingsForm";
+            Text = "Settings";
+            tabControl.ResumeLayout(false);
+            playbackTabPage.ResumeLayout(false);
+            recordingTabPage.ResumeLayout(false);
+            tabProfile.ResumeLayout(false);
+            appSettingTabPage.ResumeLayout(false);
+            languageGroupBox.ResumeLayout(false);
+            updateSettingsGroupBox.ResumeLayout(false);
+            updateSettingsGroupBox.PerformLayout();
+            audioSettingsGroupBox.ResumeLayout(false);
+            audioSettingsGroupBox.PerformLayout();
+            basicSettingsGroupBox.ResumeLayout(false);
+            basicSettingsGroupBox.PerformLayout();
+            ResumeLayout(false);
+            PerformLayout();
         }
 
         private System.Windows.Forms.Button addProfileButton;
@@ -699,6 +703,7 @@ namespace SoundSwitch.UI.Forms
         private System.Windows.Forms.CheckBox muteHotKeyCheckbox;
         private System.Windows.Forms.CheckBox telemetryCheckbox;
         private System.Windows.Forms.CheckBox quickMenuCheckbox;
+        private System.Windows.Forms.CheckBox keepVolumeCheckbox;
         private System.Windows.Forms.CheckBox autoAddDeviceCheckbox;
     }
 }

--- a/SoundSwitch/UI/Forms/Settings.cs
+++ b/SoundSwitch/UI/Forms/Settings.cs
@@ -186,6 +186,10 @@ namespace SoundSwitch.UI.Forms
             var quickMenuCheckboxToolTip = new ToolTip();
             quickMenuCheckboxToolTip.SetToolTip(quickMenuCheckbox, SettingsStrings.quickMenu_desc);
 
+            keepVolumeCheckbox.DataBindings.Add(nameof(CheckBox.Checked), AppModel.Instance, nameof(AppModel.KeepVolumeEnabled), false, DataSourceUpdateMode.OnPropertyChanged);
+            var keepVolumeCheckboxToolTip = new ToolTip();
+            keepVolumeCheckboxToolTip.SetToolTip(keepVolumeCheckbox, SettingsStrings.keepVolume_desc);
+
             autoAddDeviceCheckbox.DataBindings.Add(nameof(CheckBox.Checked), AppModel.Instance, nameof(AppModel.AutoAddNewDevice), false, DataSourceUpdateMode.OnPropertyChanged);
             var autoAddDeviceCheckboxToolTip = new ToolTip();
             autoAddDeviceCheckboxToolTip.SetToolTip(autoAddDeviceCheckbox, SettingsStrings.devices_AutoAddNewDevice_Tooltip);
@@ -336,6 +340,7 @@ namespace SoundSwitch.UI.Forms
             foregroundAppCheckbox.Text = SettingsStrings.foregroundApp;
             usePrimaryScreenCheckbox.Text = SettingsStrings.usePrimaryScreen;
             quickMenuCheckbox.Text = SettingsStrings.quickMenu;
+            keepVolumeCheckbox.Text = SettingsStrings.keepVolume;
             autoAddDeviceCheckbox.Text = SettingsStrings.devices_AutoAddNewDevice;
 
             // Settings - Update
@@ -733,6 +738,11 @@ namespace SoundSwitch.UI.Forms
         private void ForegroundAppCheckbox_CheckedChanged(object sender, EventArgs e)
         {
             AppModel.Instance.SwitchForegroundProgram = foregroundAppCheckbox.Checked;
+        }
+
+        private void keepVolumeCheckbox_CheckedChanged(object sender, EventArgs e)
+        {
+            AppModel.Instance.KeepVolumeEnabled = keepVolumeCheckbox.Checked;
         }
 
         private void usePrimaryScreenCheckbox_CheckedChanged(object sender, EventArgs e)


### PR DESCRIPTION
Created a function called SetVolumeFromDefaultDevice in the AudioSwitcher lib.

Created a new checkbox "Keep volume across playback devices" in Settings along with numerous KeepVolume values throughout the code for this checkbox.

This allows the user to keep the same volume level when switching devices. As a design choice, it can only switch between playback devices. This can be changed in the boolean inside the SetActiveDevice function of the ADeviceCycler lib.

n.b. SetVolumeFromDefaultDevice can be used for both Playback and Recording devices.

