### PR TITLE
Fixes Belphemur/SoundSwitch#491

### DIFF
--- a/SoundSwitch/Framework/TrayIcon/IconDoubleClick/DoubleClick/IconDoubleClickSwitchProfile.cs
+++ b/SoundSwitch/Framework/TrayIcon/IconDoubleClick/DoubleClick/IconDoubleClickSwitchProfile.cs
@@ -1,0 +1,9 @@
+﻿using SoundSwitch.Localization;
+
+namespace SoundSwitch.Framework.TrayIcon.IconDoubleClick.DoubleClick;
+
+internal class IconDoubleClickSwitchProfile: IIconDoubleClick
+{
+    public IconDoubleClickEnum TypeEnum => IconDoubleClickEnum.SwitchProfile;
+    public string Label => SettingsStrings.switchProfile;
+}

--- a/SoundSwitch/Framework/TrayIcon/IconDoubleClick/IconDoubleClickEnum.cs
+++ b/SoundSwitch/Framework/TrayIcon/IconDoubleClick/IconDoubleClickEnum.cs
@@ -17,6 +17,7 @@ namespace SoundSwitch.Framework.TrayIcon.IconDoubleClick
     public enum IconDoubleClickEnum
     {
         SwitchDevice = 0,
-        OpenSettings = 1
+        OpenSettings = 1,
+        SwitchProfile = 2,
     }
 }

--- a/SoundSwitch/Framework/TrayIcon/IconDoubleClick/IconDoubleClickFactory.cs
+++ b/SoundSwitch/Framework/TrayIcon/IconDoubleClick/IconDoubleClickFactory.cs
@@ -23,7 +23,8 @@ namespace SoundSwitch.Framework.TrayIcon.IconDoubleClick
             <IconDoubleClickEnum, IIconDoubleClick>
             {
                 new IconDoubleClickSwitchDevice(),
-                new IconDoubleClickOpenSettings()
+                new IconDoubleClickOpenSettings(),
+                new IconDoubleClickSwitchProfile()
             };
     }
 }

--- a/SoundSwitch/Localization/SettingsStrings.Designer.cs
+++ b/SoundSwitch/Localization/SettingsStrings.Designer.cs
@@ -1432,6 +1432,15 @@ namespace SoundSwitch.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Switch profile.
+        /// </summary>
+        internal static string switchProfile {
+            get {
+                return ResourceManager.GetString("switchProfile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Telemetry.
         /// </summary>
         internal static string telemetry {

--- a/SoundSwitch/Localization/SettingsStrings.de.resx
+++ b/SoundSwitch/Localization/SettingsStrings.de.resx
@@ -572,6 +572,9 @@ Stellt den Zustand des Systems wieder her, wenn die Anwendung geschlossen wird.<
   <data name="switchDevice" xml:space="preserve">
     <value>Gerät wechseln</value>
   </data>
+  <data name="switchProfile" xml:space="preserve">
+    <value>Profil wechseln</value>
+  </data>
   <data name="notification.banner.onscreen.time.tooltip" xml:space="preserve">
     <value>Wie lange das Banner auf dem Bildschirm angezeigt wird (in Sekunden).</value>
   </data>

--- a/SoundSwitch/Localization/SettingsStrings.resx
+++ b/SoundSwitch/Localization/SettingsStrings.resx
@@ -584,6 +584,9 @@ Restore the state of the system when the application is closed.</value>
   <data name="switchDevice" xml:space="preserve">
     <value>Switch device</value>
   </data>
+  <data name="switchProfile" xml:space="preserve">
+    <value>Switch profile</value>
+  </data>
   <data name="notification.banner.onscreen.time.tooltip" xml:space="preserve">
     <value>How long the banner stays on the screen in seconds.</value>
   </data>


### PR DESCRIPTION
This feature implements the following wish: https://github.com/Belphemur/SoundSwitch/issues/491

I've added a new double click action "switch profile". It cycles the "active" profile with every double click.
When the app starts and the action is triggered the first time it selects the first profile (with trigger "In the app menu") in the list.
With the next trigger, the next one is selected and restarts at the first profile when the last is reached.

Possible improvements:
* detecting the active profile by matching the current devies with the currently active devices (will never work in every case, because there can be combinations where there is no profile)
* storing the last active profile in persisted config (could also be false, because every manual device switch would indirectly change the profile)
* detecting device changes and guessing the profile

All the above improvements will never be 100% perfect and I think the most important part is to be abled to cycle through the profiles by double clicking, so I will not implement them and would nnever suggest to implement them.


Last Word:
I just found this app and missed exactly that feature, thats why I quickly implemented it ;-)