### PR TITLE
Update UpdateDownloadStrings.nl.resx

### DIFF
--- a/SoundSwitch/Localization/UpdateDownloadStrings.nl.resx
+++ b/SoundSwitch/Localization/UpdateDownloadStrings.nl.resx
@@ -71,7 +71,7 @@
     <value>Annuleer</value>
   </data>
   <data name="install" xml:space="preserve">
-    <value>Installatie</value>
+    <value>Installeer</value>
   </data>
   <data name="downloadFailed" xml:space="preserve">
     <value>Download mislukt</value>


### PR DESCRIPTION
The original word is not a verb and like "the installation". 
Therefor did not clearly refer to the button action: "install".