### PR TITLE
feat: ARM64 support with framework-dependent publish and winget runtime

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,10 +20,9 @@ on:
   schedule:
     - cron: '40 2 * * 4'
 env:
-  DOTNET: "7.0.x"
+  DOTNET: "10.0.x"
   DOTNET_PRERELEASE: true
   PROJECT_NAME: "SoundSwitch"
-  ARCH: "win-x64"
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,16 +21,12 @@ jobs:
         concurrency:
             group: ${{ github.workflow }}-${{ github.ref }}-build
             cancel-in-progress: true
-        strategy:
-            matrix:
-                runtime: [win-x64, win-arm64]
         uses: ./.github/workflows/reusable-build.yml
         with:
             configuration: Nightly
-            runtime: ${{ matrix.runtime }}
             publish: true
             update-nightly-version: true
-            publish-artifact-name: soundswitch-nightly-${{ matrix.runtime }}
+            publish-artifact-name: soundswitch-nightly
         secrets: inherit
 
     publish-nightly:
@@ -43,16 +39,11 @@ jobs:
             - uses: actions/checkout@v6
               with:
                   fetch-depth: 0
-            - name: Download published win-x64 output
+            - name: Download published output
               uses: actions/download-artifact@v8
               with:
-                  name: soundswitch-nightly-win-x64
-                  path: nightly-package/win-x64
-            - name: Download published win-arm64 output
-              uses: actions/download-artifact@v8
-              with:
-                  name: soundswitch-nightly-win-arm64
-                  path: nightly-package/win-arm64
+                  name: soundswitch-nightly
+                  path: nightly-package
             - name: Setup Python
               uses: actions/setup-python@v6
               with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,7 +13,6 @@ on:
 env:
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     PROJECT_NAME: SoundSwitch
-    ARCH: win-x64
     CONFIGURATION: Nightly
     SENTRY_NAME: soundswitch
 
@@ -22,13 +21,16 @@ jobs:
         concurrency:
             group: ${{ github.workflow }}-${{ github.ref }}-build
             cancel-in-progress: true
+        strategy:
+            matrix:
+                runtime: [win-x64, win-arm64]
         uses: ./.github/workflows/reusable-build.yml
         with:
             configuration: Nightly
-            runtime: win-x64
+            runtime: ${{ matrix.runtime }}
             publish: true
             update-nightly-version: true
-            publish-artifact-name: nightly-package
+            publish-artifact-name: soundswitch-nightly-${{ matrix.runtime }}
         secrets: inherit
 
     publish-nightly:
@@ -41,11 +43,16 @@ jobs:
             - uses: actions/checkout@v6
               with:
                   fetch-depth: 0
-            - name: Download published output
+            - name: Download published win-x64 output
               uses: actions/download-artifact@v8
               with:
-                  name: nightly-package
-                  path: nightly-package
+                  name: soundswitch-nightly-win-x64
+                  path: nightly-package/win-x64
+            - name: Download published win-arm64 output
+              uses: actions/download-artifact@v8
+              with:
+                  name: soundswitch-nightly-win-arm64
+                  path: nightly-package/win-arm64
             - name: Setup Python
               uses: actions/setup-python@v6
               with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,15 +57,11 @@ jobs:
         if: needs.release.outputs.released == 'true'
         permissions:
             contents: read
-        strategy:
-            matrix:
-                runtime: [win-x64, win-arm64]
         uses: ./.github/workflows/reusable-build.yml
         with:
             configuration: Release
-            runtime: ${{ matrix.runtime }}
             publish: true
-            publish-artifact-name: soundswitch-${{ matrix.runtime }}
+            publish-artifact-name: soundswitch-release
             ref: v${{ needs.release.outputs.version }}
             version: ${{ needs.release.outputs.version }}
         secrets: inherit
@@ -80,22 +76,17 @@ jobs:
         permissions:
             contents: write
         steps:
-            - name: Download win-x64 artifact
+            - name: Download artifact
               uses: actions/download-artifact@v8
               with:
-                  name: soundswitch-win-x64
-                  path: release-package/win-x64
-            - name: Download win-arm64 artifact
-              uses: actions/download-artifact@v8
-              with:
-                  name: soundswitch-win-arm64
-                  path: release-package/win-arm64
+                  name: soundswitch-release
+                  path: release-package
             - name: Create release zip
               run: |
                   version="${{ needs.release.outputs.version }}"
                   archive="${{ env.PROJECT_NAME }}-v${version}.zip"
                   cd release-package
-                  zip -r "../${archive}" win-x64 win-arm64
+                  zip -r "../${archive}" .
                   cd ..
                   echo "archive=${archive}" >> "$GITHUB_ENV"
             - name: Upload release zip to GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,12 +57,15 @@ jobs:
         if: needs.release.outputs.released == 'true'
         permissions:
             contents: read
+        strategy:
+            matrix:
+                runtime: [win-x64, win-arm64]
         uses: ./.github/workflows/reusable-build.yml
         with:
             configuration: Release
-            runtime: win-x64
+            runtime: ${{ matrix.runtime }}
             publish: true
-            publish-artifact-name: release-package
+            publish-artifact-name: soundswitch-${{ matrix.runtime }}
             ref: v${{ needs.release.outputs.version }}
             version: ${{ needs.release.outputs.version }}
         secrets: inherit
@@ -77,17 +80,22 @@ jobs:
         permissions:
             contents: write
         steps:
-            - name: Download build output
+            - name: Download win-x64 artifact
               uses: actions/download-artifact@v8
               with:
-                  name: release-package
-                  path: release-package
+                  name: soundswitch-win-x64
+                  path: release-package/win-x64
+            - name: Download win-arm64 artifact
+              uses: actions/download-artifact@v8
+              with:
+                  name: soundswitch-win-arm64
+                  path: release-package/win-arm64
             - name: Create release zip
               run: |
                   version="${{ needs.release.outputs.version }}"
                   archive="${{ env.PROJECT_NAME }}-v${version}.zip"
                   cd release-package
-                  zip -r "../${archive}" .
+                  zip -r "../${archive}" win-x64 win-arm64
                   cd ..
                   echo "archive=${archive}" >> "$GITHUB_ENV"
             - name: Upload release zip to GitHub Release

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -138,7 +138,11 @@ jobs:
                   DOTNET_RUNTIME: ${{ inputs.runtime }}
                   PUBLISH_VERSION: ${{ inputs.version }}
               run: |
-                  $outputDir = Join-Path $PWD 'Final'
+                  if ($env:DOTNET_RUNTIME) {
+                    $outputDir = Join-Path $PWD (Join-Path 'publish' $env:DOTNET_RUNTIME)
+                  } else {
+                    $outputDir = Join-Path $PWD 'Final'
+                  }
                   if (Test-Path $outputDir) { Remove-Item $outputDir -Recurse -Force }
                   New-Item -ItemType Directory -Path $outputDir | Out-Null
 
@@ -182,7 +186,11 @@ jobs:
                   python -m pip install markdown --quiet
                   if ($LASTEXITCODE -ne 0) { throw "Failed to install Python 'markdown' package (exit code $LASTEXITCODE)." }
 
-                  $outputDir = Join-Path $PWD 'Final'
+                  if ($env:DOTNET_RUNTIME) {
+                    $outputDir = Join-Path $PWD (Join-Path 'publish' $env:DOTNET_RUNTIME)
+                  } else {
+                    $outputDir = Join-Path $PWD 'Final'
+                  }
 
                   # Convert markdown files to HTML
                   python tools\markdown_to_html.py CHANGELOG.md -o "$outputDir\Changelog.html"
@@ -200,7 +208,11 @@ jobs:
               if: inputs.publish
               shell: pwsh
               run: |
-                  $outputDir = Join-Path $PWD 'Final'
+                  if ($env:DOTNET_RUNTIME) {
+                    $outputDir = Join-Path $PWD (Join-Path 'publish' $env:DOTNET_RUNTIME)
+                  } else {
+                    $outputDir = Join-Path $PWD 'Final'
+                  }
 
                   # Copy additional assets
                   Copy-Item 'img\soundSwitched.png' $outputDir -Force -ErrorAction SilentlyContinue
@@ -218,4 +230,4 @@ jobs:
               uses: actions/upload-artifact@v7
               with:
                   name: ${{ inputs.publish-artifact-name }}
-                  path: Final\*
+                  path: ${{ inputs.runtime && format('publish/{0}/*', inputs.runtime) || 'Final\*' }}

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -6,10 +6,6 @@ on:
             configuration:
                 required: true
                 type: string
-            runtime:
-                required: false
-                type: string
-                default: ""
             publish:
                 required: false
                 type: boolean
@@ -101,15 +97,7 @@ jobs:
                   cache-dependency-path: Directory.Packages.props
             - name: Restore
               shell: pwsh
-              env:
-                  DOTNET_RUNTIME: ${{ inputs.runtime }}
-              run: |
-                  $arguments = @('restore')
-                  if ($env:DOTNET_RUNTIME) {
-                    $arguments += @('-r', $env:DOTNET_RUNTIME)
-                  }
-
-                  dotnet @arguments
+              run: dotnet restore
             - name: Fetch tags
               if: inputs.update-nightly-version
               shell: pwsh
@@ -135,14 +123,9 @@ jobs:
               if: inputs.publish
               shell: pwsh
               env:
-                  DOTNET_RUNTIME: ${{ inputs.runtime }}
                   PUBLISH_VERSION: ${{ inputs.version }}
               run: |
-                  if ($env:DOTNET_RUNTIME) {
-                    $outputDir = Join-Path $PWD (Join-Path 'publish' $env:DOTNET_RUNTIME)
-                  } else {
-                    $outputDir = Join-Path $PWD 'Final'
-                  }
+                  $outputDir = Join-Path $PWD 'Final'
                   if (Test-Path $outputDir) { Remove-Item $outputDir -Recurse -Force }
                   New-Item -ItemType Directory -Path $outputDir | Out-Null
 
@@ -155,9 +138,6 @@ jobs:
                       "$proj\$proj.csproj",
                       '-o', $outputDir
                     )
-                    if ($env:DOTNET_RUNTIME) {
-                      $arguments += @('-r', $env:DOTNET_RUNTIME)
-                    }
                     if ($env:PUBLISH_VERSION) {
                       $numericVersion = $env:PUBLISH_VERSION -replace '-.*$', ''
                       $arguments += @(
@@ -186,11 +166,7 @@ jobs:
                   python -m pip install markdown --quiet
                   if ($LASTEXITCODE -ne 0) { throw "Failed to install Python 'markdown' package (exit code $LASTEXITCODE)." }
 
-                  if ($env:DOTNET_RUNTIME) {
-                    $outputDir = Join-Path $PWD (Join-Path 'publish' $env:DOTNET_RUNTIME)
-                  } else {
-                    $outputDir = Join-Path $PWD 'Final'
-                  }
+                  $outputDir = Join-Path $PWD 'Final'
 
                   # Convert markdown files to HTML
                   python tools\markdown_to_html.py CHANGELOG.md -o "$outputDir\Changelog.html"
@@ -208,11 +184,7 @@ jobs:
               if: inputs.publish
               shell: pwsh
               run: |
-                  if ($env:DOTNET_RUNTIME) {
-                    $outputDir = Join-Path $PWD (Join-Path 'publish' $env:DOTNET_RUNTIME)
-                  } else {
-                    $outputDir = Join-Path $PWD 'Final'
-                  }
+                  $outputDir = Join-Path $PWD 'Final'
 
                   # Copy additional assets
                   Copy-Item 'img\soundSwitched.png' $outputDir -Force -ErrorAction SilentlyContinue
@@ -230,4 +202,4 @@ jobs:
               uses: actions/upload-artifact@v7
               with:
                   name: ${{ inputs.publish-artifact-name }}
-                  path: ${{ inputs.runtime && format('publish/{0}/*', inputs.runtime) || 'Final\*' }}
+                  path: Final\*

--- a/.github/workflows/test-installer-build.yml
+++ b/.github/workflows/test-installer-build.yml
@@ -66,6 +66,8 @@ jobs:
           }
           $dotnetVersion = "{0}.{1}.x" -f $match.Groups['major'].Value, $match.Groups['minor'].Value
           Write-Host "Detected .NET SDK version: $dotnetVersion (from $framework)"
+          $major = $match.Groups['major'].Value
+          "major=$major" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
           "dotnet-version=$dotnetVersion" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
       - name: Setup .NET
@@ -134,7 +136,7 @@ jobs:
         shell: cmd
 
       - name: Build Installer
-        run: .\\Installer\\Make-Installer.bat Nightly
+        run: .\\Installer\\Make-Installer.bat Nightly ${{ steps.framework.outputs.major }}
         shell: cmd
 
       - name: Run Installer in Silent Mode (Machine Scope)

--- a/.github/workflows/test-installer-build.yml
+++ b/.github/workflows/test-installer-build.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build-installer-no-sign:
-    runs-on: windows-2025
+    runs-on: windows-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/test-installer-build.yml
+++ b/.github/workflows/test-installer-build.yml
@@ -75,23 +75,43 @@ jobs:
           cache: true
           cache-dependency-path: Directory.Packages.props
 
-      - name: Build SoundSwitch Application
+      - name: Build SoundSwitch Application (win-x64)
+        shell: cmd
         run: |
           echo "Cleaning build directories"
           if exist bin rmdir /q /s bin
           if exist obj rmdir /q /s obj
           if exist Release rmdir /q /s Release
-          if exist Final rmdir /q /s Final
-          mkdir Final
-          
-          echo "Building SoundSwitch CLI"
-          dotnet publish -c Release SoundSwitch.CLI\SoundSwitch.CLI.csproj -o Final
+          if exist publish rmdir /q /s publish
+          mkdir publish\win-x64
+
+          echo "Building SoundSwitch CLI (win-x64)"
+          dotnet publish -c Release -r win-x64 SoundSwitch.CLI\SoundSwitch.CLI.csproj -o publish\win-x64
           if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
 
-          echo "Building SoundSwitch Main Application"
-          dotnet publish -c Release SoundSwitch\SoundSwitch.csproj -o Final
+          echo "Building SoundSwitch Main Application (win-x64)"
+          dotnet publish -c Release -r win-x64 SoundSwitch\SoundSwitch.csproj -o publish\win-x64
           if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
+
+      - name: Build SoundSwitch Application (win-arm64)
         shell: cmd
+        run: |
+          mkdir publish\win-arm64
+
+          echo "Building SoundSwitch CLI (win-arm64)"
+          dotnet publish -c Release -r win-arm64 SoundSwitch.CLI\SoundSwitch.CLI.csproj -o publish\win-arm64
+          if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
+
+          echo "Building SoundSwitch Main Application (win-arm64)"
+          dotnet publish -c Release -r win-arm64 SoundSwitch\SoundSwitch.csproj -o publish\win-arm64
+          if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
+
+      - name: Combine architectures into Final
+        shell: cmd
+        run: |
+          mkdir Final
+          xcopy /e /y publish\win-x64\* Final\win-x64\
+          xcopy /e /y publish\win-arm64\* Final\win-arm64\
 
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -106,31 +126,39 @@ jobs:
           if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
 
           echo "Generate Changelog"
-          python tools\markdown_to_html.py CHANGELOG.md -o Final\Changelog.html
+          python tools\markdown_to_html.py CHANGELOG.md -o Final\win-x64\Changelog.html
           if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
+          xcopy /y Final\win-x64\Changelog.html Final\win-arm64\
 
           echo "Generate Terms"
-          python tools\markdown_to_html.py Terms.md -o Final\Terms.html
+          python tools\markdown_to_html.py Terms.md -o Final\win-x64\Terms.html
           if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
+          xcopy /y Final\win-x64\Terms.html Final\win-arm64\
 
           echo "Generate README"
-          python tools\markdown_to_html.py README.md -o Final\Readme.html
+          python tools\markdown_to_html.py README.md -o Final\win-x64\Readme.html
           if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
+          xcopy /y Final\win-x64\Readme.html Final\win-arm64\
 
           if exist README.de.md (
-            python tools\markdown_to_html.py README.de.md -o Final\Readme.de.html
+            python tools\markdown_to_html.py README.de.md -o Final\win-x64\Readme.de.html
             if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
+            xcopy /y Final\win-x64\Readme.de.html Final\win-arm64\
           )
 
           echo "Copy soundSwitched image"
-          xcopy /y img\soundSwitched.png Final >nul 2>nul
+          xcopy /y img\soundSwitched.png Final\win-x64\ >nul 2>nul
+          xcopy /y img\soundSwitched.png Final\win-arm64\ >nul 2>nul
 
           echo "Copy CLI README"
-          xcopy /y SoundSwitch.CLI\README.md Final >nul 2>nul
+          xcopy /y SoundSwitch.CLI\README.md Final\win-x64\ >nul 2>nul
+          xcopy /y SoundSwitch.CLI\README.md Final\win-arm64\ >nul 2>nul
 
-          echo "Copy LICENSE"
-          xcopy /y LICENSE.txt Final >nul 2>nul
-          xcopy /y Terms.txt Final >nul 2>nul
+          echo "Copy LICENSE and Terms"
+          xcopy /y LICENSE.txt Final\win-x64\ >nul 2>nul
+          xcopy /y LICENSE.txt Final\win-arm64\ >nul 2>nul
+          xcopy /y Terms.txt Final\win-x64\ >nul 2>nul
+          xcopy /y Terms.txt Final\win-arm64\ >nul 2>nul
         shell: cmd
 
       - name: Build Installer

--- a/.github/workflows/test-installer-build.yml
+++ b/.github/workflows/test-installer-build.yml
@@ -75,43 +75,23 @@ jobs:
           cache: true
           cache-dependency-path: Directory.Packages.props
 
-      - name: Build SoundSwitch Application (win-x64)
+      - name: Build SoundSwitch Application
         shell: cmd
         run: |
           echo "Cleaning build directories"
           if exist bin rmdir /q /s bin
           if exist obj rmdir /q /s obj
           if exist Release rmdir /q /s Release
-          if exist publish rmdir /q /s publish
-          mkdir publish\win-x64
-
-          echo "Building SoundSwitch CLI (win-x64)"
-          dotnet publish -c Release -r win-x64 SoundSwitch.CLI\SoundSwitch.CLI.csproj -o publish\win-x64
-          if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
-
-          echo "Building SoundSwitch Main Application (win-x64)"
-          dotnet publish -c Release -r win-x64 SoundSwitch\SoundSwitch.csproj -o publish\win-x64
-          if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
-
-      - name: Build SoundSwitch Application (win-arm64)
-        shell: cmd
-        run: |
-          mkdir publish\win-arm64
-
-          echo "Building SoundSwitch CLI (win-arm64)"
-          dotnet publish -c Release -r win-arm64 SoundSwitch.CLI\SoundSwitch.CLI.csproj -o publish\win-arm64
-          if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
-
-          echo "Building SoundSwitch Main Application (win-arm64)"
-          dotnet publish -c Release -r win-arm64 SoundSwitch\SoundSwitch.csproj -o publish\win-arm64
-          if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
-
-      - name: Combine architectures into Final
-        shell: cmd
-        run: |
+          if exist Final rmdir /q /s Final
           mkdir Final
-          xcopy /e /y publish\win-x64\* Final\win-x64\
-          xcopy /e /y publish\win-arm64\* Final\win-arm64\
+
+          echo "Building SoundSwitch CLI"
+          dotnet publish -c Release SoundSwitch.CLI\SoundSwitch.CLI.csproj -o Final
+          if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
+
+          echo "Building SoundSwitch Main Application"
+          dotnet publish -c Release SoundSwitch\SoundSwitch.csproj -o Final
+          if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
 
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -126,39 +106,31 @@ jobs:
           if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
 
           echo "Generate Changelog"
-          python tools\markdown_to_html.py CHANGELOG.md -o Final\win-x64\Changelog.html
+          python tools\markdown_to_html.py CHANGELOG.md -o Final\Changelog.html
           if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
-          xcopy /y Final\win-x64\Changelog.html Final\win-arm64\
 
           echo "Generate Terms"
-          python tools\markdown_to_html.py Terms.md -o Final\win-x64\Terms.html
+          python tools\markdown_to_html.py Terms.md -o Final\Terms.html
           if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
-          xcopy /y Final\win-x64\Terms.html Final\win-arm64\
 
           echo "Generate README"
-          python tools\markdown_to_html.py README.md -o Final\win-x64\Readme.html
+          python tools\markdown_to_html.py README.md -o Final\Readme.html
           if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
-          xcopy /y Final\win-x64\Readme.html Final\win-arm64\
 
           if exist README.de.md (
-            python tools\markdown_to_html.py README.de.md -o Final\win-x64\Readme.de.html
+            python tools\markdown_to_html.py README.de.md -o Final\Readme.de.html
             if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
-            xcopy /y Final\win-x64\Readme.de.html Final\win-arm64\
           )
 
           echo "Copy soundSwitched image"
-          xcopy /y img\soundSwitched.png Final\win-x64\ >nul 2>nul
-          xcopy /y img\soundSwitched.png Final\win-arm64\ >nul 2>nul
+          xcopy /y img\soundSwitched.png Final\ >nul 2>nul
 
           echo "Copy CLI README"
-          xcopy /y SoundSwitch.CLI\README.md Final\win-x64\ >nul 2>nul
-          xcopy /y SoundSwitch.CLI\README.md Final\win-arm64\ >nul 2>nul
+          xcopy /y SoundSwitch.CLI\README.md Final\ >nul 2>nul
 
           echo "Copy LICENSE and Terms"
-          xcopy /y LICENSE.txt Final\win-x64\ >nul 2>nul
-          xcopy /y LICENSE.txt Final\win-arm64\ >nul 2>nul
-          xcopy /y Terms.txt Final\win-x64\ >nul 2>nul
-          xcopy /y Terms.txt Final\win-arm64\ >nul 2>nul
+          xcopy /y LICENSE.txt Final\ >nul 2>nul
+          xcopy /y Terms.txt Final\ >nul 2>nul
         shell: cmd
 
       - name: Build Installer

--- a/.serena/.gitignore
+++ b/.serena/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/project.local.yml

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,154 @@
+# the name by which the project can be referenced within Serena
+project_name: "SoundSwitch"
+
+
+# list of languages for which language servers are started; choose from:
+#   al                  bash                clojure             cpp                 csharp
+#   csharp_omnisharp    dart                elixir              elm                 erlang
+#   fortran             fsharp              go                  groovy              haskell
+#   haxe                java                julia               kotlin              lua
+#   markdown
+#   matlab              nix                 pascal              perl                php
+#   php_phpactor        powershell          python              python_jedi         r
+#   rego                ruby                ruby_solargraph     rust                scala
+#   swift               terraform           toml                typescript          typescript_vts
+#   vue                 yaml                zig
+#   (This list may be outdated. For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
+#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple languages, the first language server that supports a given file will be used for that file.
+# The first language is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+languages:
+- csharp
+
+# the encoding used by text files in the project
+# For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
+encoding: "utf-8"
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# whether to use project's .gitignore files to ignore files
+ignore_all_files_in_gitignore: true
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}
+
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
+ignored_paths: []
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: false
+
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+#
+# Below is the complete list of tools for convenience.
+# To make sure you have the latest list of tools, and to view their descriptions, 
+# execute `uv run scripts/print_tool_overview.py`.
+#
+#  * `activate_project`: Activates a project based on the project name or path.
+#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
+#  * `create_text_file`: Creates/overwrites a file in the project directory.
+#  * `delete_memory`: Delete a memory file. Should only happen if a user asks for it explicitly,
+#       for example by saying that the information retrieved from a memory file is no longer correct
+#       or no longer relevant for the project.
+#  * `edit_memory`: Replaces content matching a regular expression in a memory.
+#  * `execute_shell_command`: Executes a shell command.
+#  * `find_file`: Finds files in the given relative paths
+#  * `find_referencing_symbols`: Finds symbols that reference the given symbol using the language server backend
+#  * `find_symbol`: Performs a global (or local) search using the language server backend.
+#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
+#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
+#  * `initial_instructions`: Provides instructions Serena usage (i.e. the 'Serena Instructions Manual')
+#       for clients that do not read the initial instructions when the MCP server is connected.
+#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
+#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
+#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
+#  * `list_memories`: List available memories. Any memory can be read using the `read_memory` tool.
+#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
+#  * `read_file`: Reads a file within the project directory.
+#  * `read_memory`: Read the content of a memory file. This tool should only be used if the information
+#       is relevant to the current task. You can infer whether the information
+#       is relevant from the memory file name.
+#       You should not read the same memory file multiple times in the same conversation.
+#  * `rename_memory`: Renames or moves a memory. Moving between project and global scope is supported
+#       (e.g., renaming "global/foo" to "bar" moves it from global to project scope).
+#  * `rename_symbol`: Renames a symbol throughout the codebase using language server refactoring capabilities.
+#       For JB, we use a separate tool.
+#  * `replace_content`: Replaces content in a file (optionally using regular expressions).
+#  * `replace_symbol_body`: Replaces the full definition of a symbol using the language server backend.
+#  * `safe_delete_symbol`:
+#  * `search_for_pattern`: Performs a search for a pattern in the project.
+#  * `write_memory`: Write some information (utf-8-encoded) about this project that can be useful for future tasks to a memory in md format.
+#       The memory name should be meaningful.
+excluded_tools: []
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+fixed_tools: []
+
+# list of mode names to that are always to be included in the set of active modes
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the base_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this setting overrides the global configuration.
+# Set this to [] to disable base modes for this project.
+# Set this to a list of mode names to always include the respective modes for this project.
+base_modes:
+
+# list of mode names that are to be activated by default.
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+default_modes:
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ""
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -37,6 +37,7 @@
     <PackageVersion Include="System.Diagnostics.TraceSource" Version="4.3.0" />
     <PackageVersion Include="System.Drawing.Common" Version="10.0.7" />
     <PackageVersion Include="System.Management" Version="10.0.7" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.7" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Reactive" Version="6.1.0" />
     <PackageVersion Include="System.Resources.Extensions" Version="10.0.5" />

--- a/Installer/Make-Installer.bat
+++ b/Installer/Make-Installer.bat
@@ -31,8 +31,13 @@ echo Cleaning previous installer files: ..\Final\Installer\*Installer.exe
 del ..\Final\Installer\*Installer.exe
 
 echo Building installer...
-echo Running Inno Setup: %innoSetupExe% setup.iss /DReleaseState=%1
-%innoSetupExe% setup.iss /DReleaseState=%1
+if "%2"=="" (
+    echo Running Inno Setup: %innoSetupExe% setup.iss /DReleaseState=%1
+    %innoSetupExe% setup.iss /DReleaseState=%1
+) else (
+    echo Running Inno Setup: %innoSetupExe% setup.iss /DReleaseState=%1 /DDotNetMajorVersion=%2
+    %innoSetupExe% setup.iss /DReleaseState=%1 /DDotNetMajorVersion=%2
+)
 if not %ERRORLEVEL%==0 (set errorMessage=Installer script setup.iss failed & goto ERROR_QUIT)
 
 echo Moving installer to final location: ..\Final\*Installer.exe -^> ..\Final\Installer\

--- a/Installer/scripts/app_defines.iss
+++ b/Installer/scripts/app_defines.iss
@@ -7,7 +7,7 @@
 
 #define MyAppSetupName 'SoundSwitch'
 #define ExeDir  '..\Final\'
-#define MyAppVersion GetVersionNumbersString('..\Final\win-x64\SoundSwitch.exe')
+#define MyAppVersion GetVersionNumbersString('..\Final\SoundSwitch.exe')
 #define MyAppDescription 'SoundSwitch is a powerful audio switching application.'
 
 #endif

--- a/Installer/scripts/app_defines.iss
+++ b/Installer/scripts/app_defines.iss
@@ -7,7 +7,7 @@
 
 #define MyAppSetupName 'SoundSwitch'
 #define ExeDir  '..\Final\'
-#define MyAppVersion GetVersionNumbersString('..\Final\SoundSwitch.exe')
+#define MyAppVersion GetVersionNumbersString('..\Final\win-x64\SoundSwitch.exe')
 #define MyAppDescription 'SoundSwitch is a powerful audio switching application.'
 
 #endif

--- a/Installer/scripts/products.iss
+++ b/Installer/scripts/products.iss
@@ -272,6 +272,11 @@ begin
 	Result := Is64BitInstallMode and (ProcessorArchitecture = paX64);
 end;
 
+function IsArm64: boolean;
+begin
+  Result := ProcessorArchitecture = paARM64;
+end;
+
 function GetString(x86, x64, ia64: String): String;
 begin
 	if IsX64() and (x64 <> '') then begin
@@ -283,7 +288,9 @@ end;
 
 function GetArchitectureString(): String;
 begin
-	if IsX64() then begin
+	if IsArm64() then begin
+		Result := '_arm64';
+	end else if IsX64() then begin
 		Result := '_x64';
 	end else begin
 		Result := '';

--- a/Installer/scripts/setup_utils.iss
+++ b/Installer/scripts/setup_utils.iss
@@ -18,10 +18,10 @@ begin
     end;
     
     // Ensure .NET {#DotNetMajorVersion} Desktop Runtime is installed
-    if not IsDotNetDesktopRuntime10Installed() then
+    if not IsDotNetDesktopRuntimeInstalled() then
     begin
       Log('Microsoft.WindowsDesktop.App {#DotNetMajorVersion}.x not found. Installing via winget...');
-      if not InstallDotNetDesktopRuntime10() then
+      if not InstallDotNetDesktopRuntime() then
       begin
         Log('Failed to install .NET {#DotNetMajorVersion} Desktop Runtime.');
       end;
@@ -32,9 +32,9 @@ begin
     end;
 
     // Always try to upgrade to latest runtime version (non-fatal)
-    if IsDotNetDesktopRuntime10Installed() then
+    if IsDotNetDesktopRuntimeInstalled() then
     begin
-      UpgradeDotNetDesktopRuntime10();
+      UpgradeDotNetDesktopRuntime();
     end;
   end;
 end;

--- a/Installer/scripts/setup_utils.iss
+++ b/Installer/scripts/setup_utils.iss
@@ -17,19 +17,24 @@ begin
       ModifyPath(ExpandConstant('{app}'));
     end;
     
-    // Check and install .NET 10 Desktop Runtime if not present
+    // Ensure .NET {#DotNetMajorVersion} Desktop Runtime is installed
     if not IsDotNetDesktopRuntime10Installed() then
     begin
-      Log('Microsoft.WindowsDesktop.App 10.x not found. Installing via winget...');
+      Log('Microsoft.WindowsDesktop.App {#DotNetMajorVersion}.x not found. Installing via winget...');
       if not InstallDotNetDesktopRuntime10() then
       begin
-        // Installation failed — message already shown by InstallDotNetDesktopRuntime10()
-        Log('Failed to install .NET 10 Desktop Runtime.');
+        Log('Failed to install .NET {#DotNetMajorVersion} Desktop Runtime.');
       end;
     end
     else
     begin
-      Log('Microsoft.WindowsDesktop.App 10.x is already installed.');
+      Log('Microsoft.WindowsDesktop.App {#DotNetMajorVersion}.x is already installed.');
+    end;
+
+    // Always try to upgrade to latest runtime version (non-fatal)
+    if IsDotNetDesktopRuntime10Installed() then
+    begin
+      UpgradeDotNetDesktopRuntime10();
     end;
   end;
 end;

--- a/Installer/scripts/setup_utils.iss
+++ b/Installer/scripts/setup_utils.iss
@@ -5,7 +5,7 @@
 #define setupUtilsIss
 
 [Code]
-// Called during setup process to handle PATH modifications
+// Called during setup process to handle PATH modifications and runtime installation
 procedure CurStepChanged(CurStep: TSetupStep);
 begin
   if CurStep = ssPostInstall then
@@ -15,6 +15,21 @@ begin
     begin
       // Add to PATH (function now handles admin/user mode internally)
       ModifyPath(ExpandConstant('{app}'));
+    end;
+    
+    // Check and install .NET 10 Desktop Runtime if not present
+    if not IsDotNetDesktopRuntime10Installed() then
+    begin
+      Log('Microsoft.WindowsDesktop.App 10.x not found. Installing via winget...');
+      if not InstallDotNetDesktopRuntime10() then
+      begin
+        // Installation failed — message already shown by InstallDotNetDesktopRuntime10()
+        Log('Failed to install .NET 10 Desktop Runtime.');
+      end;
+    end
+    else
+    begin
+      Log('Microsoft.WindowsDesktop.App 10.x is already installed.');
     end;
   end;
 end;

--- a/Installer/scripts/winget-dotnet-runtime.iss
+++ b/Installer/scripts/winget-dotnet-runtime.iss
@@ -1,0 +1,109 @@
+// Checks if Microsoft.WindowsDesktop.App 10.x is already installed
+function IsDotNetDesktopRuntime10Installed(): Boolean;
+var
+  FindRec: TFindRec;
+  SharedDir: String;
+begin
+  Result := false;
+  
+  // Check machine-wide install: look for any 10.0.* directory
+  SharedDir := ExpandConstant('{commonpf}\dotnet\shared\Microsoft.WindowsDesktop.App\');
+  if FindFirst(SharedDir + '*', FindRec) then
+  begin
+    repeat
+      if (FindRec.Attributes and FILE_ATTRIBUTE_DIRECTORY <> 0) and
+         (Pos('10.0', FindRec.Name) = 1) then
+      begin
+        Result := true;
+        FindClose(FindRec);
+        exit;
+      end;
+    until not FindNext(FindRec);
+    FindClose(FindRec);
+  end;
+  
+  // Check per-user install
+  SharedDir := ExpandConstant('{localappdata}\Microsoft\dotnet\shared\Microsoft.WindowsDesktop.App\');
+  if FindFirst(SharedDir + '*', FindRec) then
+  begin
+    repeat
+      if (FindRec.Attributes and FILE_ATTRIBUTE_DIRECTORY <> 0) and
+         (Pos('10.0', FindRec.Name) = 1) then
+      begin
+        Result := true;
+        FindClose(FindRec);
+        exit;
+      end;
+    until not FindNext(FindRec);
+    FindClose(FindRec);
+  end;
+end;
+
+// Installs .NET 10 Desktop Runtime via winget
+// Returns True on success, False on failure (shows error message)
+function InstallDotNetDesktopRuntime10(): Boolean;
+var
+  Scope: String;
+  Args: String;
+  ResultCode: Integer;
+  WingetPath: String;
+begin
+  Result := false;
+  
+  // .NET Desktop Runtime is system-wide only. The installer already
+  // requires admin privileges (PrivilegesRequired=admin in setup.iss).
+  Scope := 'machine';
+  
+  // Find winget: try PATH first, then fallback to known location
+  WingetPath := 'winget.exe';
+  if not FileExists(WingetPath) then
+    WingetPath := ExpandConstant('{localappdata}\Microsoft\WindowsApps\winget.exe');
+  
+  if not FileExists(WingetPath) then
+  begin
+    MsgBox('Windows Package Manager (winget) is not available on this system.' + #13#10 +
+           'Please install .NET 10 Desktop Runtime manually from:' + #13#10 +
+           'https://dotnet.microsoft.com/en-us/download/dotnet', mbError, MB_OK);
+    Result := false;
+    exit;
+  end;
+  
+  // Build winget arguments
+  Args := 'install --exact --id Microsoft.DotNet.DesktopRuntime.10' +
+          ' --scope ' + Scope +
+          ' --silent' +
+          ' --accept-package-agreements' +
+          ' --accept-source-agreements' +
+          ' --source winget';
+  
+  Log('Running: ' + WingetPath + ' ' + Args);
+  
+  if Exec(WingetPath, Args, '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
+  begin
+    case ResultCode of
+      0: begin
+        Log('.NET 10 Desktop Runtime installed successfully.');
+        Result := true;
+      end;
+      3010: begin
+        Log('.NET 10 Desktop Runtime installed (reboot required).');
+        Result := true; // Success, but needs reboot later
+      end;
+      else begin
+        Log('winget failed with exit code: ' + IntToStr(ResultCode));
+        MsgBox('Failed to install .NET 10 Desktop Runtime (exit code: ' + IntToStr(ResultCode) + ').' + #13#10 +
+               'Please install it manually from:' + #13#10 +
+               'https://dotnet.microsoft.com/en-us/download/dotnet', mbError, MB_OK);
+        Result := false;
+      end;
+    end;
+  end
+  else
+  begin
+    Log('Failed to execute winget.');
+    MsgBox('Failed to run Windows Package Manager.' + #13#10 +
+           'Please install .NET 10 Desktop Runtime manually from:' + #13#10 +
+           'https://dotnet.microsoft.com/en-us/download/dotnet', mbError, MB_OK);
+    Result := false;
+  end;
+end;

--- a/Installer/scripts/winget-dotnet-runtime.iss
+++ b/Installer/scripts/winget-dotnet-runtime.iss
@@ -1,3 +1,4 @@
+[Code]
 // Checks if Microsoft.WindowsDesktop.App 10.x is already installed
 function IsDotNetDesktopRuntime10Installed(): Boolean;
 var

--- a/Installer/scripts/winget-dotnet-runtime.iss
+++ b/Installer/scripts/winget-dotnet-runtime.iss
@@ -1,6 +1,6 @@
 [Code]
 // Checks if Microsoft.WindowsDesktop.App {#DotNetMajorVersion}.x is already installed
-function IsDotNetDesktopRuntime10Installed(): Boolean;
+function IsDotNetDesktopRuntimeInstalled(): Boolean;
 var
   FindRec: TFindRec;
   SharedDir: String;
@@ -42,7 +42,7 @@ end;
 
 // Installs .NET {#DotNetMajorVersion} Desktop Runtime via winget
 // Returns True on success, False on failure (shows error message)
-function InstallDotNetDesktopRuntime10(): Boolean;
+function InstallDotNetDesktopRuntime(): Boolean;
 var
   Scope: String;
   Args: String;
@@ -111,7 +111,7 @@ end;
 
 // Attempts to upgrade .NET {#DotNetMajorVersion} Desktop Runtime to latest version via winget
 // Non-fatal: if nothing to upgrade or winget unavailable, just logs and continues
-procedure UpgradeDotNetDesktopRuntime10();
+procedure UpgradeDotNetDesktopRuntime();
 var
   Args: String;
   ResultCode: Integer;

--- a/Installer/scripts/winget-dotnet-runtime.iss
+++ b/Installer/scripts/winget-dotnet-runtime.iss
@@ -1,3 +1,6 @@
+#ifndef wingetDotNetRuntimeIss
+#define wingetDotNetRuntimeIss
+
 [Code]
 var
   _dotnetRebootRequired: Boolean;
@@ -173,3 +176,5 @@ function NeedRestart(): Boolean;
 begin
   Result := _dotnetRebootRequired;
 end;
+
+#endif

--- a/Installer/scripts/winget-dotnet-runtime.iss
+++ b/Installer/scripts/winget-dotnet-runtime.iss
@@ -3,44 +3,57 @@ var
   _dotnetRebootRequired: Boolean;
 
 // Checks if Microsoft.WindowsDesktop.App {#DotNetMajorVersion}.x is already installed
+// Uses dotnet --list-runtimes for reliable detection across all install locations
 function IsDotNetDesktopRuntimeInstalled(): Boolean;
 var
-  FindRec: TFindRec;
-  SharedDir: String;
+  TempFile: String;
+  Output: AnsiString;
+  ResultCode: Integer;
+  DotNetExe: String;
+  CmdLine: String;
 begin
   Result := false;
 
-  // Check machine-wide install: look for any {#DotNetMajorVersion}.0.* directory
-  SharedDir := ExpandConstant('{pf}\dotnet\shared\Microsoft.WindowsDesktop.App\');
-  if FindFirst(SharedDir + '*', FindRec) then
+  // Find dotnet.exe on system PATH
+  DotNetExe := FileSearch('dotnet.exe', GetEnv('PATH'));
+  if DotNetExe = '' then
   begin
-    repeat
-      if (FindRec.Attributes and FILE_ATTRIBUTE_DIRECTORY <> 0) and
-         (Pos('{#DotNetMajorVersion}.0', FindRec.Name) = 1) then
-      begin
-        Result := true;
-        FindClose(FindRec);
-        exit;
-      end;
-    until not FindNext(FindRec);
-    FindClose(FindRec);
+    Log('dotnet CLI not found on PATH. Cannot check for runtime.');
+    exit;
   end;
 
-  // Check per-user install
-  SharedDir := ExpandConstant('{localappdata}\Microsoft\dotnet\shared\Microsoft.WindowsDesktop.App\');
-  if FindFirst(SharedDir + '*', FindRec) then
+  TempFile := ExpandConstant('{tmp}\dotnet_runtimes.txt');
+
+  // Run dotnet --list-runtimes, redirect output to temp file
+  CmdLine := '/C "' + DotNetExe + '" --list-runtimes > "' + TempFile + '"';
+  if not Exec(ExpandConstant('{cmd}'), CmdLine, '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
   begin
-    repeat
-      if (FindRec.Attributes and FILE_ATTRIBUTE_DIRECTORY <> 0) and
-         (Pos('{#DotNetMajorVersion}.0', FindRec.Name) = 1) then
-      begin
-        Result := true;
-        FindClose(FindRec);
-        exit;
-      end;
-    until not FindNext(FindRec);
-    FindClose(FindRec);
+    Log('Failed to execute dotnet --list-runtimes.');
+    exit;
   end;
+
+  if ResultCode <> 0 then
+  begin
+    Log('dotnet --list-runtimes returned non-zero exit code: ' + IntToStr(ResultCode));
+    exit;
+  end;
+
+  // Read captured output
+  if not LoadStringFromFile(TempFile, Output) then
+  begin
+    Log('Failed to read dotnet --list-runtimes output from temp file.');
+    DeleteFile(TempFile);
+    exit;
+  end;
+
+  DeleteFile(TempFile);
+
+  // Check if Microsoft.WindowsDesktop.App {#DotNetMajorVersion}. is in the output
+  Result := Pos('Microsoft.WindowsDesktop.App {#DotNetMajorVersion}.', Output) > 0;
+  if Result then
+    Log('Microsoft.WindowsDesktop.App {#DotNetMajorVersion}.x found via dotnet --list-runtimes.')
+  else
+    Log('Microsoft.WindowsDesktop.App {#DotNetMajorVersion}.x not found in dotnet --list-runtimes output.');
 end;
 
 // Installs .NET {#DotNetMajorVersion} Desktop Runtime via winget

--- a/Installer/scripts/winget-dotnet-runtime.iss
+++ b/Installer/scripts/winget-dotnet-runtime.iss
@@ -63,16 +63,11 @@ end;
 // Returns True on success, False on failure (shows error message)
 function InstallDotNetDesktopRuntime(): Boolean;
 var
-  Scope: String;
   Args: String;
   ResultCode: Integer;
   WingetPath: String;
 begin
   Result := false;
-
-  // .NET Desktop Runtime is system-wide only. The installer already
-  // requires admin privileges (PrivilegesRequired=admin in setup.iss).
-  Scope := 'machine';
 
   // Find winget: search PATH first, then known location
   WingetPath := FileSearch('winget.exe', GetEnv('PATH'));
@@ -88,9 +83,8 @@ begin
     exit;
   end;
 
-  // Build winget arguments
+  // Build winget arguments (no --scope: not supported by .NET runtime package)
   Args := 'install --exact --id Microsoft.DotNet.DesktopRuntime.{#DotNetMajorVersion}' +
-          ' --scope ' + Scope +
           ' --silent' +
           ' --accept-package-agreements' +
           ' --accept-source-agreements' +

--- a/Installer/scripts/winget-dotnet-runtime.iss
+++ b/Installer/scripts/winget-dotnet-runtime.iss
@@ -1,4 +1,7 @@
 [Code]
+var
+  _dotnetRebootRequired: Boolean;
+
 // Checks if Microsoft.WindowsDesktop.App {#DotNetMajorVersion}.x is already installed
 function IsDotNetDesktopRuntimeInstalled(): Boolean;
 var
@@ -8,7 +11,7 @@ begin
   Result := false;
 
   // Check machine-wide install: look for any {#DotNetMajorVersion}.0.* directory
-  SharedDir := ExpandConstant('{commonpf}\dotnet\shared\Microsoft.WindowsDesktop.App\');
+  SharedDir := ExpandConstant('{pf}\dotnet\shared\Microsoft.WindowsDesktop.App\');
   if FindFirst(SharedDir + '*', FindRec) then
   begin
     repeat
@@ -55,12 +58,12 @@ begin
   // requires admin privileges (PrivilegesRequired=admin in setup.iss).
   Scope := 'machine';
 
-  // Find winget: try PATH first, then fallback to known location
-  WingetPath := 'winget.exe';
-  if not FileExists(WingetPath) then
+  // Find winget: search PATH first, then known location
+  WingetPath := FileSearch('winget.exe', GetEnv('PATH'));
+  if WingetPath = '' then
     WingetPath := ExpandConstant('{localappdata}\Microsoft\WindowsApps\winget.exe');
 
-  if not FileExists(WingetPath) then
+  if WingetPath = '' then
   begin
     MsgBox('Windows Package Manager (winget) is not available on this system.' + #13#10 +
            'Please install .NET {#DotNetMajorVersion} Desktop Runtime manually from:' + #13#10 +
@@ -88,6 +91,7 @@ begin
       end;
       3010: begin
         Log('.NET {#DotNetMajorVersion} Desktop Runtime installed (reboot required).');
+        _dotnetRebootRequired := true;
         Result := true; // Success, but needs reboot later
       end;
       else begin
@@ -117,11 +121,11 @@ var
   ResultCode: Integer;
   WingetPath: String;
 begin
-  WingetPath := 'winget.exe';
-  if not FileExists(WingetPath) then
+  WingetPath := FileSearch('winget.exe', GetEnv('PATH'));
+  if WingetPath = '' then
     WingetPath := ExpandConstant('{localappdata}\Microsoft\WindowsApps\winget.exe');
 
-  if not FileExists(WingetPath) then
+  if WingetPath = '' then
   begin
     Log('winget not found, skipping runtime upgrade check.');
     exit;
@@ -139,7 +143,10 @@ begin
   begin
     case ResultCode of
       0: Log('.NET {#DotNetMajorVersion} Desktop Runtime upgrade completed successfully.');
-      3010: Log('.NET {#DotNetMajorVersion} Desktop Runtime upgraded (reboot required).');
+      3010: begin
+        Log('.NET {#DotNetMajorVersion} Desktop Runtime upgraded (reboot required).');
+        _dotnetRebootRequired := true;
+      end;
       else Log('winget upgrade exited with code: ' + IntToStr(ResultCode) + ' (may indicate no updates available).');
     end;
   end
@@ -147,4 +154,9 @@ begin
   begin
     Log('Failed to execute winget upgrade check.');
   end;
+end;
+
+function NeedRestart(): Boolean;
+begin
+  Result := _dotnetRebootRequired;
 end;

--- a/Installer/scripts/winget-dotnet-runtime.iss
+++ b/Installer/scripts/winget-dotnet-runtime.iss
@@ -70,7 +70,7 @@ begin
   end;
   
   // Build winget arguments
-  Args := 'install --exact --id Microsoft.DotNet.DesktopRuntime.10' +
+  Args := 'install --force --exact --id Microsoft.DotNet.DesktopRuntime.10' +
           ' --scope ' + Scope +
           ' --silent' +
           ' --accept-package-agreements' +

--- a/Installer/scripts/winget-dotnet-runtime.iss
+++ b/Installer/scripts/winget-dotnet-runtime.iss
@@ -1,19 +1,19 @@
 [Code]
-// Checks if Microsoft.WindowsDesktop.App 10.x is already installed
+// Checks if Microsoft.WindowsDesktop.App {#DotNetMajorVersion}.x is already installed
 function IsDotNetDesktopRuntime10Installed(): Boolean;
 var
   FindRec: TFindRec;
   SharedDir: String;
 begin
   Result := false;
-  
-  // Check machine-wide install: look for any 10.0.* directory
+
+  // Check machine-wide install: look for any {#DotNetMajorVersion}.0.* directory
   SharedDir := ExpandConstant('{commonpf}\dotnet\shared\Microsoft.WindowsDesktop.App\');
   if FindFirst(SharedDir + '*', FindRec) then
   begin
     repeat
       if (FindRec.Attributes and FILE_ATTRIBUTE_DIRECTORY <> 0) and
-         (Pos('10.0', FindRec.Name) = 1) then
+         (Pos('{#DotNetMajorVersion}.0', FindRec.Name) = 1) then
       begin
         Result := true;
         FindClose(FindRec);
@@ -22,14 +22,14 @@ begin
     until not FindNext(FindRec);
     FindClose(FindRec);
   end;
-  
+
   // Check per-user install
   SharedDir := ExpandConstant('{localappdata}\Microsoft\dotnet\shared\Microsoft.WindowsDesktop.App\');
   if FindFirst(SharedDir + '*', FindRec) then
   begin
     repeat
       if (FindRec.Attributes and FILE_ATTRIBUTE_DIRECTORY <> 0) and
-         (Pos('10.0', FindRec.Name) = 1) then
+         (Pos('{#DotNetMajorVersion}.0', FindRec.Name) = 1) then
       begin
         Result := true;
         FindClose(FindRec);
@@ -40,7 +40,7 @@ begin
   end;
 end;
 
-// Installs .NET 10 Desktop Runtime via winget
+// Installs .NET {#DotNetMajorVersion} Desktop Runtime via winget
 // Returns True on success, False on failure (shows error message)
 function InstallDotNetDesktopRuntime10(): Boolean;
 var
@@ -50,49 +50,49 @@ var
   WingetPath: String;
 begin
   Result := false;
-  
+
   // .NET Desktop Runtime is system-wide only. The installer already
   // requires admin privileges (PrivilegesRequired=admin in setup.iss).
   Scope := 'machine';
-  
+
   // Find winget: try PATH first, then fallback to known location
   WingetPath := 'winget.exe';
   if not FileExists(WingetPath) then
     WingetPath := ExpandConstant('{localappdata}\Microsoft\WindowsApps\winget.exe');
-  
+
   if not FileExists(WingetPath) then
   begin
     MsgBox('Windows Package Manager (winget) is not available on this system.' + #13#10 +
-           'Please install .NET 10 Desktop Runtime manually from:' + #13#10 +
+           'Please install .NET {#DotNetMajorVersion} Desktop Runtime manually from:' + #13#10 +
            'https://dotnet.microsoft.com/en-us/download/dotnet', mbError, MB_OK);
     Result := false;
     exit;
   end;
-  
+
   // Build winget arguments
-  Args := 'install --force --exact --id Microsoft.DotNet.DesktopRuntime.10' +
+  Args := 'install --exact --id Microsoft.DotNet.DesktopRuntime.{#DotNetMajorVersion}' +
           ' --scope ' + Scope +
           ' --silent' +
           ' --accept-package-agreements' +
           ' --accept-source-agreements' +
           ' --source winget';
-  
+
   Log('Running: ' + WingetPath + ' ' + Args);
-  
+
   if Exec(WingetPath, Args, '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
   begin
     case ResultCode of
       0: begin
-        Log('.NET 10 Desktop Runtime installed successfully.');
+        Log('.NET {#DotNetMajorVersion} Desktop Runtime installed successfully.');
         Result := true;
       end;
       3010: begin
-        Log('.NET 10 Desktop Runtime installed (reboot required).');
+        Log('.NET {#DotNetMajorVersion} Desktop Runtime installed (reboot required).');
         Result := true; // Success, but needs reboot later
       end;
       else begin
         Log('winget failed with exit code: ' + IntToStr(ResultCode));
-        MsgBox('Failed to install .NET 10 Desktop Runtime (exit code: ' + IntToStr(ResultCode) + ').' + #13#10 +
+        MsgBox('Failed to install .NET {#DotNetMajorVersion} Desktop Runtime (exit code: ' + IntToStr(ResultCode) + ').' + #13#10 +
                'Please install it manually from:' + #13#10 +
                'https://dotnet.microsoft.com/en-us/download/dotnet', mbError, MB_OK);
         Result := false;
@@ -103,8 +103,48 @@ begin
   begin
     Log('Failed to execute winget.');
     MsgBox('Failed to run Windows Package Manager.' + #13#10 +
-           'Please install .NET 10 Desktop Runtime manually from:' + #13#10 +
+           'Please install .NET {#DotNetMajorVersion} Desktop Runtime manually from:' + #13#10 +
            'https://dotnet.microsoft.com/en-us/download/dotnet', mbError, MB_OK);
     Result := false;
+  end;
+end;
+
+// Attempts to upgrade .NET {#DotNetMajorVersion} Desktop Runtime to latest version via winget
+// Non-fatal: if nothing to upgrade or winget unavailable, just logs and continues
+procedure UpgradeDotNetDesktopRuntime10();
+var
+  Args: String;
+  ResultCode: Integer;
+  WingetPath: String;
+begin
+  WingetPath := 'winget.exe';
+  if not FileExists(WingetPath) then
+    WingetPath := ExpandConstant('{localappdata}\Microsoft\WindowsApps\winget.exe');
+
+  if not FileExists(WingetPath) then
+  begin
+    Log('winget not found, skipping runtime upgrade check.');
+    exit;
+  end;
+
+  Args := 'upgrade --id Microsoft.DotNet.DesktopRuntime.{#DotNetMajorVersion}' +
+          ' --silent' +
+          ' --accept-package-agreements' +
+          ' --accept-source-agreements' +
+          ' --source winget';
+
+  Log('Checking for .NET {#DotNetMajorVersion} Desktop Runtime updates: ' + WingetPath + ' ' + Args);
+
+  if Exec(WingetPath, Args, '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
+  begin
+    case ResultCode of
+      0: Log('.NET {#DotNetMajorVersion} Desktop Runtime upgrade completed successfully.');
+      3010: Log('.NET {#DotNetMajorVersion} Desktop Runtime upgraded (reboot required).');
+      else Log('winget upgrade exited with code: ' + IntToStr(ResultCode) + ' (may indicate no updates available).');
+    end;
+  end
+  else
+  begin
+    Log('Failed to execute winget upgrade check.');
   end;
 end;

--- a/Installer/setup.iss
+++ b/Installer/setup.iss
@@ -41,8 +41,8 @@ WizardImageStretch=no
 // Code signing is now handled by tools\Sign-Binary.ps1 (called from Build-Installer.ps1)
 
 //SignedUninstaller=yes
-LicenseFile={#ExeDir}win-x64\LICENSE.txt
-InfoBeforeFile={#ExeDir}win-x64\Terms.txt
+LicenseFile={#ExeDir}LICENSE.txt
+InfoBeforeFile={#ExeDir}Terms.txt
 SetupLogging=yes
 RestartApplications=no
 ;AppMutex={#MyAppSetupName}
@@ -79,8 +79,7 @@ Name: addtopath; Description: "{cm:AddToPath,{#MyAppSetupName}}"; GroupDescripti
 Name: deletefiles; Description: "{cm:ExistingSettings}"; GroupDescription: "{cm:SettingsGroupDescription}"; Flags: unchecked checkedonce
 
 [Files] 
-Source: "{#ExeDir}\win-x64\*"; DestDir: "{app}"; Check: IsX64; Flags: ignoreversion recursesubdirs
-Source: "{#ExeDir}\win-arm64\*"; DestDir: "{app}"; Check: IsArm64; Flags: ignoreversion recursesubdirs
+Source: "{#ExeDir}*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs
 Source: "scripts\ManageWindowsUpdate.ps1"; DestDir: "{tmp}"; Flags: confirmoverwrite deleteafterinstall
 
 [Registry]

--- a/Installer/setup.iss
+++ b/Installer/setup.iss
@@ -1,4 +1,5 @@
 #include "scripts\app_defines.iss"
+#include "scripts\winget-dotnet-runtime.iss"
 // ReleaseState is expected to be defined through the command line with /D parameter
 // e.g. iscc /DReleaseState=Beta setup.iss
 
@@ -40,18 +41,18 @@ WizardImageStretch=no
 // Code signing is now handled by tools\Sign-Binary.ps1 (called from Build-Installer.ps1)
 
 //SignedUninstaller=yes
-LicenseFile={#ExeDir}LICENSE.txt
-InfoBeforeFile={#ExeDir}Terms.txt
+LicenseFile={#ExeDir}win-x64\LICENSE.txt
+InfoBeforeFile={#ExeDir}win-x64\Terms.txt
 SetupLogging=yes
 RestartApplications=no
 ;AppMutex={#MyAppSetupName}
 
 ;MinVersion default value: "0,5.0 (Windows 2000+) if Unicode Inno Setup, else 4.0,4.0 (Windows 95+)"
-MinVersion=6.1.7601sp1
+MinVersion=10.0.17763
 PrivilegesRequired=admin
 PrivilegesRequiredOverridesAllowed=commandline dialog
-ArchitecturesAllowed=x64compatible
-ArchitecturesInstallIn64BitMode=x64compatible
+ArchitecturesAllowed=x64compatible arm64
+ArchitecturesInstallIn64BitMode=x64compatible arm64
 
 ;Downloading and installing dependencies will only work if the memo/ready page is enabled (default behaviour)
 DisableReadyPage=no
@@ -78,9 +79,8 @@ Name: addtopath; Description: "{cm:AddToPath,{#MyAppSetupName}}"; GroupDescripti
 Name: deletefiles; Description: "{cm:ExistingSettings}"; GroupDescription: "{cm:SettingsGroupDescription}"; Flags: unchecked checkedonce
 
 [Files] 
-Source: "{#ExeDir}SoundSwitch.exe"; DestDir: "{app}";  Flags: ignoreversion
-Source: "{#ExeDir}SoundSwitch.CLI.exe"; DestDir: "{app}";  Flags: ignoreversion
-Source: "{#ExeDir}*"; DestDir: "{app}"; Flags: recursesubdirs ignoreversion;
+Source: "{#ExeDir}\win-x64\*"; DestDir: "{app}"; Check: IsX64; Flags: ignoreversion recursesubdirs
+Source: "{#ExeDir}\win-arm64\*"; DestDir: "{app}"; Check: IsArm64; Flags: ignoreversion recursesubdirs
 Source: "scripts\ManageWindowsUpdate.ps1"; DestDir: "{tmp}"; Flags: confirmoverwrite deleteafterinstall
 
 [Registry]
@@ -145,4 +145,4 @@ begin
   end;
 end;
 
-
+end.

--- a/Installer/setup.iss
+++ b/Installer/setup.iss
@@ -1,7 +1,7 @@
 #include "scripts\app_defines.iss"
 #include "scripts\winget-dotnet-runtime.iss"
-// ReleaseState is expected to be defined through the command line with /D parameter
-// e.g. iscc /DReleaseState=Beta setup.iss
+// ReleaseState and DotNetMajorVersion are expected to be defined through the command line with /D parameter
+// e.g. iscc /DReleaseState=Beta /DDotNetMajorVersion=10 setup.iss
 
 
 [Setup]

--- a/SoundSwitch.CLI/SoundSwitch.CLI.csproj
+++ b/SoundSwitch.CLI/SoundSwitch.CLI.csproj
@@ -7,7 +7,6 @@
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <Deterministic>true</Deterministic>
-    <SelfContained>true</SelfContained>
     <Configurations>Debug;Release;Beta;Nightly</Configurations>
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>

--- a/SoundSwitch.Tests/SoundSwitch.Tests.csproj
+++ b/SoundSwitch.Tests/SoundSwitch.Tests.csproj
@@ -15,6 +15,7 @@
         <PackageReference Include="NUnit3TestAdapter" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="Serilog.Sinks.Console" />
+        <PackageReference Include="System.Security.Cryptography.Xml" />
     </ItemGroup>
 
     <ItemGroup>

--- a/SoundSwitch/Framework/Updater/UpdateChecker.cs
+++ b/SoundSwitch/Framework/Updater/UpdateChecker.cs
@@ -72,10 +72,12 @@ public partial class UpdateChecker(Uri releaseUrl, bool checkBeta)
         {
             if (version > AppVersion)
             {
-                // Future-proof architecture matching: prefer arch-specific installer, fall back to generic
+                // Future-proof architecture matching: prefer arch-specific installer, fall back to generic (no arch suffix)
                 var archSuffix = RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? "_arm64" : "_x64";
                 var installer = serverRelease.Assets.FirstOrDefault(a => a.Name.Contains(archSuffix) && a.Name.EndsWith(".exe"))
-                                ?? serverRelease.Assets.FirstOrDefault(asset => asset.Name.EndsWith(".exe"));
+                                ?? serverRelease.Assets.FirstOrDefault(a => a.Name.EndsWith(".exe")
+                                                                           && !a.Name.Contains("_arm64")
+                                                                           && !a.Name.Contains("_x64"));
                 if (installer == null)
                 {
                     return false;

--- a/SoundSwitch/Framework/Updater/UpdateChecker.cs
+++ b/SoundSwitch/Framework/Updater/UpdateChecker.cs
@@ -13,6 +13,7 @@
  ********************************************************************/
 
 using System;
+using System.Runtime.InteropServices;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -71,7 +72,11 @@ public partial class UpdateChecker(Uri releaseUrl, bool checkBeta)
         {
             if (version > AppVersion)
             {
-                var installer = serverRelease.Assets.SingleOrDefault(asset => asset.Name.EndsWith(".exe"));
+                var installer = serverRelease.Assets.FirstOrDefault(asset => asset.Name.EndsWith(".exe"));
+                // Future-proof architecture matching: prefer arch-specific installer
+                var archSuffix = RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? "-arm64" : "-x64";
+                installer = serverRelease.Assets.FirstOrDefault(a => a.Name.Contains(archSuffix) && a.Name.EndsWith(".exe"))
+                            ?? installer;
                 if (installer == null)
                 {
                     return false;

--- a/SoundSwitch/Framework/Updater/UpdateChecker.cs
+++ b/SoundSwitch/Framework/Updater/UpdateChecker.cs
@@ -72,11 +72,10 @@ public partial class UpdateChecker(Uri releaseUrl, bool checkBeta)
         {
             if (version > AppVersion)
             {
-                var installer = serverRelease.Assets.FirstOrDefault(asset => asset.Name.EndsWith(".exe"));
-                // Future-proof architecture matching: prefer arch-specific installer
-                var archSuffix = RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? "-arm64" : "-x64";
-                installer = serverRelease.Assets.FirstOrDefault(a => a.Name.Contains(archSuffix) && a.Name.EndsWith(".exe"))
-                            ?? installer;
+                // Future-proof architecture matching: prefer arch-specific installer, fall back to generic
+                var archSuffix = RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? "_arm64" : "_x64";
+                var installer = serverRelease.Assets.FirstOrDefault(a => a.Name.Contains(archSuffix) && a.Name.EndsWith(".exe"))
+                                ?? serverRelease.Assets.FirstOrDefault(asset => asset.Name.EndsWith(".exe"));
                 if (installer == null)
                 {
                     return false;

--- a/SoundSwitch/SoundSwitch.csproj
+++ b/SoundSwitch/SoundSwitch.csproj
@@ -6,8 +6,6 @@
     <UseWindowsForms>true</UseWindowsForms>
     <Deterministic>false</Deterministic>
     <PublishTrimmed>false</PublishTrimmed>
-    <TrimMode>link</TrimMode>
-    <PublishReadyToRun>true</PublishReadyToRun>
     <Configurations>Debug;Release;Beta;Nightly</Configurations>
     <TargetFramework>net10.0-windows</TargetFramework>
     <Platforms>AnyCPU</Platforms>

--- a/SoundSwitch/SoundSwitch.csproj
+++ b/SoundSwitch/SoundSwitch.csproj
@@ -7,7 +7,6 @@
     <Deterministic>false</Deterministic>
     <PublishTrimmed>false</PublishTrimmed>
     <TrimMode>link</TrimMode>
-    <SelfContained>true</SelfContained>
     <PublishReadyToRun>true</PublishReadyToRun>
     <Configurations>Debug;Release;Beta;Nightly</Configurations>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>

--- a/SoundSwitch/SoundSwitch.csproj
+++ b/SoundSwitch/SoundSwitch.csproj
@@ -9,7 +9,6 @@
     <TrimMode>link</TrimMode>
     <PublishReadyToRun>true</PublishReadyToRun>
     <Configurations>Debug;Release;Beta;Nightly</Configurations>
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <TargetFramework>net10.0-windows</TargetFramework>
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>

--- a/tools/Build-Installer.ps1
+++ b/tools/Build-Installer.ps1
@@ -132,9 +132,18 @@ $canSign = -not $SkipSigning -and (Get-Command 'signtool.exe' -ErrorAction Silen
 if ($canSign) {
     Write-Host "`n=== Signing binaries ===" -ForegroundColor White
 
-    $binaries = @("$projectName.exe", "$cliProject.exe") |
-        ForEach-Object { Join-Path $FinalDir $_ } |
-        Where-Object  { Test-Path $_ }
+    $dirs = @('win-x64', 'win-arm64') | ForEach-Object { Join-Path $FinalDir $_ } | Where-Object { Test-Path $_ }
+
+    if (-not $dirs) {
+        # Fallback: old flat layout
+        $dirs = @($FinalDir)
+    }
+
+    $binaries = foreach ($dir in $dirs) {
+        @("$projectName.exe", "$cliProject.exe") |
+            ForEach-Object { Join-Path $dir $_ } |
+            Where-Object { Test-Path $_ }
+    }
 
     if ($binaries) {
         & $signScript -Path $binaries -CertificateName $CertificateName

--- a/tools/Build-Installer.ps1
+++ b/tools/Build-Installer.ps1
@@ -58,7 +58,9 @@ param(
 
     [string]$CertificateName = 'OpenSource Developer, Antoine Aflalo',
 
-    [string]$InstallerReleaseState = 'Release'
+    [string]$InstallerReleaseState = 'Release',
+
+    [string]$DotNetMajorVersion = '10'
 )
 
 Set-StrictMode -Version Latest
@@ -176,8 +178,8 @@ if (-not (Test-Path $setupIss)) {
     throw "Installer\setup.iss not found at $setupIss."
 }
 
-Write-Host "  Compiling: ISCC $setupIss /DReleaseState=$InstallerReleaseState"
-& $isccExe $setupIss "/DReleaseState=$InstallerReleaseState"
+Write-Host "  Compiling: ISCC $setupIss /DReleaseState=$InstallerReleaseState /DDotNetMajorVersion=$DotNetMajorVersion"
+& $isccExe $setupIss "/DReleaseState=$InstallerReleaseState" "/DDotNetMajorVersion=$DotNetMajorVersion"
 if ($LASTEXITCODE -ne 0) {
     throw "Inno Setup compilation failed with exit code $LASTEXITCODE."
 }

--- a/tools/Build-Installer.ps1
+++ b/tools/Build-Installer.ps1
@@ -132,18 +132,9 @@ $canSign = -not $SkipSigning -and (Get-Command 'signtool.exe' -ErrorAction Silen
 if ($canSign) {
     Write-Host "`n=== Signing binaries ===" -ForegroundColor White
 
-    $dirs = @('win-x64', 'win-arm64') | ForEach-Object { Join-Path $FinalDir $_ } | Where-Object { Test-Path $_ }
-
-    if (-not $dirs) {
-        # Fallback: old flat layout
-        $dirs = @($FinalDir)
-    }
-
-    $binaries = foreach ($dir in $dirs) {
-        @("$projectName.exe", "$cliProject.exe") |
-            ForEach-Object { Join-Path $dir $_ } |
-            Where-Object { Test-Path $_ }
-    }
+    $binaries = @("$projectName.exe", "$cliProject.exe") |
+        ForEach-Object { Join-Path $FinalDir $_ } |
+        Where-Object { Test-Path $_ }
 
     if ($binaries) {
         & $signScript -Path $binaries -CertificateName $CertificateName

--- a/tools/Install-BuildTools.ps1
+++ b/tools/Install-BuildTools.ps1
@@ -79,7 +79,7 @@ function Get-DotNetSdkVersion {
 
     try {
         [xml]$project = Get-Content $CsprojPath -ErrorAction Stop
-        $framework = $project.Project.PropertyGroup.TargetFramework | Select-Object -First 1
+        $framework = $project.Project.PropertyGroup.TargetFramework | Where-Object { $_ } | Select-Object -First 1
         $match = [System.Text.RegularExpressions.Regex]::Match($framework, '^net(?<major>\d+)')
         if ($match.Success) {
             return [int]$match.Groups['major'].Value

--- a/tools/Publish-Release.ps1
+++ b/tools/Publish-Release.ps1
@@ -90,7 +90,9 @@ param(
 
     [string]$CertificateName = 'Open Source Developer Antoine Aflalo',
 
-    [string]$InstallerReleaseState
+    [string]$InstallerReleaseState,
+
+    [string]$DotNetMajorVersion
 )
 
 Set-StrictMode -Version Latest
@@ -99,6 +101,22 @@ $ErrorActionPreference = 'Stop'
 # Derive InstallerReleaseState from Channel when not explicitly provided
 if (-not $PSBoundParameters.ContainsKey('InstallerReleaseState')) {
     $InstallerReleaseState = if ($Channel -eq 'beta') { 'Beta' } else { 'Release' }
+}
+
+# Detect .NET major version from global.json if not explicitly provided
+if (-not $PSBoundParameters.ContainsKey('DotNetMajorVersion')) {
+    $globalJson = Join-Path $repoRoot 'global.json'
+    if (Test-Path $globalJson) {
+        $json = Get-Content $globalJson -Raw | ConvertFrom-Json
+        if ($json.sdk.version) {
+            # Extract major version from "10.0" -> "10"
+            $DotNetMajorVersion = ($json.sdk.version -split '\.')[0]
+            Write-Host "  Detected .NET major version: $DotNetMajorVersion (from global.json)" -ForegroundColor DarkGray
+        }
+    }
+    if (-not $DotNetMajorVersion) {
+        $DotNetMajorVersion = '10'  # fallback default
+    }
 }
 
 # ── Paths ────────────────────────────────────────────────────────────────────
@@ -225,12 +243,12 @@ if ($BuildFromSource) {
     New-Item -ItemType Directory -Path $finalDir -Force | Out-Null
 
     # Publish CLI first, then main app (main app wins on shared files)
-    # When framework-dependent, use the RuntimeIdentifier from csproj (win-x64)
+    # Framework-dependent publish: IL assemblies are architecture-agnostic
     $publishDir = $finalDir
 
     foreach ($proj in @($cliProject, $projectName)) {
         $projPath = Join-Path $repoRoot "$proj\$proj.csproj"
-        Write-Host "  Publishing $proj (win-x64) ..."
+        Write-Host "  Publishing $proj ..."
         dotnet publish -c $Configuration $projPath -o $publishDir
         if ($LASTEXITCODE -ne 0) {
             throw "dotnet publish failed for $proj with exit code $LASTEXITCODE."
@@ -360,6 +378,7 @@ $buildArgs = @{
     FinalDir              = $finalDir
     InstallerReleaseState = $InstallerReleaseState
     CertificateName       = $CertificateName
+    DotNetMajorVersion    = $DotNetMajorVersion
 }
 if ($SkipSigning) {
     $buildArgs['SkipSigning'] = $true

--- a/tools/Publish-Release.ps1
+++ b/tools/Publish-Release.ps1
@@ -225,10 +225,14 @@ if ($BuildFromSource) {
     New-Item -ItemType Directory -Path $finalDir -Force | Out-Null
 
     # Publish CLI first, then main app (main app wins on shared files)
+    # When framework-dependent, use the RuntimeIdentifier from csproj (win-x64)
+    $publishDir = Join-Path $finalDir 'win-x64'
+    New-Item -ItemType Directory -Path $publishDir -Force | Out-Null
+
     foreach ($proj in @($cliProject, $projectName)) {
         $projPath = Join-Path $repoRoot "$proj\$proj.csproj"
-        Write-Host "  Publishing $proj ..."
-        dotnet publish -c $Configuration $projPath -o $finalDir
+        Write-Host "  Publishing $proj (win-x64) ..."
+        dotnet publish -c $Configuration $projPath -o $publishDir
         if ($LASTEXITCODE -ne 0) {
             throw "dotnet publish failed for $proj with exit code $LASTEXITCODE."
         }

--- a/tools/Publish-Release.ps1
+++ b/tools/Publish-Release.ps1
@@ -98,6 +98,13 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+# ── Paths ────────────────────────────────────────────────────────────────────
+
+$repoRoot    = Split-Path $PSScriptRoot -Parent
+$finalDir    = Join-Path $repoRoot 'Final'
+$projectName = 'SoundSwitch'
+$cliProject  = 'SoundSwitch.CLI'
+
 # Derive InstallerReleaseState from Channel when not explicitly provided
 if (-not $PSBoundParameters.ContainsKey('InstallerReleaseState')) {
     $InstallerReleaseState = if ($Channel -eq 'beta') { 'Beta' } else { 'Release' }
@@ -118,13 +125,6 @@ if (-not $PSBoundParameters.ContainsKey('DotNetMajorVersion')) {
         $DotNetMajorVersion = '10'  # fallback default
     }
 }
-
-# ── Paths ────────────────────────────────────────────────────────────────────
-
-$repoRoot    = Split-Path $PSScriptRoot -Parent
-$finalDir    = Join-Path $repoRoot 'Final'
-$projectName = 'SoundSwitch'
-$cliProject  = 'SoundSwitch.CLI'
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
 

--- a/tools/Publish-Release.ps1
+++ b/tools/Publish-Release.ps1
@@ -226,8 +226,7 @@ if ($BuildFromSource) {
 
     # Publish CLI first, then main app (main app wins on shared files)
     # When framework-dependent, use the RuntimeIdentifier from csproj (win-x64)
-    $publishDir = Join-Path $finalDir 'win-x64'
-    New-Item -ItemType Directory -Path $publishDir -Force | Out-Null
+    $publishDir = $finalDir
 
     foreach ($proj in @($cliProject, $projectName)) {
         $projPath = Join-Path $repoRoot "$proj\$proj.csproj"


### PR DESCRIPTION
## Summary
- Switched from self-contained to framework-dependent publish (smaller binaries)
- CI builds both win-x64 and win-arm64 via matrix strategy across nightly, release, and test-installer workflows
- Installer packages both architectures, installs correct one via Inno Setup `Check:` directives (`IsX64` / `IsArm64`)
- .NET 10 Desktop Runtime auto-installed via winget during post-install if missing
- Auto-updater preserves backward compatibility with `FirstOrDefault` + arch-preferring fallback (`-arm64` / `-x64` installer suffix)
- Minimum OS version raised to Windows 10 1809+ (required for winget)
- `Build-Installer.ps1` and `Publish-Release.ps1` updated for arch subdirectory layout (`Final/win-x64`, `Final/win-arm64`)