### PR TITLE
fix: NotifyIcon.MouseDoubleClick()

### DIFF
--- a/SoundSwitch/UI/Component/TrayIcon.cs
+++ b/SoundSwitch/UI/Component/TrayIcon.cs
@@ -122,22 +122,6 @@ namespace SoundSwitch.UI.Component
                 }
             };
 
-            NotifyIcon.MouseDoubleClick += (sender, e) =>
-            {
-                if (e.Button != MouseButtons.Left) return;
-                switch (AppModel.Instance.IconDoubleClick)
-                {
-                    case IconDoubleClickEnum.SwitchDevice:
-                        AppModel.Instance.CycleActiveDevice(DataFlow.Render);
-                        break;
-                    case IconDoubleClickEnum.OpenSettings:
-                        ShowSettings();
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException();
-                }
-            };
-
             NotifyIcon.MouseClick += (sender, e) =>
             {
                 if (e.Button != MouseButtons.Left) return;


### PR DESCRIPTION
NotifyIcon.MouseDoubleClick() accidentally duplicated and duplicate is removed.