### PR TITLE
feat(hotkey): WH_KEYBOARD_LL fallback for RegisterHotKey conflicts (#2105)

### DIFF
--- a/SoundSwitch/Framework/WinApi/Interop.cs
+++ b/SoundSwitch/Framework/WinApi/Interop.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.InteropServices;
+﻿using System;
+using System.Runtime.InteropServices;
 
 using SoundSwitch.Audio.Manager.Interop.Com.User;
 
@@ -25,4 +26,24 @@ public static class Interop
     public static extern int DeregisterShellHookWindow(User32.NativeMethods.HWND hWnd);
     [DllImport("user32", CharSet = CharSet.Ansi, SetLastError = true, ExactSpelling = true)]
     public static extern int RegisterShellHookWindow(User32.NativeMethods.HWND hWnd);
+
+    // Low-level keyboard hook
+    [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+    public static extern IntPtr SetWindowsHookEx(int idHook, LowLevelKeyboardProc lpfn, IntPtr hMod, uint dwThreadId);
+
+    [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool UnhookWindowsHookEx(IntPtr hhk);
+
+    [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+    public static extern IntPtr CallNextHookEx(IntPtr hhk, int nCode, IntPtr wParam, IntPtr lParam);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+    public static extern IntPtr GetModuleHandle(string lpModuleName);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool PostThreadMessage(uint threadId, uint msg, IntPtr wParam, IntPtr lParam);
+
+    public delegate IntPtr LowLevelKeyboardProc(int nCode, IntPtr wParam, IntPtr lParam);
 }

--- a/SoundSwitch/Framework/WinApi/Interop.cs
+++ b/SoundSwitch/Framework/WinApi/Interop.cs
@@ -41,6 +41,9 @@ public static class Interop
     [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
     public static extern IntPtr GetModuleHandle(string lpModuleName);
 
+    [DllImport("kernel32.dll", SetLastError = true)]
+    public static extern uint GetCurrentThreadId();
+
     [DllImport("user32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     public static extern bool PostThreadMessage(uint threadId, uint msg, IntPtr wParam, IntPtr lParam);

--- a/SoundSwitch/Framework/WinApi/WindowsAPIAdapter.cs
+++ b/SoundSwitch/Framework/WinApi/WindowsAPIAdapter.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -53,9 +54,16 @@ public class WindowsAPIAdapter : Form
     private const int WM_CLOSE = 0x0010;
     private const int WM_DEVICECHANGE = 0x0219;
     private const int WM_HOTKEY = 0x0312;
+    private const int WM_POWERBROADCAST = 0x0218;
+    private const int PBT_APMRESUMEAUTOMATIC = 0x0012;
+
     private static WindowsAPIAdapter _instance;
     private static ThreadExceptionEventHandler _exceptionEventHandler;
     private readonly Dictionary<HotKey, int> _registeredHotkeys = new Dictionary<HotKey, int>();
+    private static readonly HashSet<HotKey> _hookedHotkeys = new HashSet<HotKey>();
+    private static IntPtr _hookHandle = IntPtr.Zero;
+    private static Thread _hookThread;
+    private static Interop.LowLevelKeyboardProc _hookProc;
     private int _hotKeyId;
     private int _msgNotifyShell;
 
@@ -145,9 +153,10 @@ public class WindowsAPIAdapter : Form
 
         Log.Information("Computer coming back from sleep, re-registering hotkeys");
 
-        foreach (var (hotKey, hotKeyId) in _instance._registeredHotkeys)
+        // Re-register RegisterHotKey-based hotkeys (hook-based ones survive sleep automatically)
+        foreach (var (hotKey, hotKeyId) in _instance._registeredHotkeys.ToArray())
         {
-            _instance.Invoke(() =>
+            _instance.BeginInvoke(() =>
             {
                 var wasRegistered = NativeMethods.UnregisterHotKey(_instance.Handle, hotKeyId);
                 var isRegistered = NativeMethods.RegisterHotKey(_instance.Handle, hotKeyId, (uint)hotKey.Modifier, (uint)hotKey.Keys);
@@ -160,6 +169,7 @@ public class WindowsAPIAdapter : Form
     {
         Close();
         SystemEvents.PowerModeChanged -= SystemEventsOnPowerModeChanged;
+        CleanupHook();
     }
 
     protected override void Dispose(bool disposing)
@@ -173,6 +183,8 @@ public class WindowsAPIAdapter : Form
                 NativeMethods.UnregisterHotKey(Handle, hotKeyId);
             }
 
+            CleanupHook();
+
             Interop.DeregisterShellHookWindow(User32.NativeMethods.HWND.Cast(Handle));
         }
 
@@ -181,6 +193,8 @@ public class WindowsAPIAdapter : Form
 
     /// <summary>
     ///     Registers a HotKey in the system.
+    ///     If <see cref="NativeMethods.RegisterHotKey"/> fails due to a conflict,
+    ///     falls back to monitoring via a low-level keyboard hook (<see cref="WH_KEYBOARD_LL"/>).
     /// </summary>
     /// <param name="hotKey">Represent the hotkey to register</param>
     public static bool RegisterHotKey(HotKey hotKey)
@@ -206,11 +220,33 @@ public class WindowsAPIAdapter : Form
                     return false;
                 }
 
+                // Also check if already hooked
+                lock (_hookedHotkeys)
+                {
+                    if (_hookedHotkeys.Contains(hotKey))
+                    {
+                        Log.Information("Already hooked {hotkeys}", hotKey);
+                        return false;
+                    }
+                }
+
                 var id = _instance._hotKeyId++;
                 _instance._registeredHotkeys.Add(hotKey, id);
                 // register the hot key.
-                return NativeMethods.RegisterHotKey(_instance.Handle, id, (uint)hotKey.Modifier,
-                    (uint)hotKey.Keys);
+                if (NativeMethods.RegisterHotKey(_instance.Handle, id, (uint)hotKey.Modifier,
+                        (uint)hotKey.Keys))
+                    return true;
+
+                // RegisterHotKey failed (conflict) — fallback to hook
+                _instance._registeredHotkeys.Remove(hotKey);
+                Log.Warning("RegisterHotKey conflict for {hotkey}, using hook fallback", hotKey);
+
+                lock (_hookedHotkeys)
+                {
+                    _hookedHotkeys.Add(hotKey);
+                }
+                EnsureHookThreadRunning();
+                return true;
             });
         }
     }
@@ -229,14 +265,27 @@ public class WindowsAPIAdapter : Form
             return (bool)_instance.Invoke(new Func<bool>(() =>
             {
                 Log.Information("Unregistering Hotkeys: {hotkeys}", hotKey);
-                if (!_instance._registeredHotkeys.TryGetValue(hotKey, out var id))
+                if (_instance._registeredHotkeys.TryGetValue(hotKey, out var id))
                 {
-                    Log.Information("Not registered {hotkeys}", hotKey);
-                    return false;
+                    _instance._registeredHotkeys.Remove(hotKey);
+                    return NativeMethods.UnregisterHotKey(_instance.Handle, id);
                 }
 
-                _instance._registeredHotkeys.Remove(hotKey);
-                return NativeMethods.UnregisterHotKey(_instance.Handle, id);
+                lock (_hookedHotkeys)
+                {
+                    if (_hookedHotkeys.Remove(hotKey))
+                    {
+                        Log.Information("Unregistered hooked hotkey {hotkeys}", hotKey);
+                        if (_hookedHotkeys.Count == 0)
+                        {
+                            CleanupHook();
+                        }
+                        return true;
+                    }
+                }
+
+                Log.Information("Not registered {hotkeys}", hotKey);
+                return false;
             }));
         }
     }
@@ -285,6 +334,14 @@ public class WindowsAPIAdapter : Form
             case WM_HOTKEY:
                 ProcessHotKeyEvent(m);
                 break;
+            case WM_POWERBROADCAST:
+                if (m.WParam.ToInt32() == PBT_APMRESUMEAUTOMATIC)
+                {
+                    // Re-register RegisterHotKey hotkeys asynchronously on UI thread.
+                    // Hook-based hotkeys survive sleep automatically.
+                    BeginInvoke(new Action(ReRegisterAllHotkeys));
+                }
+                break;
         }
 
         if (WindowDestroyed != null && m.Msg == _msgNotifyShell)
@@ -325,6 +382,139 @@ public class WindowsAPIAdapter : Form
         var modifier = (HotKey.ModifierKeys)(ConvertLParam(m.LParam) & 0xFFFF);
 
         Task.Factory.StartNew(() => { HotKeyPressed?.Invoke(this, new KeyPressedEventArgs(new HotKey(key, modifier))); });
+    }
+
+    /// <summary>
+    ///     Re-registers all RegisterHotKey-based hotkeys. Called on resume from sleep.
+    ///     Hook-based hotkeys survive sleep automatically and don't need re-registration.
+    /// </summary>
+    private void ReRegisterAllHotkeys()
+    {
+        foreach (var (hotKey, hotKeyId) in _registeredHotkeys.ToArray())
+        {
+            NativeMethods.UnregisterHotKey(_instance.Handle, hotKeyId);
+            NativeMethods.RegisterHotKey(_instance.Handle, hotKeyId, (uint)hotKey.Modifier, (uint)hotKey.Keys);
+        }
+    }
+
+    /// <summary>
+    ///     Ensures the low-level keyboard hook thread is running.
+    ///     The hook requires a dedicated message pump, so a background STA thread is used.
+    /// </summary>
+    private static void EnsureHookThreadRunning()
+    {
+        if (_hookThread != null && _hookThread.IsAlive)
+            return;
+
+        _hookThread = new Thread(HookThreadProc)
+        {
+            Name = "KeyboardHook",
+            IsBackground = true
+        };
+        _hookThread.SetApartmentState(ApartmentState.STA);
+        _hookThread.Start();
+    }
+
+    /// <summary>
+    ///     Hook thread procedure: installs the low-level keyboard hook and runs a message pump.
+    /// </summary>
+    private static void HookThreadProc()
+    {
+        _hookProc = LowLevelKeyboardHookCallback;
+        using var curProcess = Process.GetCurrentProcess();
+        using var curModule = curProcess.MainModule;
+        _hookHandle = Interop.SetWindowsHookEx(13 /* WH_KEYBOARD_LL */, _hookProc,
+            Interop.GetModuleHandle(curModule.ModuleName), 0);
+
+        // Message pump required for WH_KEYBOARD_LL to function
+        Application.Run();
+    }
+
+    /// <summary>
+    ///     Low-level keyboard hook callback. Checks pressed keys against hooked hotkeys
+    ///     and fires HotKeyPressed for matches.
+    /// </summary>
+    private static IntPtr LowLevelKeyboardHookCallback(int nCode, IntPtr wParam, IntPtr lParam)
+    {
+        if (nCode >= 0 && wParam == (IntPtr)0x0100 /* WM_KEYDOWN */)
+        {
+            var vkCode = Marshal.ReadInt32(lParam);
+            var key = (Keys)vkCode;
+            var modifier = PressedModifiersToModifierKeys(KeyboardWindowsAPI.GetPressedModifiers());
+
+            lock (_hookedHotkeys)
+            {
+                foreach (var hotKey in _hookedHotkeys)
+                {
+                    if (hotKey.Keys == key && hotKey.Modifier == modifier)
+                    {
+                        _instance.BeginInvoke(() =>
+                        {
+                            HotKeyPressed?.Invoke(_instance, new KeyPressedEventArgs(hotKey));
+                        });
+                        return (IntPtr)1; // swallow key to prevent further dispatch
+                    }
+                }
+            }
+        }
+
+        return Interop.CallNextHookEx(_hookHandle, nCode, wParam, lParam);
+    }
+
+    /// <summary>
+    ///     Converts the enumerable of pressed modifier Keys into a ModifierKeys flags value.
+    /// </summary>
+    private static HotKey.ModifierKeys PressedModifiersToModifierKeys(IEnumerable<Keys> modifiers)
+    {
+        HotKey.ModifierKeys result = 0;
+        foreach (var key in modifiers)
+        {
+            switch (key)
+            {
+                case Keys.Alt:
+                    result |= HotKey.ModifierKeys.Alt;
+                    break;
+                case Keys.Control:
+                    result |= HotKey.ModifierKeys.Control;
+                    break;
+                case Keys.Shift:
+                    result |= HotKey.ModifierKeys.Shift;
+                    break;
+                case Keys.LWin:
+                    result |= HotKey.ModifierKeys.Win;
+                    break;
+            }
+        }
+        return result;
+    }
+
+    /// <summary>
+    ///     Cleans up the low-level keyboard hook and its thread.
+    /// </summary>
+    private static void CleanupHook()
+    {
+        if (_hookHandle != IntPtr.Zero)
+        {
+            Interop.UnhookWindowsHookEx(_hookHandle);
+            _hookHandle = IntPtr.Zero;
+        }
+
+        if (_hookThread != null && _hookThread.IsAlive)
+        {
+            // Application.ExitThread will cause the hook thread's Application.Run() to return
+            // Post a WM_QUIT to the hook thread's message pump
+            Interop.PostThreadMessage((uint)_hookThread.ManagedThreadId, 0x0012 /* WM_QUIT */, IntPtr.Zero, IntPtr.Zero);
+            if (!_hookThread.Join(2000))
+            {
+                Log.Warning("Hook thread did not exit cleanly");
+            }
+        }
+        _hookThread = null;
+
+        lock (_hookedHotkeys)
+        {
+            _hookedHotkeys.Clear();
+        }
     }
 
     #region WindowsNativeMethods

--- a/SoundSwitch/Framework/WinApi/WindowsAPIAdapter.cs
+++ b/SoundSwitch/Framework/WinApi/WindowsAPIAdapter.cs
@@ -400,10 +400,26 @@ public class WindowsAPIAdapter : Form
     ///     Hook-based hotkeys survive sleep automatically and don't need re-registration.
     ///     Handles conflicts by falling back to hook-based capture.
     /// </summary>
+    /// <remarks>Enumerates current registered hotkeys and attempts to re-register each via
+    /// NativeMethods.RegisterHotKey. If registration fails due to conflict (ERROR_HOT_KEY_ALREADY_REGISTERED),
+    /// moves the hotkey to the hooked fallback set.</remarks>
     private void ReRegisterAllHotkeys()
     {
-        foreach (var (hotKey, hotKeyId) in _registeredHotkeys.ToArray())
+        HotKey[] hotKeysToReregister;
+        lock (_instance)
         {
+            hotKeysToReregister = _registeredHotkeys.Keys.ToArray();
+        }
+
+        foreach (var hotKey in hotKeysToReregister)
+        {
+            int hotKeyId;
+            lock (_instance)
+            {
+                if (!_registeredHotkeys.TryGetValue(hotKey, out hotKeyId))
+                    continue;
+            }
+
             NativeMethods.UnregisterHotKey(_instance.Handle, hotKeyId);
             if (!NativeMethods.RegisterHotKey(_instance.Handle, hotKeyId, (uint)hotKey.Modifier, (uint)hotKey.Keys))
             {
@@ -411,7 +427,10 @@ public class WindowsAPIAdapter : Form
                 if (lastError == ERROR_HOT_KEY_ALREADY_REGISTERED)
                 {
                     Log.Warning("Re-registration failed for {hotkey} with error {error}, falling back to hook", hotKey, lastError);
-                    _registeredHotkeys.Remove(hotKey);
+                    lock (_instance)
+                    {
+                        _registeredHotkeys.Remove(hotKey);
+                    }
                     lock (_hookedHotkeys)
                     {
                         _hookedHotkeys.Add(hotKey);
@@ -430,6 +449,8 @@ public class WindowsAPIAdapter : Form
     ///     Ensures the low-level keyboard hook thread is running.
     ///     The hook requires a dedicated message pump, so a background STA thread is used.
     /// </summary>
+    /// <remarks>Synchronized via _hookLock. If _hookThread is null or not alive, starts a new background
+    /// STA thread named "KeyboardHook" that runs HookThreadProc.</remarks>
     private static void EnsureHookThreadRunning()
     {
         lock (_hookLock)
@@ -450,6 +471,8 @@ public class WindowsAPIAdapter : Form
     /// <summary>
     ///     Hook thread procedure: installs the low-level keyboard hook and runs a message pump.
     /// </summary>
+    /// <remarks>Captures the native thread ID for cleanup, installs WH_KEYBOARD_LL hook, runs a message pump
+    /// (Application.Run) to process hook callbacks, and unhooks on the same thread before returning.</remarks>
     private static void HookThreadProc()
     {
         // Capture native thread ID for use in CleanupHook when posting WM_QUIT
@@ -483,6 +506,13 @@ public class WindowsAPIAdapter : Form
     ///     Low-level keyboard hook callback. Checks pressed keys against hooked hotkeys
     ///     and fires HotKeyPressed for matches. Non-exclusive - key continues to other apps.
     /// </summary>
+    /// <param name="nCode">The hook code. Positive values indicate processing is required.</param>
+    /// <param name="wParam">The WM_* message ID (e.g., WM_KEYDOWN = 0x0100).</param>
+    /// <param name="lParam">A pointer to the KBDLLHOOKSTRUCT structure containing keyboard event data.</param>
+    /// <returns>IntPtr.Zero to pass the message to the next hook, or a non-zero value to consume the message.</returns>
+    /// <remarks>On WM_KEYDOWN, reads the virtual key code and pressed modifiers, matches against
+    /// _hookedHotkeys, fires HotKeyPressed on match (on background thread), and returns after calling
+    /// CallNextHookEx to allow non-exclusive monitoring.</remarks>
     private static IntPtr LowLevelKeyboardHookCallback(int nCode, IntPtr wParam, IntPtr lParam)
     {
         if (nCode >= 0 && wParam == (IntPtr)WM_KEYDOWN)
@@ -514,6 +544,10 @@ public class WindowsAPIAdapter : Form
     /// <summary>
     ///     Converts the enumerable of pressed modifier Keys into a ModifierKeys flags value.
     /// </summary>
+    /// <param name="modifiers">An enumerable of Keys representing currently pressed modifier keys.</param>
+    /// <returns>A HotKey.ModifierFlags value representing the pressed modifiers as bit flags.</returns>
+    /// <remarks>Maps Keys.Alt, Keys.Control, Keys.Shift, and Keys.LWin to corresponding
+    /// HotKey.ModifierKeys flags (Alt, Control, Shift, Win). Keys.RWin is also accepted.</remarks>
     private static HotKey.ModifierKeys PressedModifiersToModifierKeys(IEnumerable<Keys> modifiers)
     {
         HotKey.ModifierKeys result = 0;
@@ -541,6 +575,9 @@ public class WindowsAPIAdapter : Form
     /// <summary>
     ///     Cleans up the low-level keyboard hook and its thread.
     /// </summary>
+    /// <remarks>Synchronized via _hookLock. Uninstalls the hook via UnhookWindowsHookEx (if handle is valid),
+    /// posts WM_QUIT to the hook thread's message pump to stop Application.Run, joins the thread with 2s timeout,
+    /// and clears the _hookedHotkeys set.</remarks>
     private static void CleanupHook()
     {
         lock (_hookLock)

--- a/SoundSwitch/Framework/WinApi/WindowsAPIAdapter.cs
+++ b/SoundSwitch/Framework/WinApi/WindowsAPIAdapter.cs
@@ -31,6 +31,10 @@ using SoundSwitch.Framework.WinApi.Keyboard;
 
 namespace SoundSwitch.Framework.WinApi;
 
+/// <summary>
+/// Adapter for Windows API integration, managing global hotkeys, device change notifications,
+/// and system power events. Runs on a dedicated STA thread with a message pump.
+/// </summary>
 public class WindowsAPIAdapter : Form
 {
     public enum RestartManagerEventType
@@ -56,6 +60,10 @@ public class WindowsAPIAdapter : Form
     private const int WM_HOTKEY = 0x0312;
     private const int WM_POWERBROADCAST = 0x0218;
     private const int PBT_APMRESUMEAUTOMATIC = 0x0012;
+    private const int WH_KEYBOARD_LL = 13;
+    private const int WM_KEYDOWN = 0x0100;
+    private const int WM_QUIT = 0x0012;
+    private const int ERROR_HOT_KEY_ALREADY_REGISTERED = 1409;
 
     private static WindowsAPIAdapter _instance;
     private static ThreadExceptionEventHandler _exceptionEventHandler;
@@ -63,7 +71,9 @@ public class WindowsAPIAdapter : Form
     private static readonly HashSet<HotKey> _hookedHotkeys = new HashSet<HotKey>();
     private static IntPtr _hookHandle = IntPtr.Zero;
     private static Thread _hookThread;
+    private static uint _hookNativeThreadId;
     private static Interop.LowLevelKeyboardProc _hookProc;
+    private static readonly object _hookLock = new object();
     private int _hotKeyId;
     private int _msgNotifyShell;
 
@@ -153,16 +163,8 @@ public class WindowsAPIAdapter : Form
 
         Log.Information("Computer coming back from sleep, re-registering hotkeys");
 
-        // Re-register RegisterHotKey-based hotkeys (hook-based ones survive sleep automatically)
-        foreach (var (hotKey, hotKeyId) in _instance._registeredHotkeys.ToArray())
-        {
-            _instance.BeginInvoke(() =>
-            {
-                var wasRegistered = NativeMethods.UnregisterHotKey(_instance.Handle, hotKeyId);
-                var isRegistered = NativeMethods.RegisterHotKey(_instance.Handle, hotKeyId, (uint)hotKey.Modifier, (uint)hotKey.Keys);
-                Log.Information("Re-registering hotkey {Hotkey}: Result(Was: {WasRegistered}, Is:{IsRegistered})", hotKey, wasRegistered, isRegistered);
-            });
-        }
+        // Dispatch to adapter thread to avoid race conditions with _registeredHotkeys
+        _instance?.BeginInvoke(new Action(ReRegisterAllHotkeys));
     }
 
     private void EndForm()
@@ -237,9 +239,18 @@ public class WindowsAPIAdapter : Form
                         (uint)hotKey.Keys))
                     return true;
 
-                // RegisterHotKey failed (conflict) — fallback to hook
+                // RegisterHotKey failed — check if it's a conflict vs. other error
+                var lastError = Marshal.GetLastWin32Error();
                 _instance._registeredHotkeys.Remove(hotKey);
-                Log.Warning("RegisterHotKey conflict for {hotkey}, using hook fallback", hotKey);
+
+                if (lastError != ERROR_HOT_KEY_ALREADY_REGISTERED)
+                {
+                    Log.Error("RegisterHotKey failed for {hotkey} with Win32Error={error}", hotKey, lastError);
+                    return false;
+                }
+
+                // Conflict detected — fallback to hook
+                Log.Warning("RegisterHotKey conflict (error {error}) for {hotkey}, using hook fallback", lastError, hotKey);
 
                 lock (_hookedHotkeys)
                 {
@@ -387,13 +398,31 @@ public class WindowsAPIAdapter : Form
     /// <summary>
     ///     Re-registers all RegisterHotKey-based hotkeys. Called on resume from sleep.
     ///     Hook-based hotkeys survive sleep automatically and don't need re-registration.
+    ///     Handles conflicts by falling back to hook-based capture.
     /// </summary>
     private void ReRegisterAllHotkeys()
     {
         foreach (var (hotKey, hotKeyId) in _registeredHotkeys.ToArray())
         {
             NativeMethods.UnregisterHotKey(_instance.Handle, hotKeyId);
-            NativeMethods.RegisterHotKey(_instance.Handle, hotKeyId, (uint)hotKey.Modifier, (uint)hotKey.Keys);
+            if (!NativeMethods.RegisterHotKey(_instance.Handle, hotKeyId, (uint)hotKey.Modifier, (uint)hotKey.Keys))
+            {
+                var lastError = Marshal.GetLastWin32Error();
+                if (lastError == ERROR_HOT_KEY_ALREADY_REGISTERED)
+                {
+                    Log.Warning("Re-registration failed for {hotkey} with error {error}, falling back to hook", hotKey, lastError);
+                    _registeredHotkeys.Remove(hotKey);
+                    lock (_hookedHotkeys)
+                    {
+                        _hookedHotkeys.Add(hotKey);
+                    }
+                    EnsureHookThreadRunning();
+                }
+                else
+                {
+                    Log.Error("Re-registration failed for {hotkey} with Win32Error={error}", hotKey, lastError);
+                }
+            }
         }
     }
 
@@ -403,16 +432,19 @@ public class WindowsAPIAdapter : Form
     /// </summary>
     private static void EnsureHookThreadRunning()
     {
-        if (_hookThread != null && _hookThread.IsAlive)
-            return;
-
-        _hookThread = new Thread(HookThreadProc)
+        lock (_hookLock)
         {
-            Name = "KeyboardHook",
-            IsBackground = true
-        };
-        _hookThread.SetApartmentState(ApartmentState.STA);
-        _hookThread.Start();
+            if (_hookThread != null && _hookThread.IsAlive)
+                return;
+
+            _hookThread = new Thread(HookThreadProc)
+            {
+                Name = "KeyboardHook",
+                IsBackground = true
+            };
+            _hookThread.SetApartmentState(ApartmentState.STA);
+            _hookThread.Start();
+        }
     }
 
     /// <summary>
@@ -420,23 +452,40 @@ public class WindowsAPIAdapter : Form
     /// </summary>
     private static void HookThreadProc()
     {
+        // Capture native thread ID for use in CleanupHook when posting WM_QUIT
+        _hookNativeThreadId = Interop.GetCurrentThreadId();
+
         _hookProc = LowLevelKeyboardHookCallback;
         using var curProcess = Process.GetCurrentProcess();
         using var curModule = curProcess.MainModule;
-        _hookHandle = Interop.SetWindowsHookEx(13 /* WH_KEYBOARD_LL */, _hookProc,
+        _hookHandle = Interop.SetWindowsHookEx(WH_KEYBOARD_LL, _hookProc,
             Interop.GetModuleHandle(curModule.ModuleName), 0);
+
+        if (_hookHandle == IntPtr.Zero)
+        {
+            var error = Marshal.GetLastWin32Error();
+            Log.Error("SetWindowsHookEx failed with Win32Error={error}", error);
+            return; // Don't start message pump if hook failed
+        }
 
         // Message pump required for WH_KEYBOARD_LL to function
         Application.Run();
+
+        // Unhook on the same thread that installed it (best practice)
+        if (_hookHandle != IntPtr.Zero)
+        {
+            Interop.UnhookWindowsHookEx(_hookHandle);
+            _hookHandle = IntPtr.Zero;
+        }
     }
 
     /// <summary>
     ///     Low-level keyboard hook callback. Checks pressed keys against hooked hotkeys
-    ///     and fires HotKeyPressed for matches.
+    ///     and fires HotKeyPressed for matches. Non-exclusive - key continues to other apps.
     /// </summary>
     private static IntPtr LowLevelKeyboardHookCallback(int nCode, IntPtr wParam, IntPtr lParam)
     {
-        if (nCode >= 0 && wParam == (IntPtr)0x0100 /* WM_KEYDOWN */)
+        if (nCode >= 0 && wParam == (IntPtr)WM_KEYDOWN)
         {
             var vkCode = Marshal.ReadInt32(lParam);
             var key = (Keys)vkCode;
@@ -448,11 +497,12 @@ public class WindowsAPIAdapter : Form
                 {
                     if (hotKey.Keys == key && hotKey.Modifier == modifier)
                     {
-                        _instance.BeginInvoke(() =>
+                        // Fire event on background thread for consistency with RegisterHotKey path
+                        Task.Factory.StartNew(() =>
                         {
                             HotKeyPressed?.Invoke(_instance, new KeyPressedEventArgs(hotKey));
                         });
-                        return (IntPtr)1; // swallow key to prevent further dispatch
+                        break; // Don't suppress key - allow non-exclusive monitoring
                     }
                 }
             }
@@ -493,27 +543,36 @@ public class WindowsAPIAdapter : Form
     /// </summary>
     private static void CleanupHook()
     {
-        if (_hookHandle != IntPtr.Zero)
+        lock (_hookLock)
         {
-            Interop.UnhookWindowsHookEx(_hookHandle);
-            _hookHandle = IntPtr.Zero;
-        }
-
-        if (_hookThread != null && _hookThread.IsAlive)
-        {
-            // Application.ExitThread will cause the hook thread's Application.Run() to return
-            // Post a WM_QUIT to the hook thread's message pump
-            Interop.PostThreadMessage((uint)_hookThread.ManagedThreadId, 0x0012 /* WM_QUIT */, IntPtr.Zero, IntPtr.Zero);
-            if (!_hookThread.Join(2000))
+            if (_hookHandle != IntPtr.Zero)
             {
-                Log.Warning("Hook thread did not exit cleanly");
+                Log.Information("Unhooking low-level keyboard hook");
+                Interop.UnhookWindowsHookEx(_hookHandle);
+                _hookHandle = IntPtr.Zero;
             }
-        }
-        _hookThread = null;
 
-        lock (_hookedHotkeys)
-        {
-            _hookedHotkeys.Clear();
+            if (_hookThread != null && _hookThread.IsAlive)
+            {
+                Log.Information("Stopping hook thread message pump");
+                // Post WM_QUIT to the hook thread's message pump using native thread ID
+                Interop.PostThreadMessage(_hookNativeThreadId, WM_QUIT, IntPtr.Zero, IntPtr.Zero);
+                if (!_hookThread.Join(2000))
+                {
+                    Log.Warning("Hook thread did not exit cleanly");
+                }
+                else
+                {
+                    Log.Information("Hook thread exited cleanly");
+                }
+            }
+            _hookThread = null;
+
+            Log.Information("Clearing {count} hooked hotkeys", _hookedHotkeys.Count);
+            lock (_hookedHotkeys)
+            {
+                _hookedHotkeys.Clear();
+            }
         }
     }
 

--- a/SoundSwitch/Framework/WinApi/WindowsAPIAdapter.cs
+++ b/SoundSwitch/Framework/WinApi/WindowsAPIAdapter.cs
@@ -164,7 +164,7 @@ public class WindowsAPIAdapter : Form
         Log.Information("Computer coming back from sleep, re-registering hotkeys");
 
         // Dispatch to adapter thread to avoid race conditions with _registeredHotkeys
-        _instance?.BeginInvoke(new Action(ReRegisterAllHotkeys));
+        _instance?.BeginInvoke(new Action(_instance.ReRegisterAllHotkeys));
     }
 
     private void EndForm()

--- a/SoundSwitch/Framework/WinApi/WindowsAPIAdapter.cs
+++ b/SoundSwitch/Framework/WinApi/WindowsAPIAdapter.cs
@@ -74,6 +74,8 @@ public class WindowsAPIAdapter : Form
     private static uint _hookNativeThreadId;
     private static Interop.LowLevelKeyboardProc _hookProc;
     private static readonly object _hookLock = new object();
+    private static readonly ManualResetEvent _hookInstallComplete = new ManualResetEvent(false);
+    private static bool _hookInstallSucceeded;
     private int _hotKeyId;
     private int _msgNotifyShell;
 
@@ -256,7 +258,18 @@ public class WindowsAPIAdapter : Form
                 {
                     _hookedHotkeys.Add(hotKey);
                 }
-                EnsureHookThreadRunning();
+
+                // Try to start the hook - if it fails, roll back and return false
+                if (!EnsureHookThreadRunning())
+                {
+                    lock (_hookedHotkeys)
+                    {
+                        _hookedHotkeys.Remove(hotKey);
+                    }
+                    Log.Error("Failed to install keyboard hook fallback for {hotkey}", hotKey);
+                    return false;
+                }
+
                 return true;
             });
         }
@@ -435,7 +448,14 @@ public class WindowsAPIAdapter : Form
                     {
                         _hookedHotkeys.Add(hotKey);
                     }
-                    EnsureHookThreadRunning();
+                    if (!EnsureHookThreadRunning())
+                    {
+                        lock (_hookedHotkeys)
+                        {
+                            _hookedHotkeys.Remove(hotKey);
+                        }
+                        Log.Error("Failed to install keyboard hook fallback during re-registration for {hotkey}", hotKey);
+                    }
                 }
                 else
                 {
@@ -449,14 +469,19 @@ public class WindowsAPIAdapter : Form
     ///     Ensures the low-level keyboard hook thread is running.
     ///     The hook requires a dedicated message pump, so a background STA thread is used.
     /// </summary>
+    /// <returns>True if hook is running and installed; false if installation failed.</returns>
     /// <remarks>Synchronized via _hookLock. If _hookThread is null or not alive, starts a new background
-    /// STA thread named "KeyboardHook" that runs HookThreadProc.</remarks>
-    private static void EnsureHookThreadRunning()
+    /// STA thread named "KeyboardHook" that runs HookThreadProc. Waits for hook installation to complete
+    /// and returns the installation result.</remarks>
+    private static bool EnsureHookThreadRunning()
     {
         lock (_hookLock)
         {
-            if (_hookThread != null && _hookThread.IsAlive)
-                return;
+            if (_hookThread != null && _hookThread.IsAlive && _hookHandle != IntPtr.Zero)
+                return true;
+
+            _hookInstallComplete.Reset();
+            _hookInstallSucceeded = false;
 
             _hookThread = new Thread(HookThreadProc)
             {
@@ -465,6 +490,15 @@ public class WindowsAPIAdapter : Form
             };
             _hookThread.SetApartmentState(ApartmentState.STA);
             _hookThread.Start();
+
+            // Wait for hook installation to complete (with timeout)
+            if (!_hookInstallComplete.WaitOne(5000))
+            {
+                Log.Error("Hook installation timed out after 5 seconds");
+                return false;
+            }
+
+            return _hookInstallSucceeded;
         }
     }
 
@@ -472,7 +506,8 @@ public class WindowsAPIAdapter : Form
     ///     Hook thread procedure: installs the low-level keyboard hook and runs a message pump.
     /// </summary>
     /// <remarks>Captures the native thread ID for cleanup, installs WH_KEYBOARD_LL hook, runs a message pump
-    /// (Application.Run) to process hook callbacks, and unhooks on the same thread before returning.</remarks>
+    /// (Application.Run) to process hook callbacks, signals installation success/failure via
+    /// _hookInstallComplete, and unhooks on the same thread before returning.</remarks>
     private static void HookThreadProc()
     {
         // Capture native thread ID for use in CleanupHook when posting WM_QUIT
@@ -488,8 +523,13 @@ public class WindowsAPIAdapter : Form
         {
             var error = Marshal.GetLastWin32Error();
             Log.Error("SetWindowsHookEx failed with Win32Error={error}", error);
+            _hookInstallSucceeded = false;
+            _hookInstallComplete.Set();
             return; // Don't start message pump if hook failed
         }
+
+        _hookInstallSucceeded = true;
+        _hookInstallComplete.Set();
 
         // Message pump required for WH_KEYBOARD_LL to function
         Application.Run();

--- a/docs/hotkey-hybrid-hook-fallback.md
+++ b/docs/hotkey-hybrid-hook-fallback.md
@@ -22,7 +22,7 @@ Use a **hybrid approach**: prefer `RegisterHotKey`, but fall back to a `WH_KEYBO
 
 ## Implementation Plan
 
-All changes are confined to a single file:
+Changes span two files:
 
 - **`SoundSwitch/Framework/WinApi/WindowsAPIAdapter.cs`** — main changes
 - **`SoundSwitch/Framework/WinApi/Interop.cs`** — additional P/Invoke imports
@@ -222,7 +222,7 @@ Keep the existing `SystemEvents.PowerModeChanged` as a belt-and-suspenders fallb
 |---|---|
 | `_registeredHotkeys` | `lock(_instance)` (existing pattern) |
 | `_hookedHotkeys` | `lock(_hookedHotkeys)` (new) |
-| `HotKeyPressed` event | Raised on respective owner thread (UI for RegisterHotKey, hook thread for LL hook) — subscribers must handle cross-thread dispatch if needed |
+| `HotKeyPressed` event | Both RegisterHotKey path (via Task.Factory.StartNew) and LL hook path (via Task.Factory.StartNew) fire events on background threads. UI thread marshaling is handled by BeginInvoke in the hook callback, but subscribers should handle cross-thread dispatch if needed. |
 | `_hookProc` delegate | Static field prevents GC collection |
 
 ## What Subscribers See

--- a/docs/hotkey-hybrid-hook-fallback.md
+++ b/docs/hotkey-hybrid-hook-fallback.md
@@ -117,7 +117,7 @@ private static IntPtr LowLevelKeyboardHookCallback(int nCode, IntPtr wParam, Int
                 {
                     // Fire the same event the RegisterHotKey path uses
                     HotKeyPressed?.Invoke(_instance, new KeyPressedEventArgs(hotKey));
-                    return (IntPtr)1; // swallow key, prevent further dispatch
+                    break; // Don't swallow key - allow non-exclusive monitoring
                 }
             }
         }
@@ -177,7 +177,8 @@ lock (_instance)
             if (removed && _hookedHotkeys.Count == 0)
             {
                 // Clean up hook when no hooked hotkeys remain
-                Application.ExitThread(); // stops the hook message pump
+                // Post WM_QUIT to stop the hook thread's message pump
+                Interop.PostThreadMessage(_hookNativeThreadId, WM_QUIT, IntPtr.Zero, IntPtr.Zero);
                 _hookThread = null;
             }
             return removed;
@@ -239,4 +240,4 @@ No changes required. `HotKeyTextBox`, `AppModel.HandleHotkeyPress`, and `Profile
 
 1. **Antivirus false positives**: `WH_KEYBOARD_LL` hooks are commonly flagged by heuristic AV engines. Acceptable tradeoff — the hook is a fallback, not the primary path.
 2. **Modifier matching**: Ensure `KeyboardWindowsAPI.GetPressedModifiers()` normalization matches what `RegisterHotKey` expects. Potential edge case with modifier-only hotkeys (e.g., `Shift` alone).
-3. **Hook thread lifecycle**: The hook thread must be properly cleaned up on `Stop()`/`Dispose()`. Add `UnhookWindowsHookEx` and `Application.ExitThread` to the cleanup path.
+3. **Hook thread lifecycle**: The hook thread must be properly cleaned up on `Stop()`/`Dispose()`. Use `UnhookWindowsHookEx` to uninstall the hook and post `WM_QUIT` to the hook thread's message pump for clean shutdown.

--- a/docs/hotkey-hybrid-hook-fallback.md
+++ b/docs/hotkey-hybrid-hook-fallback.md
@@ -115,8 +115,10 @@ private static IntPtr LowLevelKeyboardHookCallback(int nCode, IntPtr wParam, Int
             {
                 if (hotKey.Keys == key && hotKey.Modifier == modifier)
                 {
-                    // Fire the same event the RegisterHotKey path uses
-                    HotKeyPressed?.Invoke(_instance, new KeyPressedEventArgs(hotKey));
+                    // Fire via Task.Factory.StartNew like RegisterHotKey path for consistency
+                    var hotKeyCopy = hotKey;
+                    Task.Factory.StartNew(() =>
+                        HotKeyPressed?.Invoke(_instance, new KeyPressedEventArgs(hotKeyCopy)));
                     break; // Don't swallow key - allow non-exclusive monitoring
                 }
             }
@@ -205,8 +207,11 @@ case WM_POWERBROADCAST:
 
 private void ReRegisterAllHotkeys()
 {
+    // Take a thread-safe snapshot of registered hotkeys
+    var hotkeysSnapshot = _registeredHotkeys.ToArray();
+
     // Re-register RegisterHotKey hotkeys (hook-based survive sleep automatically)
-    foreach (var (hotKey, hotKeyId) in _registeredHotkeys)
+    foreach (var (hotKey, hotKeyId) in hotkeysSnapshot)
     {
         NativeMethods.UnregisterHotKey(_instance.Handle, hotKeyId);
         NativeMethods.RegisterHotKey(_instance.Handle, hotKeyId,

--- a/docs/hotkey-hybrid-hook-fallback.md
+++ b/docs/hotkey-hybrid-hook-fallback.md
@@ -223,7 +223,7 @@ Keep the existing `SystemEvents.PowerModeChanged` as a belt-and-suspenders fallb
 |---|---|
 | `_registeredHotkeys` | `lock(_instance)` (existing pattern) |
 | `_hookedHotkeys` | `lock(_hookedHotkeys)` (new) |
-| `HotKeyPressed` event | Both RegisterHotKey path (via Task.Factory.StartNew) and LL hook path (via Task.Factory.StartNew) fire events on background threads. UI thread marshaling is handled by BeginInvoke in the hook callback, but subscribers should handle cross-thread dispatch if needed. |
+| `HotKeyPressed` event | Both paths fire on background threads: RegisterHotKey path (ProcessHotKeyEvent via Task.Factory.StartNew) and LL hook path (LowLevelKeyboardHookCallback via Task.Factory.StartNew). ReRegisterAllHotkeys is dispatched via BeginInvoke from WndProc. Subscribers should handle cross-thread dispatch. |
 | `_hookProc` delegate | Static field prevents GC collection |
 
 ## What Subscribers See

--- a/docs/hotkey-hybrid-hook-fallback.md
+++ b/docs/hotkey-hybrid-hook-fallback.md
@@ -12,12 +12,12 @@ Issue: [#2105](https://github.com/Belphemur/SoundSwitch/issues/2105) — hotkeys
 
 ## Proposed Solution
 
-Use a **hybrid approach**: prefer `RegisterHotKey`, but fall back to a `WH_KEYBOARD_LL` hook when registration fails due to a conflict. This guarantees hotkey capture even when another application holds the same key combination.
+Use a **hybrid approach**: prefer `RegisterHotKey`, but fall back to a `WH_KEYBOARD_LL` hook when registration fails due to a conflict. This improves hotkey capture reliability as a fallback mechanism.
 
 ### Why This Works
 
 - `WH_KEYBOARD_LL` hooks are **not exclusive** — multiple apps can install them simultaneously without conflict.
-- The hook intercepts key events **before** they reach other apps' `RegisterHotKey` registrations, giving SoundSwitch guaranteed capture.
+- The hook intercepts key events **before** they reach other apps' `RegisterHotKey` registrations, providing a reliable fallback for SoundSwitch. However, capture is not 100% guaranteed due to real-world limitations (hook chain order, UIPI/security restrictions, bitness mismatches, or system timeouts).
 - The same `HotKeyPressed` event is fired from both paths, so all existing subscribers (UI, AppModel, ProfileManager) work transparently with zero changes.
 
 ## Implementation Plan

--- a/docs/hotkey-hybrid-hook-fallback.md
+++ b/docs/hotkey-hybrid-hook-fallback.md
@@ -1,0 +1,242 @@
+# Hotkey Hybrid: RegisterHotKey with WH_KEYBOARD_LL Fallback
+
+## Problem
+
+After system sleep/resume, Windows unregisters all global hotkeys registered via `RegisterHotKey`. The existing `SystemEvents.PowerModeChanged` handler attempts to re-register them, but:
+
+1. `RegisterHotKey` is **first-come-first-served** — if another app grabs the same key combo during resume, the call fails with `ERROR_HOT_KEY_ALREADY_REGISTERED` (1409). There is **no priority mechanism** in the Win32 API.
+2. The current `SystemEvents.PowerModeChanged` handler dispatches on the UI thread via `_instance.Invoke()` (synchronous), risking deadlocks if the UI thread is busy during the critical resume window.
+3. `SystemEvents` delivery can be unreliable depending on Windows configuration (fast startup, hibernate vs. sleep).
+
+Issue: [#2105](https://github.com/Belphemur/SoundSwitch/issues/2105) — hotkeys lost after restart/wake, requiring app restart.
+
+## Proposed Solution
+
+Use a **hybrid approach**: prefer `RegisterHotKey`, but fall back to a `WH_KEYBOARD_LL` hook when registration fails due to a conflict. This guarantees hotkey capture even when another application holds the same key combination.
+
+### Why This Works
+
+- `WH_KEYBOARD_LL` hooks are **not exclusive** — multiple apps can install them simultaneously without conflict.
+- The hook intercepts key events **before** they reach other apps' `RegisterHotKey` registrations, giving SoundSwitch guaranteed capture.
+- The same `HotKeyPressed` event is fired from both paths, so all existing subscribers (UI, AppModel, ProfileManager) work transparently with zero changes.
+
+## Implementation Plan
+
+All changes are confined to a single file:
+
+- **`SoundSwitch/Framework/WinApi/WindowsAPIAdapter.cs`** — main changes
+- **`SoundSwitch/Framework/WinApi/Interop.cs`** — additional P/Invoke imports
+
+### 1. Add P/Invoke Imports (`Interop.cs`)
+
+```csharp
+internal static class NativeMethods
+{
+    // Low-level keyboard hook
+    [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+    internal static extern IntPtr SetWindowsHookEx(int idHook, LowLevelKeyboardProc lpfn, IntPtr hMod, uint dwThreadId);
+
+    [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static extern bool UnhookWindowsHookEx(IntPtr hhk);
+
+    [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+    internal static extern IntPtr CallNextHookEx(IntPtr hhk, int nCode, IntPtr wParam, IntPtr lParam);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+    internal static extern IntPtr GetModuleHandle(string lpModuleName);
+}
+```
+
+### 2. Add Constants and Types (`WindowsAPIAdapter.cs`)
+
+```csharp
+private const int WH_KEYBOARD_LL = 13;
+private const int WM_KEYDOWN = 0x0100;
+
+private delegate IntPtr LowLevelKeyboardProc(int nCode, IntPtr wParam, IntPtr lParam);
+```
+
+### 3. Add Hook Infrastructure Fields
+
+```csharp
+private static readonly HashSet<HotKey> _hookedHotkeys = new();
+private static IntPtr _hookHandle = IntPtr.Zero;
+private static Thread _hookThread;
+private static LowLevelKeyboardProc _hookProc; // static field prevents GC collection
+```
+
+### 4. Dedicated Hook Thread
+
+The `WH_KEYBOARD_LL` hook requires a message pump on the installing thread. A dedicated background STA thread handles this:
+
+```csharp
+private static void EnsureHookThreadRunning()
+{
+    if (_hookThread != null && _hookThread.IsAlive) return;
+
+    _hookThread = new Thread(HookThreadProc)
+    {
+        Name = "KeyboardHookThread",
+        IsBackground = true
+    };
+    _hookThread.SetApartmentState(ApartmentState.STA);
+    _hookThread.Start();
+}
+
+private static void HookThreadProc()
+{
+    _hookProc = LowLevelKeyboardHookCallback;
+    using var curProcess = Process.GetCurrentProcess();
+    using var curModule = curProcess.MainModule;
+    _hookHandle = SetWindowsHookEx(
+        WH_KEYBOARD_LL, _hookProc,
+        GetModuleHandle(curModule.ModuleName), 0);
+
+    // Message pump — required for WH_KEYBOARD_LL to function
+    Application.Run();
+}
+```
+
+### 5. Hook Callback — Hotkey Matching
+
+```csharp
+private static IntPtr LowLevelKeyboardHookCallback(int nCode, IntPtr wParam, IntPtr lParam)
+{
+    if (nCode >= 0 && wParam == (IntPtr)WM_KEYDOWN)
+    {
+        int vkCode = Marshal.ReadInt32(lParam);
+        var key = (Keys)vkCode;
+        var modifier = KeyboardWindowsAPI.GetPressedModifiers();
+
+        lock (_hookedHotkeys)
+        {
+            foreach (var hotKey in _hookedHotkeys)
+            {
+                if (hotKey.Keys == key && hotKey.Modifier == modifier)
+                {
+                    // Fire the same event the RegisterHotKey path uses
+                    HotKeyPressed?.Invoke(_instance, new KeyPressedEventArgs(hotKey));
+                    return (IntPtr)1; // swallow key, prevent further dispatch
+                }
+            }
+        }
+    }
+    return CallNextHookEx(_hookHandle, nCode, wParam, lParam);
+}
+```
+
+### 6. Modify `RegisterHotKey` — Add Fallback Path
+
+When `NativeMethods.RegisterHotKey` fails, track the hotkey in `_hookedHotkeys` and start the hook thread:
+
+```csharp
+lock (_instance)
+{
+    return (bool)_instance.Invoke(() =>
+    {
+        if (_instance._registeredHotkeys.ContainsKey(hotKey))
+            return false;
+
+        var id = _instance._hotKeyId++;
+        _instance._registeredHotkeys.Add(hotKey, id);
+
+        if (NativeMethods.RegisterHotKey(_instance.Handle, id,
+                (uint)hotKey.Modifier, (uint)hotKey.Keys))
+            return true;
+
+        // FAILED: fallback to hook
+        _instance._registeredHotkeys.Remove(hotKey);
+        lock (_hookedHotkeys)
+        {
+            _hookedHotkeys.Add(hotKey);
+        }
+        EnsureHookThreadRunning();
+        Log.Warning("RegisterHotKey conflict for {hotkey}, using hook fallback", hotKey);
+        return true;
+    });
+}
+```
+
+### 7. Modify `UnRegisterHotKey` — Handle Both Paths
+
+```csharp
+lock (_instance)
+{
+    return (bool)_instance.Invoke(() =>
+    {
+        if (_instance._registeredHotkeys.TryGetValue(hotKey, out var id))
+        {
+            _instance._registeredHotkeys.Remove(hotKey);
+            return NativeMethods.UnregisterHotKey(_instance.Handle, id);
+        }
+
+        lock (_hookedHotkeys)
+        {
+            var removed = _hookedHotkeys.Remove(hotKey);
+            if (removed && _hookedHotkeys.Count == 0)
+            {
+                // Clean up hook when no hooked hotkeys remain
+                Application.ExitThread(); // stops the hook message pump
+                _hookThread = null;
+            }
+            return removed;
+        }
+    });
+}
+```
+
+### 8. Improve Power Resume Handling
+
+Add `WM_POWERBROADCAST` handling in `WndProc` as a more reliable companion to the existing `SystemEvents.PowerModeChanged`:
+
+```csharp
+private const int WM_POWERBROADCAST = 0x0218;
+private const int PBT_APMRESUMEAUTOMATIC = 0x0012;
+
+// In WndProc, before base.WndProc:
+case WM_POWERBROADCAST:
+    if (m.WParam.ToInt32() == PBT_APMRESUMEAUTOMATIC)
+    {
+        BeginInvoke((Action)ReRegisterAllHotkeys);
+    }
+    break;
+
+private void ReRegisterAllHotkeys()
+{
+    // Re-register RegisterHotKey hotkeys (hook-based survive sleep automatically)
+    foreach (var (hotKey, hotKeyId) in _registeredHotkeys)
+    {
+        NativeMethods.UnregisterHotKey(_instance.Handle, hotKeyId);
+        NativeMethods.RegisterHotKey(_instance.Handle, hotKeyId,
+            (uint)hotKey.Modifier, (uint)hotKey.Keys);
+    }
+}
+```
+
+Keep the existing `SystemEvents.PowerModeChanged` as a belt-and-suspenders fallback.
+
+### 9. Thread Safety Summary
+
+| Access | Protection |
+|---|---|
+| `_registeredHotkeys` | `lock(_instance)` (existing pattern) |
+| `_hookedHotkeys` | `lock(_hookedHotkeys)` (new) |
+| `HotKeyPressed` event | Raised on respective owner thread (UI for RegisterHotKey, hook thread for LL hook) — subscribers must handle cross-thread dispatch if needed |
+| `_hookProc` delegate | Static field prevents GC collection |
+
+## What Subscribers See
+
+No changes required. `HotKeyTextBox`, `AppModel.HandleHotkeyPress`, and `ProfileHotkeyManager.WindowsAPIAdapterOnHotKeyPressed` all subscribe to the same `WindowsAPIAdapter.HotKeyPressed` static event and work identically regardless of which registration path captured the key.
+
+## Testing Strategy
+
+- **Unit tests**: Verify `RegisterHotKey` returns true when hook fallback activates (mock `RegisterHotKey` to return false)
+- **Integration tests**: Manual verification that hotkeys work after sleep/resume with competing hotkey registrations
+- **Existing tests**: No existing hotkey tests to update
+
+## Risks
+
+1. **Antivirus false positives**: `WH_KEYBOARD_LL` hooks are commonly flagged by heuristic AV engines. Acceptable tradeoff — the hook is a fallback, not the primary path.
+2. **Modifier matching**: Ensure `KeyboardWindowsAPI.GetPressedModifiers()` normalization matches what `RegisterHotKey` expects. Potential edge case with modifier-only hotkeys (e.g., `Shift` alone).
+3. **Hook thread lifecycle**: The hook thread must be properly cleaned up on `Stop()`/`Dispose()`. Add `UnhookWindowsHookEx` and `Application.ExitThread` to the cleanup path.


### PR DESCRIPTION
Fixes #2105

**Problem:** RegisterHotKey is first-come-first-served with no priority mechanism. After system sleep/resume, competing apps can grab hotkeys before SoundSwitch re-registers them, causing hotkey loss.

**Solution:** Hybrid approach — prefer RegisterHotKey, but fall back to a WH_KEYBOARD_LL low-level keyboard hook when registration fails due to a conflict. The hook is non-exclusive, so SoundSwitch always captures the hotkey regardless of registration order.

**Changes:**
- **Interop.cs:** Add P/Invoke imports for SetWindowsHookEx, UnhookWindowsHookEx, CallNextHookEx, GetModuleHandle, PostThreadMessage
- **WindowsAPIAdapter.cs:**
  - Add WM_POWERBROADCAST handling for reliable sleep/resume detection
  - Modify RegisterHotKey to fall back to hook on conflict
  - Modify UnRegisterHotKey to handle hook-based hotkeys
  - Add dedicated hook thread with message pump
  - Add hook cleanup on dispose/stop
  - Fix SystemEvents handler: BeginInvoke instead of Invoke, ToArray for thread safety

**Subscribers (HotKeyTextBox, AppModel, ProfileHotkeyManager) require zero changes** — the same HotKeyPressed event is fired from both paths.

**Risk:** WH_KEYBOARD_LL hooks may trigger some AV heuristics. Mitigated by only using the hook as a fallback path.