### PR TITLE
chore(build): add LinuxBuild MSBuild property for building on Linux

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,5 +50,8 @@ For additional developer-focused documentation — including build instructions,
 
 ## Validation
 
-- Default validation: `dotnet build SoundSwitch.sln -c Debug`
-- Run targeted tests for the area you change, and at minimum run the related test project when changing shared logic.
+- Default validation (Windows): `dotnet build SoundSwitch.sln -c Debug`
+- Linux validation: the full solution cannot build on Linux (CsWinRT projection generation in `SoundSwitch.Audio.Manager` requires Windows). Validate compile changes with:
+  `dotnet build SoundSwitch/SoundSwitch.csproj -c Debug -p:LinuxBuild=true -p:BuildProjectReferences=false`
+  `LinuxBuild=true` (defined in `Directory.Build.props`) enables `EnableWindowsTargeting` and skips the PowerShell-based `PatchLocalizedResourceDesigners` prebuild target, which is safe because the patched `*.Designer.cs` files are committed.
+- Run targeted tests for the area you change, and at minimum run the related test project when changing shared logic (Windows only).

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <!-- Opt-in properties for building on non-Windows hosts: -p:LinuxBuild=true -->
+  <PropertyGroup Condition="'$(LinuxBuild)' == 'true'">
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+  </PropertyGroup>
+</Project>

--- a/SoundSwitch/SoundSwitch.csproj
+++ b/SoundSwitch/SoundSwitch.csproj
@@ -112,7 +112,9 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
-  <Target Name="PatchLocalizedResourceDesigners" BeforeTargets="CoreCompile">
+  <!-- Skipped when LinuxBuild=true: the patch script requires Windows PowerShell and the
+       Designer files it patches are committed to the repo already patched. -->
+  <Target Name="PatchLocalizedResourceDesigners" BeforeTargets="CoreCompile" Condition="'$(LinuxBuild)' != 'true'">
     <Exec Command="powershell -NoProfile -ExecutionPolicy Bypass -File &quot;$(MSBuildProjectDirectory)\Localization\Patch-LocalizedResourceDesigners.ps1&quot; &quot;$(MSBuildProjectDirectory)&quot;" />
   </Target>
   <PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.301",
+    "version": "10.0.302",
     "rollForward": "latestMajor",
     "allowPrerelease": true
   }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.302",
+    "version": "10.0.301",
     "rollForward": "latestMajor",
     "allowPrerelease": true
   }


### PR DESCRIPTION
## Motivation

Enable compile validation of the main `SoundSwitch` project on Linux dev machines (useful for contributors and AI coding agents running on Linux).

Three things blocked any Linux build:

1. **`global.json`** pinned SDK `10.0.302`; with only `10.0.301` installed the pin is a hard floor (`rollForward: latestMajor` only rolls *forward*). Lowered to `10.0.301` — CI and Windows devs are unaffected since CI installs the latest `10.0.x` channel and roll-forward accepts anything newer.
2. **`PatchLocalizedResourceDesigners`** prebuild target Execs Windows `powershell`. It patches the committed `*.Designer.cs` localization files in place, so skipping it off-Windows is behavior-safe.
3. Windows targeting on non-Windows hosts requires `EnableWindowsTargeting=true`.

## Changes

- New repo-root **`Directory.Build.props`**: `LinuxBuild=true` → `EnableWindowsTargeting=true`.
- **`SoundSwitch.csproj`**: `PatchLocalizedResourceDesigners` target now conditioned on `'$(LinuxBuild)' != 'true'`.
- **`global.json`**: SDK pin `10.0.302` → `10.0.301`.
- **`AGENTS.md`**: Validation section documents both Windows and Linux flows.

Fully opt-in: with `LinuxBuild` unset, Windows/CI behavior is byte-identical.

## Linux validation command

```bash
dotnet build SoundSwitch/SoundSwitch.csproj -c Debug -p:LinuxBuild=true -p:BuildProjectReferences=false
```

Note: the **full solution still can't build on Linux** — CsWinRT projection generation in `SoundSwitch.Audio.Manager` (`cswinrt.exe`) can't run under Wine. This is documented in `AGENTS.md`.