### PR TITLE
Restart app on user login console connect

### DIFF
--- a/SoundSwitch/Framework/WinApi/WindowsAPIAdapter.cs
+++ b/SoundSwitch/Framework/WinApi/WindowsAPIAdapter.cs
@@ -173,7 +173,7 @@ public class WindowsAPIAdapter : Form
 
     private static void SystemEventsSessionSwitch(object sender, SessionSwitchEventArgs e)
     {
-        if (e.Reason.Equals(SessionSwitchReason.ConsoleConnect))
+        if (e.Reason == SessionSwitchReason.ConsoleConnect)
         {
             Log.Information("User login");
             Program.RestartApp();

--- a/SoundSwitch/Framework/WinApi/WindowsAPIAdapter.cs
+++ b/SoundSwitch/Framework/WinApi/WindowsAPIAdapter.cs
@@ -147,6 +147,8 @@ public class WindowsAPIAdapter : Form
 
         SystemEvents.PowerModeChanged += SystemEventsOnPowerModeChanged;
 
+        SystemEvents.SessionSwitch += SystemEventsSessionSwitch;
+
         _instance = new WindowsAPIAdapter();
         _instance.CreateHandle();
         _instance._msgNotifyShell = Interop.RegisterWindowMessage("SHELLHOOK");
@@ -169,10 +171,20 @@ public class WindowsAPIAdapter : Form
         _instance?.BeginInvoke(new Action(_instance.ReRegisterAllHotkeys));
     }
 
+    private static void SystemEventsSessionSwitch(object sender, SessionSwitchEventArgs e)
+    {
+        if (e.Reason.Equals(SessionSwitchReason.ConsoleConnect))
+        {
+            Log.Information("User login");
+            Program.RestartApp();
+        }
+    }
+
     private void EndForm()
     {
         Close();
         SystemEvents.PowerModeChanged -= SystemEventsOnPowerModeChanged;
+        SystemEvents.SessionSwitch -= SystemEventsSessionSwitch;
         CleanupHook();
     }
 


### PR DESCRIPTION
For #2137 

Program.RestartApp(); is likely overkill but it works.

App restart allows for On Startup profile trigger to occur on a user switch event.