### PR TITLE
fix(website): finding-soundswitch FAQ — reopening opens settings

### DIFF
--- a/website/src/faq/finding-soundswitch.md
+++ b/website/src/faq/finding-soundswitch.md
@@ -18,7 +18,7 @@ SoundSwitch lives in the **system tray** (the area next to the clock on the task
 From the tray icon you can:
 
 - **Right-click** → Open the context menu and choose **Settings** to reopen the configuration window.
-- **Double-click** → Cycle through playback devices (configurable in [General Settings](../configuration/general.md)).
+- **Double-click** → Cycle through playback or recording devices (configurable in [General Settings](../configuration/general.md)).
 - **Hover** → See the currently active device.
 
 ![SoundSwitch tray icon](/images/faq/tray-icon.gif)

--- a/website/src/faq/finding-soundswitch.md
+++ b/website/src/faq/finding-soundswitch.md
@@ -1,17 +1,25 @@
 ---
 title: Where did SoundSwitch go?
-description: SoundSwitch lives in the Windows system tray after the first launch. Here's how to find the icon and reopen the settings window.
+description: SoundSwitch lives in the Windows system tray after the first launch. Reopening the app from the Start menu brings the settings back instantly.
 ---
 
 # I can't find SoundSwitch — where did it go?
 
-After the initial setup, SoundSwitch hides itself in the background. Reopening the application from the Start menu won't bring the settings window back.
+After the initial setup, SoundSwitch hides itself in the background.
 
-## Where to find it
+## The quick way: reopen SoundSwitch
+
+If you just want to get the settings window back, **reopen SoundSwitch** from the Start menu or your desktop shortcut. Launching it again will detect the already-running instance and open the settings window automatically — no need to hunt through the system tray.
+
+## Where to find the tray icon
 
 SoundSwitch lives in the **system tray** (the area next to the clock on the taskbar). The first time you launch it, the settings window opens automatically. After that, the window closes and only the tray icon remains.
 
-To open the settings again, **right-click** the SoundSwitch icon in the system tray and choose **Settings**.
+From the tray icon you can:
+
+- **Right-click** → Open the context menu and choose **Settings** to reopen the configuration window.
+- **Double-click** → Cycle through playback devices (configurable in [General Settings](../configuration/general.md)).
+- **Hover** → See the currently active device.
 
 ![SoundSwitch tray icon](/images/faq/tray-icon.gif)
 


### PR DESCRIPTION
## What changed

The `finding-soundswitch.md` FAQ incorrectly claimed:

> Reopening the application from the Start menu won't bring the settings window back.

This is **wrong**. Launching SoundSwitch a second time detects the already-running instance and signals it to open the settings window — this behavior is confirmed by the `settings-open-at-startup.md` FAQ. In fact, reopening is the easiest way to get the settings back.

## Changes

- **Removed** the incorrect claim about reopening not working
- **Added** a new "The quick way: reopen SoundSwitch" section as the first recommendation
- **Enhanced** the tray icon section with bullet points for right-click, double-click, and hover actions (with a link to General Settings for double-click configuration)
- **Updated** the `description` frontmatter to reflect that reopening works

## Before / After

| Before | After |
|--------|-------|
| Tells users to find the tray icon, claims reopening doesn't work | Promotes reopening as the quickest option, then explains the tray icon method |