### PR TITLE
feat(cli): add status command for active profile and current audio devices

### DIFF
--- a/SoundSwitch.CLI/Commands/DevicesCommand.cs
+++ b/SoundSwitch.CLI/Commands/DevicesCommand.cs
@@ -1,13 +1,13 @@
 #nullable enable
 using SoundSwitch.IPC.Pipe;
-using SoundSwitch.IPC.Pipe.Messages.GetActiveDevices;
+using SoundSwitch.IPC.Pipe.Messages.GetSwitchableDevices;
 
 using Spectre.Console;
 using Spectre.Console.Cli;
 
 namespace SoundSwitch.CLI.Commands;
 
-public class StatusCommand : AsyncCommand<StatusCommand.Settings>
+public class DevicesCommand : AsyncCommand<DevicesCommand.Settings>
 {
     public class Settings : JsonCommandSettings
     {
@@ -27,24 +27,21 @@ public class StatusCommand : AsyncCommand<StatusCommand.Settings>
     {
         try
         {
-            var response = await NamedPipe.SendRequestAsync<GetActiveDevicesResponse>(
+            var response = await NamedPipe.SendRequestAsync<GetSwitchableDevicesResponse>(
                 PipeConstants.GetUserPipeName(),
-                new GetActiveDevicesRequest(),
+                new GetSwitchableDevicesRequest(),
                 cancellationToken);
 
             if (!response.Success)
             {
-                JsonOutput.WriteError(response.Error ?? "Failed to retrieve status");
+                JsonOutput.WriteError(response.Error ?? "Failed to retrieve devices");
                 return 1;
             }
 
             JsonOutput.Write(new
             {
-                activeProfile = response.ActiveProfile,
-                playbackDevice = response.PlaybackDevice,
-                recordingDevice = response.RecordingDevice,
-                playbackCommunicationDevice = response.PlaybackCommunicationDevice,
-                recordingCommunicationDevice = response.RecordingCommunicationDevice
+                playbackDevices = response.PlaybackDevices,
+                recordingDevices = response.RecordingDevices
             });
             return 0;
         }
@@ -60,29 +57,33 @@ public class StatusCommand : AsyncCommand<StatusCommand.Settings>
         try
         {
             return await AnsiConsole.Status()
-                .StartAsync("Fetching status...", async _ =>
+                .StartAsync("Fetching devices...", async _ =>
                 {
-                    var response = await NamedPipe.SendRequestAsync<GetActiveDevicesResponse>(
+                    var response = await NamedPipe.SendRequestAsync<GetSwitchableDevicesResponse>(
                         PipeConstants.GetUserPipeName(),
-                        new GetActiveDevicesRequest(),
+                        new GetSwitchableDevicesRequest(),
                         cancellationToken);
 
                     if (!response.Success)
                     {
-                        AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(response.Error ?? "Failed to retrieve status")}");
+                        AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(response.Error ?? "Failed to retrieve devices")}");
                         return 1;
                     }
 
                     var table = new Table()
-                        .AddColumn("Category")
-                        .AddColumn("Device / Profile")
+                        .AddColumn("Type")
+                        .AddColumn("Device")
                         .Border(TableBorder.Rounded);
 
-                    table.AddRow("Active Profile", response.ActiveProfile is null ? "[grey]None[/]" : Markup.Escape(response.ActiveProfile));
-                    table.AddRow("[green]Playback[/]", $"[green]{Markup.Escape(response.PlaybackDevice)}[/]");
-                    table.AddRow("[red]Recording[/]", $"[red]{Markup.Escape(response.RecordingDevice)}[/]");
-                    table.AddRow("[green]Playback Comm[/]", $"[green]{Markup.Escape(response.PlaybackCommunicationDevice)}[/]");
-                    table.AddRow("[red]Recording Comm[/]", $"[red]{Markup.Escape(response.RecordingCommunicationDevice)}[/]");
+                    foreach (var device in response.PlaybackDevices)
+                    {
+                        table.AddRow("[green]Playback[/]", $"[green]{Markup.Escape(device)}[/]");
+                    }
+
+                    foreach (var device in response.RecordingDevices)
+                    {
+                        table.AddRow("[red]Recording[/]", $"[red]{Markup.Escape(device)}[/]");
+                    }
 
                     AnsiConsole.Write(table);
                     return 0;

--- a/SoundSwitch.CLI/Commands/JsonCommandSettings.cs
+++ b/SoundSwitch.CLI/Commands/JsonCommandSettings.cs
@@ -1,0 +1,14 @@
+#nullable enable
+using Spectre.Console.Cli;
+
+namespace SoundSwitch.CLI.Commands;
+
+/// <summary>
+/// Base settings shared by every CLI command that supports machine-readable output.
+/// Inheriting from this class automatically registers the <c>--json</c> option.
+/// </summary>
+public class JsonCommandSettings : CommandSettings
+{
+    [CommandOption("--json")]
+    public bool Json { get; set; }
+}

--- a/SoundSwitch.CLI/Commands/JsonOutput.cs
+++ b/SoundSwitch.CLI/Commands/JsonOutput.cs
@@ -1,0 +1,20 @@
+#nullable enable
+using System.Text.Json;
+
+namespace SoundSwitch.CLI.Commands;
+
+/// <summary>
+/// Centralized JSON output helpers for CLI commands running with <c>--json</c>.
+/// All output is written to <see cref="Console.Out"/> via <see cref="Console.WriteLine"/>
+/// so it is safe to pipe into tools like <c>jq</c> or capture into a variable.
+/// Spectre.Console helpers (status spinners, markup) must never be used in this path
+/// because they emit ANSI escape sequences that corrupt piped output.
+/// </summary>
+internal static class JsonOutput
+{
+    private static readonly JsonSerializerOptions Options = new() { WriteIndented = true };
+
+    public static void Write(object value) => Console.WriteLine(JsonSerializer.Serialize(value, Options));
+
+    public static void WriteError(string message) => Write(new { error = message });
+}

--- a/SoundSwitch.CLI/Commands/MuteCommand.cs
+++ b/SoundSwitch.CLI/Commands/MuteCommand.cs
@@ -1,4 +1,5 @@
-﻿using SoundSwitch.IPC.Pipe;
+﻿#nullable enable
+using SoundSwitch.IPC.Pipe;
 using SoundSwitch.IPC.Pipe.Messages.Microphone;
 using SoundSwitch.IPC.Pipe.Messages.Mute;
 
@@ -9,7 +10,7 @@ namespace SoundSwitch.CLI.Commands;
 
 public class MuteCommand : AsyncCommand<MuteCommand.Settings>
 {
-    public class Settings : CommandSettings
+    public class Settings : JsonCommandSettings
     {
         [CommandArgument(0, "[state]")]
         [CommandOption("-s|--state")]
@@ -19,6 +20,71 @@ public class MuteCommand : AsyncCommand<MuteCommand.Settings>
     }
 
     protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    {
+        if (settings.Json)
+        {
+            return await ExecuteJsonAsync(settings, cancellationToken);
+        }
+
+        return await ExecuteTableAsync(settings, cancellationToken);
+    }
+
+    private static async Task<int> ExecuteJsonAsync(Settings settings, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var currentState = await NamedPipe.SendRequestAsync<MicrophoneStateResponse>(
+                PipeConstants.GetUserPipeName(),
+                new MicrophoneStateRequest(),
+                cancellationToken);
+
+            if (!currentState.Success)
+            {
+                JsonOutput.WriteError("Failed to get microphone state");
+                return 1;
+            }
+
+            // No action requested: just report the current state.
+            if (!settings.State.HasValue && !settings.Toggle)
+            {
+                WriteMicrophoneState(currentState);
+                return 0;
+            }
+
+            var targetState = settings.Toggle ? !currentState.IsMuted : settings.State!.Value;
+
+            // Already in the requested state: no change needed.
+            if (targetState == currentState.IsMuted)
+            {
+                WriteMicrophoneState(currentState);
+                return 0;
+            }
+
+            var muteResponse = await NamedPipe.SendRequestAsync<MicrophoneStateResponse>(
+                PipeConstants.GetUserPipeName(),
+                new MuteRequest { Mute = targetState },
+                cancellationToken);
+
+            if (!muteResponse.Success)
+            {
+                JsonOutput.WriteError("Failed to change microphone state");
+                return 1;
+            }
+
+            WriteMicrophoneState(muteResponse);
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            JsonOutput.WriteError(ex.Message);
+            return 1;
+        }
+    }
+
+    private static void WriteMicrophoneState(MicrophoneStateResponse state) =>
+        JsonOutput.Write(new { deviceName = state.DeviceName, isMuted = state.IsMuted });
+
+    private static async Task<int> ExecuteTableAsync(Settings settings, CancellationToken cancellationToken)
     {
         try
         {

--- a/SoundSwitch.CLI/Commands/ProfileCommand.cs
+++ b/SoundSwitch.CLI/Commands/ProfileCommand.cs
@@ -1,4 +1,5 @@
-﻿using SoundSwitch.IPC.Pipe;
+﻿#nullable enable
+using SoundSwitch.IPC.Pipe;
 using SoundSwitch.IPC.Pipe.Messages.GetProfileList;
 using SoundSwitch.IPC.Pipe.Messages.TriggerProfile;
 
@@ -9,7 +10,7 @@ namespace SoundSwitch.CLI.Commands;
 
 public class ProfileCommand : AsyncCommand<ProfileCommand.Settings>
 {
-    public class Settings : CommandSettings
+    public class Settings : JsonCommandSettings
     {
         [CommandOption("-l|--list")]
         public bool List { get; set; }
@@ -19,6 +20,65 @@ public class ProfileCommand : AsyncCommand<ProfileCommand.Settings>
     }
 
     protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    {
+        if (settings.Json)
+        {
+            return await ExecuteJsonAsync(settings, cancellationToken);
+        }
+
+        return await ExecuteTableAsync(settings, cancellationToken);
+    }
+
+    private static async Task<int> ExecuteJsonAsync(Settings settings, CancellationToken cancellationToken)
+    {
+        try
+        {
+            if (settings.List)
+            {
+                var response = await NamedPipe.SendRequestAsync<GetProfileListResponse>(
+                    PipeConstants.GetUserPipeName(),
+                    new GetProfileListRequest(),
+                    cancellationToken);
+
+                JsonOutput.Write(response.Profiles.Select(p => new
+                {
+                    name = p.Name,
+                    playbackDevice = p.PlaybackDevice,
+                    playbackCommunicationDevice = p.PlaybackCommunicationDevice,
+                    recordingDevice = p.RecordingDevice,
+                    recordingCommunicationDevice = p.RecordingCommunicationDevice
+                }).ToArray());
+                return 0;
+            }
+
+            if (string.IsNullOrEmpty(settings.Name))
+            {
+                JsonOutput.WriteError("Profile name is required unless --list is specified");
+                return 1;
+            }
+
+            var triggerResponse = await NamedPipe.SendRequestAsync<TriggerProfileResponse>(
+                PipeConstants.GetUserPipeName(),
+                new TriggerProfileRequest { ProfileName = settings.Name },
+                cancellationToken);
+
+            if (triggerResponse.Success)
+            {
+                JsonOutput.Write(new { success = true, profile = settings.Name });
+                return 0;
+            }
+
+            JsonOutput.WriteError($"Failed to trigger profile: {triggerResponse.Error}");
+            return 1;
+        }
+        catch (Exception ex)
+        {
+            JsonOutput.WriteError(ex.Message);
+            return 1;
+        }
+    }
+
+    private static async Task<int> ExecuteTableAsync(Settings settings, CancellationToken cancellationToken)
     {
         try
         {

--- a/SoundSwitch.CLI/Commands/SettingsCommand.cs
+++ b/SoundSwitch.CLI/Commands/SettingsCommand.cs
@@ -1,4 +1,5 @@
-﻿using SoundSwitch.IPC.Pipe;
+﻿#nullable enable
+using SoundSwitch.IPC.Pipe;
 using SoundSwitch.IPC.Pipe.Messages.OpenSettings;
 
 using Spectre.Console;
@@ -6,9 +7,48 @@ using Spectre.Console.Cli;
 
 namespace SoundSwitch.CLI.Commands;
 
-public class SettingsCommand : AsyncCommand
+public class SettingsCommand : AsyncCommand<SettingsCommand.Settings>
 {
-    protected override async Task<int> ExecuteAsync(CommandContext context, CancellationToken cancellationToken)
+    public class Settings : JsonCommandSettings
+    {
+    }
+
+    protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    {
+        if (settings.Json)
+        {
+            return await ExecuteJsonAsync(cancellationToken);
+        }
+
+        return await ExecuteTableAsync(cancellationToken);
+    }
+
+    private static async Task<int> ExecuteJsonAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var response = await NamedPipe.SendRequestAsync<OpenSettingsResponse>(
+                PipeConstants.GetUserPipeName(),
+                new OpenSettingsRequest(),
+                cancellationToken);
+
+            if (response.Success)
+            {
+                JsonOutput.Write(new { success = true });
+                return 0;
+            }
+
+            JsonOutput.WriteError("Failed to open settings");
+            return 1;
+        }
+        catch (Exception ex)
+        {
+            JsonOutput.WriteError(ex.Message);
+            return 1;
+        }
+    }
+
+    private static async Task<int> ExecuteTableAsync(CancellationToken cancellationToken)
     {
         try
         {

--- a/SoundSwitch.CLI/Commands/StatusCommand.cs
+++ b/SoundSwitch.CLI/Commands/StatusCommand.cs
@@ -19,6 +19,50 @@ public class StatusCommand : AsyncCommand<StatusCommand.Settings>
 
     protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken)
     {
+        if (settings.Json)
+        {
+            return await ExecuteJsonAsync(cancellationToken);
+        }
+
+        return await ExecuteTableAsync(cancellationToken);
+    }
+
+    private static async Task<int> ExecuteJsonAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var response = await NamedPipe.SendRequestAsync<GetActiveDevicesResponse>(
+                PipeConstants.GetUserPipeName(),
+                new GetActiveDevicesRequest(),
+                cancellationToken);
+
+            if (!response.Success)
+            {
+                WriteJsonError(response.Error ?? "Failed to retrieve status");
+                return 1;
+            }
+
+            var json = JsonSerializer.Serialize(new
+            {
+                activeProfile = response.ActiveProfile,
+                playbackDevice = response.PlaybackDevice,
+                recordingDevice = response.RecordingDevice,
+                playbackCommunicationDevice = response.PlaybackCommunicationDevice,
+                recordingCommunicationDevice = response.RecordingCommunicationDevice
+            }, new JsonSerializerOptions { WriteIndented = true });
+
+            Console.WriteLine(json);
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            WriteJsonError(ex.Message);
+            return 1;
+        }
+    }
+
+    private static async Task<int> ExecuteTableAsync(CancellationToken cancellationToken)
+    {
         try
         {
             return await AnsiConsole.Status()
@@ -29,19 +73,10 @@ public class StatusCommand : AsyncCommand<StatusCommand.Settings>
                         new GetActiveDevicesRequest(),
                         cancellationToken);
 
-                    if (settings.Json)
+                    if (!response.Success)
                     {
-                        var json = JsonSerializer.Serialize(new
-                        {
-                            activeProfile = response.ActiveProfile,
-                            playbackDevice = response.PlaybackDevice,
-                            recordingDevice = response.RecordingDevice,
-                            playbackCommunicationDevice = response.PlaybackCommunicationDevice,
-                            recordingCommunicationDevice = response.RecordingCommunicationDevice
-                        }, new JsonSerializerOptions { WriteIndented = true });
-
-                        Console.WriteLine(json);
-                        return 0;
+                        AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(response.Error ?? "Failed to retrieve status")}");
+                        return 1;
                     }
 
                     var table = new Table()
@@ -49,11 +84,11 @@ public class StatusCommand : AsyncCommand<StatusCommand.Settings>
                         .AddColumn("Device / Profile")
                         .Border(TableBorder.Rounded);
 
-                    table.AddRow("Active Profile", response.ActiveProfile ?? "[grey]None[/]");
-                    table.AddRow("[green]Playback[/]", $"[green]{response.PlaybackDevice}[/]");
-                    table.AddRow("[red]Recording[/]", $"[red]{response.RecordingDevice}[/]");
-                    table.AddRow("[green]Playback Comm[/]", $"[green]{response.PlaybackCommunicationDevice}[/]");
-                    table.AddRow("[red]Recording Comm[/]", $"[red]{response.RecordingCommunicationDevice}[/]");
+                    table.AddRow("Active Profile", response.ActiveProfile is null ? "[grey]None[/]" : Markup.Escape(response.ActiveProfile));
+                    table.AddRow("[green]Playback[/]", $"[green]{Markup.Escape(response.PlaybackDevice)}[/]");
+                    table.AddRow("[red]Recording[/]", $"[red]{Markup.Escape(response.RecordingDevice)}[/]");
+                    table.AddRow("[green]Playback Comm[/]", $"[green]{Markup.Escape(response.PlaybackCommunicationDevice)}[/]");
+                    table.AddRow("[red]Recording Comm[/]", $"[red]{Markup.Escape(response.RecordingCommunicationDevice)}[/]");
 
                     AnsiConsole.Write(table);
                     return 0;
@@ -61,8 +96,14 @@ public class StatusCommand : AsyncCommand<StatusCommand.Settings>
         }
         catch (Exception ex)
         {
-            AnsiConsole.MarkupLine($"[red]Error:[/] {ex.Message}");
+            AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(ex.Message)}");
             return 1;
         }
+    }
+
+    private static void WriteJsonError(string message)
+    {
+        var json = JsonSerializer.Serialize(new { error = message }, new JsonSerializerOptions { WriteIndented = true });
+        Console.WriteLine(json);
     }
 }

--- a/SoundSwitch.CLI/Commands/StatusCommand.cs
+++ b/SoundSwitch.CLI/Commands/StatusCommand.cs
@@ -11,6 +11,8 @@ namespace SoundSwitch.CLI.Commands;
 
 public class StatusCommand : AsyncCommand<StatusCommand.Settings>
 {
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
     public class Settings : CommandSettings
     {
         [CommandOption("--json")]
@@ -49,7 +51,7 @@ public class StatusCommand : AsyncCommand<StatusCommand.Settings>
                 recordingDevice = response.RecordingDevice,
                 playbackCommunicationDevice = response.PlaybackCommunicationDevice,
                 recordingCommunicationDevice = response.RecordingCommunicationDevice
-            }, new JsonSerializerOptions { WriteIndented = true });
+            }, JsonOptions);
 
             Console.WriteLine(json);
             return 0;
@@ -103,7 +105,7 @@ public class StatusCommand : AsyncCommand<StatusCommand.Settings>
 
     private static void WriteJsonError(string message)
     {
-        var json = JsonSerializer.Serialize(new { error = message }, new JsonSerializerOptions { WriteIndented = true });
+        var json = JsonSerializer.Serialize(new { error = message }, JsonOptions);
         Console.WriteLine(json);
     }
 }

--- a/SoundSwitch.CLI/Commands/StatusCommand.cs
+++ b/SoundSwitch.CLI/Commands/StatusCommand.cs
@@ -1,0 +1,68 @@
+#nullable enable
+using System.Text.Json;
+
+using SoundSwitch.IPC.Pipe;
+using SoundSwitch.IPC.Pipe.Messages.GetActiveDevices;
+
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace SoundSwitch.CLI.Commands;
+
+public class StatusCommand : AsyncCommand<StatusCommand.Settings>
+{
+    public class Settings : CommandSettings
+    {
+        [CommandOption("--json")]
+        public bool Json { get; set; }
+    }
+
+    protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await AnsiConsole.Status()
+                .StartAsync("Fetching status...", async _ =>
+                {
+                    var response = await NamedPipe.SendRequestAsync<GetActiveDevicesResponse>(
+                        PipeConstants.GetUserPipeName(),
+                        new GetActiveDevicesRequest(),
+                        cancellationToken);
+
+                    if (settings.Json)
+                    {
+                        var json = JsonSerializer.Serialize(new
+                        {
+                            activeProfile = response.ActiveProfile,
+                            playbackDevice = response.PlaybackDevice,
+                            recordingDevice = response.RecordingDevice,
+                            playbackCommunicationDevice = response.PlaybackCommunicationDevice,
+                            recordingCommunicationDevice = response.RecordingCommunicationDevice
+                        }, new JsonSerializerOptions { WriteIndented = true });
+
+                        Console.WriteLine(json);
+                        return 0;
+                    }
+
+                    var table = new Table()
+                        .AddColumn("Category")
+                        .AddColumn("Device / Profile")
+                        .Border(TableBorder.Rounded);
+
+                    table.AddRow("Active Profile", response.ActiveProfile ?? "[grey]None[/]");
+                    table.AddRow("[green]Playback[/]", $"[green]{response.PlaybackDevice}[/]");
+                    table.AddRow("[red]Recording[/]", $"[red]{response.RecordingDevice}[/]");
+                    table.AddRow("[green]Playback Comm[/]", $"[green]{response.PlaybackCommunicationDevice}[/]");
+                    table.AddRow("[red]Recording Comm[/]", $"[red]{response.RecordingCommunicationDevice}[/]");
+
+                    AnsiConsole.Write(table);
+                    return 0;
+                });
+        }
+        catch (Exception ex)
+        {
+            AnsiConsole.MarkupLine($"[red]Error:[/] {ex.Message}");
+            return 1;
+        }
+    }
+}

--- a/SoundSwitch.CLI/Commands/SwitchCommand.cs
+++ b/SoundSwitch.CLI/Commands/SwitchCommand.cs
@@ -10,7 +10,7 @@ namespace SoundSwitch.CLI.Commands;
 
 public class SwitchCommand : AsyncCommand<SwitchCommand.Settings>
 {
-    public class Settings : CommandSettings
+    public class Settings : JsonCommandSettings
     {
         [CommandArgument(0, "[type]")]
         [CommandOption("-t|--type")]
@@ -18,6 +18,41 @@ public class SwitchCommand : AsyncCommand<SwitchCommand.Settings>
     }
 
     protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    {
+        if (settings.Json)
+        {
+            return await ExecuteJsonAsync(settings, cancellationToken);
+        }
+
+        return await ExecuteTableAsync(settings, cancellationToken);
+    }
+
+    private static async Task<int> ExecuteJsonAsync(Settings settings, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var response = await NamedPipe.SendRequestAsync<TriggerSwitchResponse>(
+                PipeConstants.GetUserPipeName(),
+                new TriggerSwitchRequest { Type = settings.Type },
+                cancellationToken);
+
+            if (response.Success)
+            {
+                JsonOutput.Write(new { success = true, type = settings.Type.ToString() });
+                return 0;
+            }
+
+            JsonOutput.WriteError($"Failed to switch {settings.Type} device");
+            return 1;
+        }
+        catch (Exception ex)
+        {
+            JsonOutput.WriteError(ex.Message);
+            return 1;
+        }
+    }
+
+    private static async Task<int> ExecuteTableAsync(Settings settings, CancellationToken cancellationToken)
     {
         try
         {

--- a/SoundSwitch.CLI/Program.cs
+++ b/SoundSwitch.CLI/Program.cs
@@ -32,6 +32,11 @@ public static class Program
                 .WithExample("mute", "--state", "true")
                 .WithExample("mute", "--toggle")
                 .WithExample("mute");
+
+            config.AddCommand<StatusCommand>("status")
+                .WithDescription("Show active profile and current audio devices")
+                .WithExample("status")
+                .WithExample("status", "--json");
         });
 
         return await app.RunAsync(args);

--- a/SoundSwitch.CLI/Program.cs
+++ b/SoundSwitch.CLI/Program.cs
@@ -17,26 +17,35 @@ public static class Program
             config.AddCommand<SwitchCommand>("switch")
                 .WithDescription("Switch audio device type")
                 .WithExample("switch", "--type", "Recording")
-                .WithExample("switch", "--type", "Playback");
+                .WithExample("switch", "--type", "Playback")
+                .WithExample("switch", "--type", "Playback", "--json");
 
             config.AddCommand<ProfileCommand>("profile")
                 .WithDescription("Manage audio profiles")
                 .WithExample("profile", "--list")
+                .WithExample("profile", "--list", "--json")
                 .WithExample("profile", "--name", "Headphones + Mic");
 
             config.AddCommand<SettingsCommand>("settings")
-                .WithDescription("Open SoundSwitch settings");
+                .WithDescription("Open SoundSwitch settings")
+                .WithExample("settings", "--json");
 
             config.AddCommand<MuteCommand>("mute")
                 .WithDescription("Control microphone mute state")
                 .WithExample("mute", "--state", "true")
                 .WithExample("mute", "--toggle")
-                .WithExample("mute");
+                .WithExample("mute")
+                .WithExample("mute", "--json");
 
             config.AddCommand<StatusCommand>("status")
                 .WithDescription("Show active profile and current audio devices")
                 .WithExample("status")
                 .WithExample("status", "--json");
+
+            config.AddCommand<DevicesCommand>("devices")
+                .WithDescription("List devices selected for switching")
+                .WithExample("devices")
+                .WithExample("devices", "--json");
         });
 
         return await app.RunAsync(args);

--- a/SoundSwitch.CLI/README.md
+++ b/SoundSwitch.CLI/README.md
@@ -33,18 +33,18 @@ SoundSwitch.CLI.exe profile --name "Profile Name"
 
 ### Settings
 Open SoundSwitch settings:
-```
+```shell
 SoundSwitch.CLI.exe settings
 ```
 
 ### Status
 Show active profile and current default audio devices:
-```
+```shell
 SoundSwitch.CLI.exe status              # Human-readable table output
 SoundSwitch.CLI.exe status --json       # Machine-readable JSON output
 ```
 
-The JSON output includes: `activeProfile`, `playbackDevice`, `recordingDevice`, `playbackCommunicationDevice`, `recordingCommunicationDevice`.
+The JSON output includes: `activeProfile`, `playbackDevice`, `recordingDevice`, `playbackCommunicationDevice`, `recordingCommunicationDevice`. On failure, `status --json` prints a JSON object with an `error` field and exits with code 1.
 
 **Note:** "Active Profile" shows the last profile explicitly triggered by a user action or trigger. It may not reflect changes made outside SoundSwitch (e.g., via Windows sound settings).
 
@@ -76,14 +76,14 @@ SoundSwitch.CLI.exe settings
 ```
 
 6. Mute/Unmute microphone:
-```
+```shell
 SoundSwitch.CLI.exe mute -t          # Toggle mute
 SoundSwitch.CLI.exe mute -s true     # Mute
 SoundSwitch.CLI.exe mute --state false # Unmute
 ```
 
 7. Show current audio status:
-```
+```shell
 SoundSwitch.CLI.exe status
 SoundSwitch.CLI.exe status --json
 ```

--- a/SoundSwitch.CLI/README.md
+++ b/SoundSwitch.CLI/README.md
@@ -33,9 +33,20 @@ SoundSwitch.CLI.exe profile --name "Profile Name"
 
 ### Settings
 Open SoundSwitch settings:
-```shell
+```
 SoundSwitch.CLI.exe settings
 ```
+
+### Status
+Show active profile and current default audio devices:
+```
+SoundSwitch.CLI.exe status              # Human-readable table output
+SoundSwitch.CLI.exe status --json       # Machine-readable JSON output
+```
+
+The JSON output includes: `activeProfile`, `playbackDevice`, `recordingDevice`, `playbackCommunicationDevice`, `recordingCommunicationDevice`.
+
+**Note:** "Active Profile" shows the last profile explicitly triggered by a user action or trigger. It may not reflect changes made outside SoundSwitch (e.g., via Windows sound settings).
 
 ## Examples
 
@@ -65,10 +76,16 @@ SoundSwitch.CLI.exe settings
 ```
 
 6. Mute/Unmute microphone:
-```shell
+```
 SoundSwitch.CLI.exe mute -t          # Toggle mute
 SoundSwitch.CLI.exe mute -s true     # Mute
 SoundSwitch.CLI.exe mute --state false # Unmute
+```
+
+7. Show current audio status:
+```
+SoundSwitch.CLI.exe status
+SoundSwitch.CLI.exe status --json
 ```
 
 ## Error Handling

--- a/SoundSwitch.CLI/README.md
+++ b/SoundSwitch.CLI/README.md
@@ -103,7 +103,7 @@ SoundSwitch.CLI.exe status              # Human-readable table output
 SoundSwitch.CLI.exe status --json       # Machine-readable JSON output
 ```
 
-The JSON output includes: `activeProfile`, `playbackDevice`, `recordingDevice`, `playbackCommunicationDevice`, `recordingCommunicationDevice`. On failure, `status --json` prints a JSON object with an `error` field and exits with code 1.
+The JSON output includes: `activeProfile`, `playbackDevice`, `recordingDevice`, `playbackCommunicationDevice`, `recordingCommunicationDevice`. Devices that are not present are serialized as empty strings (`""`). On failure, `status --json` prints a JSON object with an `error` field and exits with code 1.
 
 ```json
 {

--- a/SoundSwitch.CLI/README.md
+++ b/SoundSwitch.CLI/README.md
@@ -2,6 +2,12 @@
 
 A command-line interface for controlling SoundSwitch.
 
+All commands accept `--json` for machine-readable output; failures in JSON mode print a JSON object with an `error` field and exit with code 1:
+
+```json
+{ "error": "Failed to retrieve status" }
+```
+
 ## Commands
 
 ### Switch Audio Device
@@ -9,6 +15,16 @@ Switch between recording or playback devices:
 ```shell
 SoundSwitch.CLI.exe switch --type Recording
 SoundSwitch.CLI.exe switch --type Playback
+SoundSwitch.CLI.exe switch --type Playback --json
+```
+
+The `--json` variant prints `{ "success": true, "type": "Playback" }` on success and `{ "error": "..." }` on failure (exit code 1).
+
+```json
+{
+  "success": true,
+  "type": "Playback"
+}
 ```
 
 ### Microphone Control
@@ -18,12 +34,37 @@ SoundSwitch.CLI.exe mute              # Show current mute state
 SoundSwitch.CLI.exe mute --state true # Mute the microphone
 SoundSwitch.CLI.exe mute -s false     # Unmute the microphone
 SoundSwitch.CLI.exe mute --toggle     # Toggle mute state
+SoundSwitch.CLI.exe mute --json       # Query current state as JSON
+```
+
+The `--json` variant always prints `{ "deviceName": "...", "isMuted": true|false }`; on failure it prints `{ "error": "..." }` (exit code 1).
+
+```json
+{
+  "deviceName": "Microphone (USB Audio Device)",
+  "isMuted": false
+}
 ```
 
 ### Profile Management
 List all available profiles:
 ```shell
 SoundSwitch.CLI.exe profile --list
+SoundSwitch.CLI.exe profile --list --json
+```
+
+The `--json` variant prints a JSON array of profile objects (`name`, `playbackDevice`, `playbackCommunicationDevice`, `recordingDevice`, `recordingCommunicationDevice`).
+
+```json
+[
+  {
+    "name": "Gaming",
+    "playbackDevice": "Speakers (Realtek(R) Audio)",
+    "playbackCommunicationDevice": "Headset Earphone (HyperX Cloud II)",
+    "recordingDevice": "Microphone (USB Audio Device)",
+    "recordingCommunicationDevice": "Headset Microphone (HyperX Cloud II)"
+  }
+]
 ```
 
 Trigger a specific profile:
@@ -31,10 +72,28 @@ Trigger a specific profile:
 SoundSwitch.CLI.exe profile --name "Profile Name"
 ```
 
+With `--name` and `--json`, on success the command prints `{ "success": true, "profile": "Profile Name" }`; on failure it prints `{ "error": "..." }` (exit code 1).
+
+```json
+{
+  "success": true,
+  "profile": "Gaming"
+}
+```
+
 ### Settings
 Open SoundSwitch settings:
 ```shell
 SoundSwitch.CLI.exe settings
+SoundSwitch.CLI.exe settings --json
+```
+
+The `--json` variant prints `{ "success": true }` on success and `{ "error": "..." }` on failure (exit code 1).
+
+```json
+{
+  "success": true
+}
 ```
 
 ### Status
@@ -46,7 +105,38 @@ SoundSwitch.CLI.exe status --json       # Machine-readable JSON output
 
 The JSON output includes: `activeProfile`, `playbackDevice`, `recordingDevice`, `playbackCommunicationDevice`, `recordingCommunicationDevice`. On failure, `status --json` prints a JSON object with an `error` field and exits with code 1.
 
+```json
+{
+  "activeProfile": "Gaming",
+  "playbackDevice": "Speakers (Realtek(R) Audio)",
+  "recordingDevice": "Microphone (USB Audio Device)",
+  "playbackCommunicationDevice": "Headset Earphone (HyperX Cloud II)",
+  "recordingCommunicationDevice": "Headset Microphone (HyperX Cloud II)"
+}
+```
+
 **Note:** "Active Profile" shows the last profile explicitly triggered by a user action or trigger. It may not reflect changes made outside SoundSwitch (e.g., via Windows sound settings).
+
+### Devices
+List devices that are both currently active and selected in SoundSwitch settings (i.e. devices SoundSwitch will cycle through):
+```shell
+SoundSwitch.CLI.exe devices
+SoundSwitch.CLI.exe devices --json
+```
+
+The `--json` variant prints `{ "playbackDevices": [...], "recordingDevices": [...] }`; on failure it prints `{ "error": "..." }` (exit code 1).
+
+```json
+{
+  "playbackDevices": [
+    "Speakers (Realtek(R) Audio)",
+    "Headset Earphone (HyperX Cloud II)"
+  ],
+  "recordingDevices": [
+    "Microphone (USB Audio Device)"
+  ]
+}
+```
 
 ## Examples
 
@@ -86,6 +176,12 @@ SoundSwitch.CLI.exe mute --state false # Unmute
 ```shell
 SoundSwitch.CLI.exe status
 SoundSwitch.CLI.exe status --json
+```
+
+8. List devices selected for switching:
+```shell
+SoundSwitch.CLI.exe devices
+SoundSwitch.CLI.exe devices --json
 ```
 
 ## Error Handling

--- a/SoundSwitch.IPC/Pipe/Messages/GetActiveDevices/GetActiveDevicesRequest.cs
+++ b/SoundSwitch.IPC/Pipe/Messages/GetActiveDevices/GetActiveDevicesRequest.cs
@@ -1,0 +1,9 @@
+#nullable enable
+using MessagePack;
+
+namespace SoundSwitch.IPC.Pipe.Messages.GetActiveDevices;
+
+[MessagePackObject(keyAsPropertyName: true)]
+public class GetActiveDevicesRequest : IPipeMessage
+{
+}

--- a/SoundSwitch.IPC/Pipe/Messages/GetActiveDevices/GetActiveDevicesResponse.cs
+++ b/SoundSwitch.IPC/Pipe/Messages/GetActiveDevices/GetActiveDevicesResponse.cs
@@ -1,0 +1,14 @@
+#nullable enable
+using MessagePack;
+
+namespace SoundSwitch.IPC.Pipe.Messages.GetActiveDevices;
+
+[MessagePackObject(keyAsPropertyName: true)]
+public class GetActiveDevicesResponse : IPipeMessage
+{
+    public string? ActiveProfile { get; set; }
+    public string PlaybackDevice { get; set; } = "";
+    public string RecordingDevice { get; set; } = "";
+    public string PlaybackCommunicationDevice { get; set; } = "";
+    public string RecordingCommunicationDevice { get; set; } = "";
+}

--- a/SoundSwitch.IPC/Pipe/Messages/GetActiveDevices/GetActiveDevicesResponse.cs
+++ b/SoundSwitch.IPC/Pipe/Messages/GetActiveDevices/GetActiveDevicesResponse.cs
@@ -11,4 +11,6 @@ public class GetActiveDevicesResponse : IPipeMessage
     public string RecordingDevice { get; set; } = "";
     public string PlaybackCommunicationDevice { get; set; } = "";
     public string RecordingCommunicationDevice { get; set; } = "";
+    public bool Success { get; set; }
+    public string? Error { get; set; }
 }

--- a/SoundSwitch.IPC/Pipe/Messages/GetSwitchableDevices/GetSwitchableDevicesRequest.cs
+++ b/SoundSwitch.IPC/Pipe/Messages/GetSwitchableDevices/GetSwitchableDevicesRequest.cs
@@ -1,0 +1,9 @@
+#nullable enable
+using MessagePack;
+
+namespace SoundSwitch.IPC.Pipe.Messages.GetSwitchableDevices;
+
+[MessagePackObject(keyAsPropertyName: true)]
+public class GetSwitchableDevicesRequest : IPipeMessage
+{
+}

--- a/SoundSwitch.IPC/Pipe/Messages/GetSwitchableDevices/GetSwitchableDevicesResponse.cs
+++ b/SoundSwitch.IPC/Pipe/Messages/GetSwitchableDevices/GetSwitchableDevicesResponse.cs
@@ -1,0 +1,13 @@
+#nullable enable
+using MessagePack;
+
+namespace SoundSwitch.IPC.Pipe.Messages.GetSwitchableDevices;
+
+[MessagePackObject(keyAsPropertyName: true)]
+public class GetSwitchableDevicesResponse : IPipeMessage
+{
+    public string[] PlaybackDevices { get; set; } = [];
+    public string[] RecordingDevices { get; set; } = [];
+    public bool Success { get; set; }
+    public string? Error { get; set; }
+}

--- a/SoundSwitch.IPC/Pipe/Messages/IPipeMessage.cs
+++ b/SoundSwitch.IPC/Pipe/Messages/IPipeMessage.cs
@@ -3,6 +3,7 @@ using MessagePack;
 
 using SoundSwitch.IPC.Pipe.Messages.GetActiveDevices;
 using SoundSwitch.IPC.Pipe.Messages.GetProfileList;
+using SoundSwitch.IPC.Pipe.Messages.GetSwitchableDevices;
 using SoundSwitch.IPC.Pipe.Messages.Microphone;
 using SoundSwitch.IPC.Pipe.Messages.Mute;
 using SoundSwitch.IPC.Pipe.Messages.OpenSettings;
@@ -24,6 +25,8 @@ namespace SoundSwitch.IPC.Pipe.Messages;
 [Union(10, typeof(MicrophoneStateRequest))]
 [Union(11, typeof(GetActiveDevicesRequest))]
 [Union(12, typeof(GetActiveDevicesResponse))]
+[Union(13, typeof(GetSwitchableDevicesRequest))]
+[Union(14, typeof(GetSwitchableDevicesResponse))]
 public interface IPipeMessage
 {
 }

--- a/SoundSwitch.IPC/Pipe/Messages/IPipeMessage.cs
+++ b/SoundSwitch.IPC/Pipe/Messages/IPipeMessage.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 using MessagePack;
 
+using SoundSwitch.IPC.Pipe.Messages.GetActiveDevices;
 using SoundSwitch.IPC.Pipe.Messages.GetProfileList;
 using SoundSwitch.IPC.Pipe.Messages.Microphone;
 using SoundSwitch.IPC.Pipe.Messages.Mute;
@@ -21,6 +22,8 @@ namespace SoundSwitch.IPC.Pipe.Messages;
 [Union(8, typeof(MuteRequest))]
 [Union(9, typeof(MicrophoneStateResponse))]
 [Union(10, typeof(MicrophoneStateRequest))]
+[Union(11, typeof(GetActiveDevicesRequest))]
+[Union(12, typeof(GetActiveDevicesResponse))]
 public interface IPipeMessage
 {
 }

--- a/SoundSwitch/Framework/Profile/ProfileManager.cs
+++ b/SoundSwitch/Framework/Profile/ProfileManager.cs
@@ -41,6 +41,13 @@ public class ProfileManager
     private Profile? _steamProfile;
     private Profile? _forcedProfile;
 
+    /// <summary>
+    /// Name of the most recently triggered profile, or <c>null</c> if no profile
+    /// has been triggered since startup. Read by the IPC layer to report the
+    /// currently active profile to CLI consumers.
+    /// </summary>
+    public string? LastTriggeredProfile { get; private set; }
+
     private readonly ConcurrentDictionary<User32.NativeMethods.HWND, Profile> _activeWindowsTrigger = new();
 
     private readonly Dictionary<string, (Profile Profile, Trigger.Trigger Trigger)> _profileByApplication = new();
@@ -382,6 +389,10 @@ public class ProfileManager
     private void SwitchAudio(Profile profile, uint processId)
     {
         _notificationManager.NotifyProfileChanged(profile, processId);
+        if (AppConfigs.Configuration.Profiles.Any(p => p.Name == profile.Name))
+        {
+            LastTriggeredProfile = profile.Name;
+        }
         foreach (var device in profile.Devices)
         {
             var deviceToUse = CheckDeviceAvailable(device.DeviceInfo);
@@ -408,6 +419,10 @@ public class ProfileManager
     public void SwitchAudio(Profile profile)
     {
         _notificationManager.NotifyProfileChanged(profile, null);
+        if (AppConfigs.Configuration.Profiles.Any(p => p.Name == profile.Name))
+        {
+            LastTriggeredProfile = profile.Name;
+        }
         if (profile.SwitchForegroundApp)
         {
             _audioSwitcher.ResetProcessDeviceConfiguration();

--- a/SoundSwitch/Model/SoundSwitchApplicationContext.cs
+++ b/SoundSwitch/Model/SoundSwitchApplicationContext.cs
@@ -19,6 +19,7 @@ using SoundSwitch.Framework.Profile;
 using SoundSwitch.Framework.Updater;
 using SoundSwitch.IPC.Pipe;
 using SoundSwitch.IPC.Pipe.Messages;
+using SoundSwitch.IPC.Pipe.Messages.GetActiveDevices;
 using SoundSwitch.IPC.Pipe.Messages.GetProfileList;
 using SoundSwitch.IPC.Pipe.Messages.Microphone;
 using SoundSwitch.IPC.Pipe.Messages.Models;
@@ -196,6 +197,52 @@ public class SoundSwitchApplicationContext : ApplicationContext
                     })
                     .ToArray();
                 return new GetProfileListResponse { Profiles = profiles };
+
+            case GetActiveDevicesRequest:
+                try
+                {
+                    var playback = await Task.Run(() =>
+                        AudioSwitcher.Instance.GetDefaultAudioEndpoint(
+                            Audio.Manager.Interop.Enum.EDataFlow.eRender,
+                            Audio.Manager.Interop.Enum.ERole.eMultimedia
+                        ), token);
+                    var playbackComm = await Task.Run(() =>
+                        AudioSwitcher.Instance.GetDefaultAudioEndpoint(
+                            Audio.Manager.Interop.Enum.EDataFlow.eRender,
+                            Audio.Manager.Interop.Enum.ERole.eCommunications
+                        ), token);
+                    var recording = await Task.Run(() =>
+                        AudioSwitcher.Instance.GetDefaultAudioEndpoint(
+                            Audio.Manager.Interop.Enum.EDataFlow.eCapture,
+                            Audio.Manager.Interop.Enum.ERole.eMultimedia
+                        ), token);
+                    var recordingComm = await Task.Run(() =>
+                        AudioSwitcher.Instance.GetDefaultAudioEndpoint(
+                            Audio.Manager.Interop.Enum.EDataFlow.eCapture,
+                            Audio.Manager.Interop.Enum.ERole.eCommunications
+                        ), token);
+
+                    return new GetActiveDevicesResponse
+                    {
+                        ActiveProfile = AppModel.Instance.ProfileManager.LastTriggeredProfile,
+                        PlaybackDevice = playback?.FriendlyName ?? "",
+                        RecordingDevice = recording?.FriendlyName ?? "",
+                        PlaybackCommunicationDevice = playbackComm?.FriendlyName ?? "",
+                        RecordingCommunicationDevice = recordingComm?.FriendlyName ?? ""
+                    };
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, "Failed to get active devices");
+                    return new GetActiveDevicesResponse
+                    {
+                        ActiveProfile = null,
+                        PlaybackDevice = "",
+                        RecordingDevice = "",
+                        PlaybackCommunicationDevice = "",
+                        RecordingCommunicationDevice = ""
+                    };
+                }
 
             default:
                 Log.Warning("Unknown message type received: {MessageType}", message.GetType());

--- a/SoundSwitch/Model/SoundSwitchApplicationContext.cs
+++ b/SoundSwitch/Model/SoundSwitchApplicationContext.cs
@@ -202,33 +202,42 @@ public class SoundSwitchApplicationContext : ApplicationContext
                 try
                 {
                     var playback = await Task.Run(() =>
-                        AudioSwitcher.Instance.GetDefaultAudioEndpoint(
+                    {
+                        using var device = AudioSwitcher.Instance.GetDefaultAudioEndpoint(
                             Audio.Manager.Interop.Enum.EDataFlow.eRender,
-                            Audio.Manager.Interop.Enum.ERole.eMultimedia
-                        ), token);
+                            Audio.Manager.Interop.Enum.ERole.eMultimedia);
+                        return device?.NameClean ?? "";
+                    }, token);
                     var playbackComm = await Task.Run(() =>
-                        AudioSwitcher.Instance.GetDefaultAudioEndpoint(
+                    {
+                        using var device = AudioSwitcher.Instance.GetDefaultAudioEndpoint(
                             Audio.Manager.Interop.Enum.EDataFlow.eRender,
-                            Audio.Manager.Interop.Enum.ERole.eCommunications
-                        ), token);
+                            Audio.Manager.Interop.Enum.ERole.eCommunications);
+                        return device?.NameClean ?? "";
+                    }, token);
                     var recording = await Task.Run(() =>
-                        AudioSwitcher.Instance.GetDefaultAudioEndpoint(
+                    {
+                        using var device = AudioSwitcher.Instance.GetDefaultAudioEndpoint(
                             Audio.Manager.Interop.Enum.EDataFlow.eCapture,
-                            Audio.Manager.Interop.Enum.ERole.eMultimedia
-                        ), token);
+                            Audio.Manager.Interop.Enum.ERole.eMultimedia);
+                        return device?.NameClean ?? "";
+                    }, token);
                     var recordingComm = await Task.Run(() =>
-                        AudioSwitcher.Instance.GetDefaultAudioEndpoint(
+                    {
+                        using var device = AudioSwitcher.Instance.GetDefaultAudioEndpoint(
                             Audio.Manager.Interop.Enum.EDataFlow.eCapture,
-                            Audio.Manager.Interop.Enum.ERole.eCommunications
-                        ), token);
+                            Audio.Manager.Interop.Enum.ERole.eCommunications);
+                        return device?.NameClean ?? "";
+                    }, token);
 
                     return new GetActiveDevicesResponse
                     {
+                        Success = true,
                         ActiveProfile = AppModel.Instance.ProfileManager.LastTriggeredProfile,
-                        PlaybackDevice = playback?.FriendlyName ?? "",
-                        RecordingDevice = recording?.FriendlyName ?? "",
-                        PlaybackCommunicationDevice = playbackComm?.FriendlyName ?? "",
-                        RecordingCommunicationDevice = recordingComm?.FriendlyName ?? ""
+                        PlaybackDevice = playback,
+                        RecordingDevice = recording,
+                        PlaybackCommunicationDevice = playbackComm,
+                        RecordingCommunicationDevice = recordingComm
                     };
                 }
                 catch (Exception ex)
@@ -236,6 +245,8 @@ public class SoundSwitchApplicationContext : ApplicationContext
                     Log.Error(ex, "Failed to get active devices");
                     return new GetActiveDevicesResponse
                     {
+                        Success = false,
+                        Error = ex.Message,
                         ActiveProfile = null,
                         PlaybackDevice = "",
                         RecordingDevice = "",

--- a/SoundSwitch/Model/SoundSwitchApplicationContext.cs
+++ b/SoundSwitch/Model/SoundSwitchApplicationContext.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -21,6 +22,7 @@ using SoundSwitch.IPC.Pipe;
 using SoundSwitch.IPC.Pipe.Messages;
 using SoundSwitch.IPC.Pipe.Messages.GetActiveDevices;
 using SoundSwitch.IPC.Pipe.Messages.GetProfileList;
+using SoundSwitch.IPC.Pipe.Messages.GetSwitchableDevices;
 using SoundSwitch.IPC.Pipe.Messages.Microphone;
 using SoundSwitch.IPC.Pipe.Messages.Models;
 using SoundSwitch.IPC.Pipe.Messages.Mute;
@@ -252,6 +254,45 @@ public class SoundSwitchApplicationContext : ApplicationContext
                         RecordingDevice = "",
                         PlaybackCommunicationDevice = "",
                         RecordingCommunicationDevice = ""
+                    };
+                }
+
+            case GetSwitchableDevicesRequest:
+                try
+                {
+                    var playback = await Task.Run(() =>
+                    {
+                        var names = new List<string>();
+                        foreach (var device in AppModel.Instance.AvailablePlaybackDevices)
+                        {
+                            names.Add(device.NameClean);
+                        }
+                        return names.ToArray();
+                    }, token);
+                    var recording = await Task.Run(() =>
+                    {
+                        var names = new List<string>();
+                        foreach (var device in AppModel.Instance.AvailableRecordingDevices)
+                        {
+                            names.Add(device.NameClean);
+                        }
+                        return names.ToArray();
+                    }, token);
+
+                    return new GetSwitchableDevicesResponse
+                    {
+                        Success = true,
+                        PlaybackDevices = playback,
+                        RecordingDevices = recording
+                    };
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, "Failed to get switchable devices");
+                    return new GetSwitchableDevicesResponse
+                    {
+                        Success = false,
+                        Error = ex.Message
                     };
                 }
 

--- a/website/src/faq/command-line.md
+++ b/website/src/faq/command-line.md
@@ -7,10 +7,11 @@ description: Yes — SoundSwitch ships with an official CLI bundled with the ins
 
 Yes — SoundSwitch ships with an official **CLI** (`SoundSwitch.CLI`). It is bundled with the installer and added to your `PATH` so you can call it from any terminal:
 
-```text
-SoundSwitch.CLI playback next
-SoundSwitch.CLI recording next
-SoundSwitch.CLI mute toggle
+```shell
+SoundSwitch.CLI.exe switch --type Playback
+SoundSwitch.CLI.exe switch --type Recording
+SoundSwitch.CLI.exe mute --toggle
+SoundSwitch.CLI.exe status
 ```
 
 See the [CLI usage page](../usage/cli.md) for the full command reference.

--- a/website/src/faq/command-line.md
+++ b/website/src/faq/command-line.md
@@ -11,8 +11,12 @@ Yes — SoundSwitch ships with an official **CLI** (`SoundSwitch.CLI`). It is bu
 SoundSwitch.CLI.exe switch --type Playback
 SoundSwitch.CLI.exe switch --type Recording
 SoundSwitch.CLI.exe mute --toggle
+SoundSwitch.CLI.exe profile --list --json
 SoundSwitch.CLI.exe status
+SoundSwitch.CLI.exe devices
 ```
+
+All commands accept `--json` for machine-readable output; failures in JSON mode print a JSON object with an `error` field and exit with code 1.
 
 See the [CLI usage page](../usage/cli.md) for the full command reference.
 

--- a/website/src/usage/cli.md
+++ b/website/src/usage/cli.md
@@ -7,15 +7,18 @@ description: Automate SoundSwitch from scripts and shortcuts with the bundled So
 
 SoundSwitch includes a command-line interface (`SoundSwitch.CLI`) for advanced users who want to control audio devices, manage profiles, and automate device switching through scripts.
 
+All commands accept `--json` for machine-readable output; failures in JSON mode print a JSON object with an `error` field and exit with code 1.
+
 ## Available Commands
 
 The CLI provides the following capabilities:
 
-- **Switch devices** — Change the active playback or recording device by name or index.
+- **Switch devices** — Cycle through available playback or recording devices.
 - **Mute microphone** — Toggle or set the mute state of the default communication microphone.
 - **Manage profiles** — Switch between saved audio profiles or list available profiles.
 - **Access settings** — Open the SoundSwitch settings window.
-- **Check status** — Display the active profile and current default playback/recording devices.
+- **Check status** — Display the active profile and current default audio endpoints (playback, recording, and communication).
+- **List devices** — Show devices that are both active and selected for switching in SoundSwitch settings.
 
 ## Using the CLI
 
@@ -27,12 +30,66 @@ Run `SoundSwitch.CLI.exe --help` (or `--version`) from the command line to see a
 |---------|-------------|
 | `SoundSwitch.CLI.exe switch --type Playback` | Cycle to the next playback device. |
 | `SoundSwitch.CLI.exe switch --type Recording` | Cycle to the next recording device. |
+| `SoundSwitch.CLI.exe switch --type Playback --json` | Cycle to the next playback device and print JSON status. |
 | `SoundSwitch.CLI.exe mute --toggle` | Toggle the microphone mute state. |
 | `SoundSwitch.CLI.exe mute --state false` | Unmute the microphone. |
+| `SoundSwitch.CLI.exe mute --json` | Print the current microphone mute state as JSON. |
 | `SoundSwitch.CLI.exe profile --list` | List all available audio profiles. |
+| `SoundSwitch.CLI.exe profile --list --json` | List all available audio profiles as JSON. |
 | `SoundSwitch.CLI.exe profile --name "Gaming"` | Activate the "Gaming" audio profile. |
 | `SoundSwitch.CLI.exe status` | Show active profile and current default audio devices. |
 | `SoundSwitch.CLI.exe status --json` | Show active profile and current devices in machine-readable JSON. |
+| `SoundSwitch.CLI.exe devices` | List devices selected for switching (active and selected in settings). |
+| `SoundSwitch.CLI.exe devices --json` | List switchable devices in machine-readable JSON. |
 | `SoundSwitch.CLI.exe settings` | Open the SoundSwitch settings window. |
+| `SoundSwitch.CLI.exe settings --json` | Open the SoundSwitch settings window and print the result as JSON. |
 
 For the full list of commands and options, run `SoundSwitch.CLI.exe --help` or see the [SoundSwitch.CLI README](https://github.com/Belphemur/SoundSwitch/blob/master/SoundSwitch.CLI/README.md) on GitHub.
+
+## JSON Output
+
+When used with `--json`, each command produces machine-readable JSON output. The most commonly scripted commands are shown below.
+
+### status --json
+
+```json
+{
+  "activeProfile": "Gaming",
+  "playbackDevice": "Speakers (Realtek(R) Audio)",
+  "recordingDevice": "Microphone (USB Audio Device)",
+  "playbackCommunicationDevice": "Headset Earphone (HyperX Cloud II)",
+  "recordingCommunicationDevice": "Headset Microphone (HyperX Cloud II)"
+}
+```
+
+`activeProfile` is `null` when no profile has been triggered since startup.
+
+### devices --json
+
+```json
+{
+  "playbackDevices": [
+    "Speakers (Realtek(R) Audio)",
+    "Headset Earphone (HyperX Cloud II)"
+  ],
+  "recordingDevices": [
+    "Microphone (USB Audio Device)"
+  ]
+}
+```
+
+### profile --list --json
+
+```json
+[
+  {
+    "name": "Gaming",
+    "playbackDevice": "Speakers (Realtek(R) Audio)",
+    "playbackCommunicationDevice": "Headset Earphone (HyperX Cloud II)",
+    "recordingDevice": "Microphone (USB Audio Device)",
+    "recordingCommunicationDevice": "Headset Microphone (HyperX Cloud II)"
+  }
+]
+```
+
+Action commands (`switch`, `mute`, `settings`, `profile --name`) return simpler responses: `{ "success": true, ... }`, `{ "deviceName": "...", "isMuted": false }`, or `{ "success": true }`. On any failure in `--json` mode, the CLI prints `{ "error": "..." }` to stdout and exits with code 1.

--- a/website/src/usage/cli.md
+++ b/website/src/usage/cli.md
@@ -14,7 +14,8 @@ The CLI provides the following capabilities:
 - **Switch devices** — Change the active playback or recording device by name or index.
 - **Mute microphone** — Toggle or set the mute state of the default communication microphone.
 - **Manage profiles** — Switch between saved audio profiles or list available profiles.
-- **Access settings** — Query or modify SoundSwitch configuration values.
+- **Access settings** — Open the SoundSwitch settings window.
+- **Check status** — Display the active profile and current default playback/recording devices.
 
 ## Using the CLI
 
@@ -24,9 +25,14 @@ Run `SoundSwitch.CLI.exe --help` (or `--version`) from the command line to see a
 
 | Command | Description |
 |---------|-------------|
-| `SoundSwitch.CLI.exe --playback "Headphones"` | Switch the default playback device to "Headphones". |
-| `SoundSwitch.CLI.exe --record "Microphone"` | Switch the default recording device to "Microphone". |
-| `SoundSwitch.CLI.exe --mute-toggle` | Toggle the microphone mute state. |
-| `SoundSwitch.CLI.exe --profile "Gaming"` | Activate the "Gaming" audio profile. |
+| `SoundSwitch.CLI.exe switch --type Playback` | Cycle to the next playback device. |
+| `SoundSwitch.CLI.exe switch --type Recording` | Cycle to the next recording device. |
+| `SoundSwitch.CLI.exe mute --toggle` | Toggle the microphone mute state. |
+| `SoundSwitch.CLI.exe mute --state false` | Unmute the microphone. |
+| `SoundSwitch.CLI.exe profile --list` | List all available audio profiles. |
+| `SoundSwitch.CLI.exe profile --name "Gaming"` | Activate the "Gaming" audio profile. |
+| `SoundSwitch.CLI.exe status` | Show active profile and current default audio devices. |
+| `SoundSwitch.CLI.exe status --json` | Show active profile and current devices in machine-readable JSON. |
+| `SoundSwitch.CLI.exe settings` | Open the SoundSwitch settings window. |
 
 For the full list of commands and options, run `SoundSwitch.CLI.exe --help` or see the [SoundSwitch.CLI README](https://github.com/Belphemur/SoundSwitch/blob/master/SoundSwitch.CLI/README.md) on GitHub.

--- a/website/src/usage/cli.md
+++ b/website/src/usage/cli.md
@@ -64,6 +64,8 @@ When used with `--json`, each command produces machine-readable JSON output. The
 
 `activeProfile` is `null` when no profile has been triggered since startup.
 
+Device fields are empty strings (`""`) when no matching device is present.
+
 ### devices --json
 
 ```json


### PR DESCRIPTION
## What this PR does
Adds a new `status` CLI command (issue #2300) and extends all existing CLI commands with a `--json` flag for machine-readable output.

### New commands
- **`status`** — Show active profile and current default audio endpoints (playback, recording, playback-comm, recording-comm). Supports `status --json`.
- **`devices`** — List devices that are both active and selected for switching in SoundSwitch settings. Supports `devices --json`.

### Global `--json` option
All 6 commands (`switch`, `profile`, `mute`, `settings`, `status`, `devices`) now accept `--json`. JSON output is indented camelCase, emitted via `Console.WriteLine` (no ANSI codes), safe for `| jq`. Failures in JSON mode print `{"error":"..."}` to stdout with exit code 1.

### Technical details
- IPC: new `GetActiveDevices` and `GetSwitchableDevices` request/response message pairs (MessagePack)
- Server handler queries audio endpoints via `AudioSwitcher.GetDefaultAudioEndpoint` and selected devices via `AppModel.Instance.Available*Devices`
- `ProfileManager.LastTriggeredProfile` tracks the last real profile applied from any trigger source (hotkey, app/window, startup, forced, CLI)
- Shared `JsonCommandSettings`/`JsonOutput` helpers keep `--json` DRY across all commands
- JSON paths never touch `AnsiConsole.Status()` — no spinner corruption in piped output

### Documentation
- CLI README updated with all 6 commands + JSON examples
- Website usage and FAQ pages updated