### PR TITLE
fix(banner): apply display option to notification banners

### DIFF
--- a/SoundSwitch/Framework/Banner/BannerData.cs
+++ b/SoundSwitch/Framework/Banner/BannerData.cs
@@ -19,6 +19,10 @@ using System.Drawing;
 using SoundSwitch.Framework.Audio;
 using SoundSwitch.Framework.Banner.BannerPosition.Position;
 
+// Alias required: inside namespace SoundSwitch.Framework.Banner the simple name
+// BannerDisplayInfo resolves to the nested namespace, shadowing the enum.
+using BannerDisplayInfoEnum = SoundSwitch.Framework.Banner.BannerDisplayInfo.BannerDisplayInfo;
+
 namespace SoundSwitch.Framework.Banner;
 
 /// <summary>
@@ -73,6 +77,20 @@ public class BannerData
     /// Opacity of the banner
     /// </summary>
     public int Opacity { get; internal set; } = 100;
+
+    /// <summary>
+    /// Which elements of the banner to display: icon, text, or both
+    /// </summary>
+    public BannerDisplayInfoEnum DisplayInfo { get; internal set; } = BannerDisplayInfoEnum.FullDisplay;
+
+    /// <summary>
+    /// The display mode that can actually be rendered for this banner.
+    /// An icon-only banner without an image would be empty, so it falls back to full display.
+    /// </summary>
+    public BannerDisplayInfoEnum EffectiveDisplayInfo =>
+        DisplayInfo == BannerDisplayInfoEnum.IconOnly && Image == null
+            ? BannerDisplayInfoEnum.FullDisplay
+            : DisplayInfo;
 
     /// <summary>
     /// When enabled, displays the banner in compact mode (half the normal size)

--- a/SoundSwitch/Framework/Banner/BannerForm.cs
+++ b/SoundSwitch/Framework/Banner/BannerForm.cs
@@ -335,8 +335,9 @@ public partial class BannerForm : Form
             }
         }
 
-        if (data.Image != null)
-            pbxLogo.Image = data.Image;
+        // Assign unconditionally: banner forms are reused, so a null image must
+        // clear the previous notification's image instead of leaving it stale.
+        pbxLogo.Image = data.Image;
 
         if (data.SoundFile != null)
         {

--- a/SoundSwitch/Framework/Banner/BannerForm.cs
+++ b/SoundSwitch/Framework/Banner/BannerForm.cs
@@ -28,6 +28,9 @@ using SoundSwitch.Framework.Threading;
 using SoundSwitch.Model;
 using SoundSwitch.UI.Menu.Util;
 
+// Alias required: inside namespace SoundSwitch.Framework.Banner the simple name
+// BannerDisplayInfo resolves to the nested namespace, shadowing the enum.
+using BannerDisplayInfoEnum = SoundSwitch.Framework.Banner.BannerDisplayInfo.BannerDisplayInfo;
 using Timer = System.Windows.Forms.Timer;
 
 namespace SoundSwitch.Framework.Banner;
@@ -345,6 +348,7 @@ public partial class BannerForm : Form
         Opacity = (double)data.Opacity / 100;
         lblTitle.Text = data.Text;
         lblTop.Text = data.Title;
+        ApplyDisplayInfo(data);
 
         if (data.CustomPositionMode)
         {
@@ -426,6 +430,23 @@ public partial class BannerForm : Form
         _cancellationTokenSource.Cancel();
         _cancellationTokenSource.Dispose();
         _cancellationTokenSource = new();
+    }
+
+    /// <summary>
+    /// Applies the configured display mode (full, icon only, or description only)
+    /// by toggling control visibility. Must run before Region/Location are computed
+    /// so the auto-sized form reflects the final layout.
+    /// </summary>
+    private void ApplyDisplayInfo(BannerData data)
+    {
+        var displayInfo = data.EffectiveDisplayInfo;
+
+        var showText = displayInfo != BannerDisplayInfoEnum.IconOnly;
+        lblTop.Visible = showText;
+        lblTitle.Visible = showText;
+        pbxLogo.Visible = displayInfo != BannerDisplayInfoEnum.DescriptionOnly;
+
+        PerformLayout();
     }
 
     private void ApplyCompactMode()

--- a/SoundSwitch/Framework/Banner/ToastBannerAdapter.cs
+++ b/SoundSwitch/Framework/Banner/ToastBannerAdapter.cs
@@ -20,6 +20,10 @@ using Windows.Data.Xml.Dom;
 using Windows.UI.Notifications;
 using Serilog;
 
+// Alias required: inside namespace SoundSwitch.Framework.Banner the simple name
+// BannerDisplayInfo resolves to the nested namespace, shadowing the enum.
+using BannerDisplayInfoEnum = SoundSwitch.Framework.Banner.BannerDisplayInfo.BannerDisplayInfo;
+
 namespace SoundSwitch.Framework.Banner;
 
 /// <summary>
@@ -104,10 +108,15 @@ internal static class ToastBannerAdapter
 
     private static XmlDocument BuildXml(BannerData data)
     {
+        var displayInfo = data.EffectiveDisplayInfo;
+
         // Save the Image to a temp PNG so the toast can reference it via
         // a file:// URI. System.Drawing.Image cannot be passed directly to
         // the WinRT toast XML; it requires a file path or ms-appx URI.
-        string? imagePath = SaveImageToTemp(data.Image);
+        // A description-only banner never shows the image, so skip saving it.
+        string? imagePath = displayInfo == BannerDisplayInfoEnum.DescriptionOnly
+            ? null
+            : SaveImageToTemp(data.Image);
 
         // Build the toast XML by hand — no dependency on
         // Microsoft.Toolkit.Uwp.Notifications needed for net10.0-windows.
@@ -117,13 +126,19 @@ internal static class ToastBannerAdapter
             ? $"""<image placement="appLogoOverride" hint-crop="circle" src="{new Uri(imagePath).AbsoluteUri}" />"""
             : string.Empty;
 
+        // An icon-only toast drops the text lines — unless there is no image
+        // to show, in which case the toast would be empty and we keep them.
+        var showText = displayInfo != BannerDisplayInfoEnum.IconOnly || imagePath == null;
+        var textElements = showText
+            ? $"<text>{EscapeXml(data.Title)}</text>\n          <text>{EscapeXml(data.Text)}</text>"
+            : string.Empty;
+
         var xml = $"""
             <toast>
               <visual>
                 <binding template="ToastGeneric">
                   {imageElement}
-                  <text>{EscapeXml(data.Title)}</text>
-                  <text>{EscapeXml(data.Text)}</text>
+                  {textElements}
                 </binding>
               </visual>
             </toast>

--- a/SoundSwitch/Framework/NotificationManager/Notification/NotificationBanner.cs
+++ b/SoundSwitch/Framework/NotificationManager/Notification/NotificationBanner.cs
@@ -45,17 +45,24 @@ internal class NotificationBanner : INotification
 
     private IPosition BannerPosition => _bannerPositionFactory.Get(Configuration.BannerPosition);
 
+    /// <summary>
+    /// Creates banner data pre-filled with the shared notification configuration
+    /// (position, TTL, opacity, display mode).
+    /// </summary>
+    private BannerData CreateBannerData() => new()
+    {
+        Position = BannerPosition,
+        Ttl = Configuration.Ttl,
+        Opacity = Configuration.Opacity,
+        DisplayInfo = Configuration.DisplayInfo
+    };
+
     public void NotifyDefaultChanged(DeviceFullInfo audioDevice)
     {
         using var iconHandle = audioDevice.LargeIcon;
-        var toastData = new BannerData
-        {
-            Image = iconHandle.ToBitmap(),
-            Text = audioDevice.NameClean,
-            Position = BannerPosition,
-            Ttl = Configuration.Ttl,
-            Opacity = Configuration.Opacity
-        };
+        var toastData = CreateBannerData();
+        toastData.Image = iconHandle.ToBitmap();
+        toastData.Text = audioDevice.NameClean;
         if (CustomSoundCheck(audioDevice))
         {
             toastData.SoundFile = Configuration.CustomSound;
@@ -74,16 +81,11 @@ internal class NotificationBanner : INotification
 
     public void NotifyProfileChanged(Profile.Profile profile, Bitmap icon, uint? processId)
     {
-        var bannerData = new BannerData
-        {
-            Priority = 1,
-            Image = icon,
-            Title = string.Format(SettingsStrings.profile_notification_text, profile.Name),
-            Text = string.Join("\n", profile.Devices.Select(wrapper => wrapper.DeviceInfo.NameClean).Distinct()),
-            Position = BannerPosition,
-            Ttl = Configuration.Ttl,
-            Opacity = Configuration.Opacity
-        };
+        var bannerData = CreateBannerData();
+        bannerData.Priority = 1;
+        bannerData.Image = icon;
+        bannerData.Title = string.Format(SettingsStrings.profile_notification_text, profile.Name);
+        bannerData.Text = string.Join("\n", profile.Devices.Select(wrapper => wrapper.DeviceInfo.NameClean).Distinct());
         _bannerManager.ShowNotification(bannerData);
     }
 
@@ -93,16 +95,11 @@ internal class NotificationBanner : INotification
         if (playback != null) devices.Add(playback.NameClean);
         if (recording != null) devices.Add(recording.NameClean);
 
-        var bannerData = new BannerData
-        {
-            Priority = 1,
-            Image = icon,
-            Title = SettingsStrings.appSoundLock_tab,
-            Text = string.Join("\n", devices),
-            Position = BannerPosition,
-            Ttl = Configuration.Ttl,
-            Opacity = Configuration.Opacity
-        };
+        var bannerData = CreateBannerData();
+        bannerData.Priority = 1;
+        bannerData.Image = icon;
+        bannerData.Title = SettingsStrings.appSoundLock_tab;
+        bannerData.Text = string.Join("\n", devices);
         _bannerManager.ShowNotification(bannerData);
     }
 
@@ -136,15 +133,10 @@ internal class NotificationBanner : INotification
 
         var icon = newMuteState ? Resources.microphone_muted : Resources.microphone_unmuted;
 
-        var bannerData = new BannerData
-        {
-            Priority = 2,
-            Image = icon,
-            Title = title,
-            Position = BannerPosition,
-            Ttl = Configuration.Ttl,
-            Opacity = Configuration.Opacity
-        };
+        var bannerData = CreateBannerData();
+        bannerData.Priority = 2;
+        bannerData.Image = icon;
+        bannerData.Title = title;
         _bannerManager.ShowNotification(bannerData);
     }
 

--- a/SoundSwitch/Framework/NotificationManager/Notification/configuration/INotificationConfiguration.cs
+++ b/SoundSwitch/Framework/NotificationManager/Notification/configuration/INotificationConfiguration.cs
@@ -17,6 +17,7 @@ using System.IO;
 using System.Windows.Forms;
 
 using SoundSwitch.Framework.Audio;
+using SoundSwitch.Framework.Banner.BannerDisplayInfo;
 using SoundSwitch.Framework.Banner.BannerPosition;
 using SoundSwitch.Framework.Banner.MicrophoneMute;
 
@@ -28,6 +29,7 @@ public interface INotificationConfiguration
     Stream DefaultSound { get; set; }
     CachedSound CustomSound { get; set; }
     BannerPosition BannerPosition { get; set; }
+    BannerDisplayInfo DisplayInfo { get; set; }
     TimeSpan Ttl { get; set; }
     int Opacity { get; set; }
     MicrophoneMute MicrophoneMuteBanner { get; set; }

--- a/SoundSwitch/Framework/NotificationManager/Notification/configuration/NotificationConfiguration.cs
+++ b/SoundSwitch/Framework/NotificationManager/Notification/configuration/NotificationConfiguration.cs
@@ -17,6 +17,7 @@ using System.IO;
 using System.Windows.Forms;
 
 using SoundSwitch.Framework.Audio;
+using SoundSwitch.Framework.Banner.BannerDisplayInfo;
 using SoundSwitch.Framework.Banner.BannerPosition;
 using SoundSwitch.Framework.Banner.MicrophoneMute;
 
@@ -28,6 +29,7 @@ public class NotificationConfiguration : INotificationConfiguration
     public Stream DefaultSound { get; set; }
     public CachedSound CustomSound { get; set; }
     public BannerPosition BannerPosition { get; set; }
+    public BannerDisplayInfo DisplayInfo { get; set; }
     public TimeSpan Ttl { get; set; }
     public int Opacity { get; set; }
     public MicrophoneMute MicrophoneMuteBanner { get; set; }

--- a/SoundSwitch/Framework/NotificationManager/NotificationManager.cs
+++ b/SoundSwitch/Framework/NotificationManager/NotificationManager.cs
@@ -88,6 +88,7 @@ public class NotificationManager(INotificationSettings notificationSettings, IAp
             Icon = infrastructure.TrayIcon.NotifyIcon,
             DefaultSound = Resources.NotificationSound,
             BannerPosition = notificationSettings.BannerPosition,
+            DisplayInfo = notificationSettings.BannerDisplayInfo,
             Ttl = notificationSettings.BannerOnScreenTime,
             Opacity = notificationSettings.BannerOpacityPercentage,
             MicrophoneMuteBanner = notificationSettings.MicrophoneMuteBanner,
@@ -110,6 +111,7 @@ public class NotificationManager(INotificationSettings notificationSettings, IAp
     private static void ApplyConfigurationChanges(INotification notification, BannerDataChangedEvent e)
     {
         notification.Configuration.BannerPosition = e.NewBannerPosition;
+        notification.Configuration.DisplayInfo = e.NewBannerDisplayInfo;
         notification.Configuration.Ttl = e.NewTtl;
         notification.Configuration.Opacity = e.NewOpacity;
         notification.Configuration.MicrophoneMuteBanner = e.NewMicrophoneMuteBanner;

--- a/SoundSwitch/UI/Forms/Settings.Designer.cs
+++ b/SoundSwitch/UI/Forms/Settings.Designer.cs
@@ -967,6 +967,7 @@ sealed partial class SettingsForm
         bannerDisplayComboBox.Name = "bannerDisplayComboBox";
         bannerDisplayComboBox.Size = new System.Drawing.Size(120, 23);
         bannerDisplayComboBox.TabIndex = 53;
+        bannerDisplayComboBox.SelectedValueChanged += BannerDisplayComboBox_SelectedValueChanged;
         // 
         // onScreenUpDown
         // 

--- a/SoundSwitch/UI/Forms/Settings.cs
+++ b/SoundSwitch/UI/Forms/Settings.cs
@@ -1036,6 +1036,12 @@ public sealed partial class SettingsForm : Form
             AppModel.Instance.MicrophoneUnmuteBanner = selectedItem.Enum);
     }
 
+    private void BannerDisplayComboBox_SelectedValueChanged(object sender, EventArgs e)
+    {
+        SetComboBoxValue<BannerDisplayInfo>(sender, selectedItem =>
+            AppModel.Instance.BannerDisplayInfo = selectedItem.Enum);
+    }
+
     private void PositionGroupBox_Paint(object sender, PaintEventArgs e)
     {
         Size round =  new(RECT_PEN_WIDTH * 4, RECT_PEN_WIDTH * 4);


### PR DESCRIPTION
## Problem

The banner display option (**Full Display / Icon Only / Description Only**) shown in Settings was never functional:
1. `bannerDisplayComboBox` had no `SelectedValueChanged` handler (unlike every other combobox on the form), so the selection was never saved and reverted to *Full Display* when the settings window was closed.
2. Even when set in the config file, nothing consumed the setting — `BannerData` had no field for it and `BannerForm` always rendered icon + title + text.

## Changes

- **Settings**: wire `bannerDisplayComboBox.SelectedValueChanged` → handler using the existing `SetComboBoxValue<BannerDisplayInfo>` helper, matching every other combobox.
- **Plumbing**: carry the setting through `INotificationConfiguration`/`NotificationConfiguration` → `NotificationManager` (initial value + live updates via `BannerDataChangedEvent.NewBannerDisplayInfo`) → `BannerData.DisplayInfo`.
- **BannerForm**: new `ApplyDisplayInfo` hides the icon (`DescriptionOnly`) or the labels (`IconOnly`) before compact mode / region / location are computed, and resets visibility on every `SetData` (banner form instances are reused across notifications).
- **Fallback**: `BannerData.EffectiveDisplayInfo` centralizes the rule *Icon Only without an image → Full Display*, consumed by both `BannerForm` and `ToastBannerAdapter`.
- **ToastBannerAdapter** (exclusive-fullscreen path): honors the same option — skips the image (and the temp-file save) for `DescriptionOnly`, omits text for `IconOnly`, and keeps a safety net so a toast is never rendered empty if the image save fails.
- **DRY**: extracted `NotificationBanner.CreateBannerData()` so the four notification methods only set their specific properties.

Microphone-mute persistent banners are intentionally left on Full Display.

## Validation

- `dotnet build SoundSwitch/SoundSwitch.csproj -c Debug -p:LinuxBuild=true -p:BuildProjectReferences=false` → 0 errors (only 2 pre-existing CS0219 warnings in untouched code).
- Manual UI verification on Windows is still recommended (banner rendering can't run on Linux).

Fixes #2306