### PR TITLE
fix(pipe): always respond to IPC requests and close startup race

### DIFF
--- a/SoundSwitch.IPC.Tests/NamedPipeTests.cs
+++ b/SoundSwitch.IPC.Tests/NamedPipeTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO.Pipes;
+using System.Threading;
 using System.Threading.Tasks;
 
 using FluentAssertions;
@@ -31,7 +32,29 @@ public sealed class NamedPipeTests
         return pipeName;
     }
 
-    private static Task WaitForServerReadyAsync() => Task.Delay(TimeSpan.FromMilliseconds(200));
+    private static async Task WaitForServerReadyAsync(string pipeName)
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        while (!cts.IsCancellationRequested)
+        {
+            var probe = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
+            try
+            {
+                await probe.ConnectAsync(250, cts.Token);
+                return; // Connected — server is ready
+            }
+            catch
+            {
+                // Server not ready yet; retry
+            }
+            finally
+            {
+                await probe.DisposeAsync();
+            }
+        }
+
+        Assert.Fail($"Server on pipe '{pipeName}' did not become ready within 5 seconds");
+    }
 
     [Test]
     public async Task SendRequestAsync_WhenHandlerResponds_ReturnsResponse()
@@ -40,7 +63,7 @@ public sealed class NamedPipeTests
         var handlerId = NamedPipe.RegisterMessageHandler((_, _) => Task.FromResult<IPipeMessage>(new OpenSettingsResponse { Success = true }));
         try
         {
-            await WaitForServerReadyAsync();
+            await WaitForServerReadyAsync(pipeName);
 
             var response = await NamedPipe.SendRequestAsync<OpenSettingsResponse>(pipeName, new OpenSettingsRequest());
 
@@ -56,7 +79,7 @@ public sealed class NamedPipeTests
     public async Task SendRequestAsync_WhenNoHandlerRegistered_ThrowsNotReadyPipeRequestException()
     {
         var pipeName = StartServer();
-        await WaitForServerReadyAsync();
+        await WaitForServerReadyAsync(pipeName);
 
         var act = () => NamedPipe.SendRequestAsync<OpenSettingsResponse>(pipeName, new OpenSettingsRequest());
 
@@ -71,7 +94,7 @@ public sealed class NamedPipeTests
         var handlerId = NamedPipe.RegisterMessageHandler((_, _) => throw new InvalidOperationException("boom"));
         try
         {
-            await WaitForServerReadyAsync();
+            await WaitForServerReadyAsync(pipeName);
 
             var act = () => NamedPipe.SendRequestAsync<OpenSettingsResponse>(pipeName, new OpenSettingsRequest());
 
@@ -92,7 +115,7 @@ public sealed class NamedPipeTests
         var handlerId = NamedPipe.RegisterMessageHandler((_, _) => Task.FromResult<IPipeMessage>(new OpenSettingsResponse { Success = true }));
         try
         {
-            await WaitForServerReadyAsync();
+            await WaitForServerReadyAsync(pipeName);
 
             // Connect raw, write a partial length prefix, then vanish mid-request
             await using (var rawClient = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous))
@@ -125,7 +148,7 @@ public sealed class NamedPipeTests
         try
         {
             NamedPipe.ResponseTimeout = TimeSpan.FromMilliseconds(500);
-            await WaitForServerReadyAsync();
+            await WaitForServerReadyAsync(pipeName);
 
             var act = () => NamedPipe.SendRequestAsync<OpenSettingsResponse>(pipeName, new OpenSettingsRequest());
 
@@ -135,6 +158,41 @@ public sealed class NamedPipeTests
         {
             NamedPipe.ResponseTimeout = originalTimeout;
             // Release the server-side handler so no slow request lingers past this test
+            gate.TrySetResult();
+            NamedPipe.UnregisterMessageHandler(handlerId);
+        }
+    }
+
+    [Test]
+    public async Task SendRequestAsync_WhenHandlerRunsLongerThanIdleTimeout_StillReturnsResponse()
+    {
+        var pipeName = StartServer();
+        var originalIdleTimeout = NamedPipe.ServerIdleTimeout;
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var handlerId = NamedPipe.RegisterMessageHandler(async (_, _) =>
+        {
+            await gate.Task;
+            return (IPipeMessage)new OpenSettingsResponse { Success = true };
+        });
+        try
+        {
+            NamedPipe.ServerIdleTimeout = TimeSpan.FromMilliseconds(500);
+            await WaitForServerReadyAsync(pipeName);
+
+            var sendTask = NamedPipe.SendRequestAsync<OpenSettingsResponse>(pipeName, new OpenSettingsRequest());
+
+            // Wait far past the idle timeout (4x margin) — the old code would have disconnected mid-request
+            await Task.Delay(TimeSpan.FromMilliseconds(2000));
+
+            // Release the server-side handler
+            gate.TrySetResult();
+
+            var response = await sendTask;
+            response.Success.Should().BeTrue("the connection should survive processing longer than the idle timeout");
+        }
+        finally
+        {
+            NamedPipe.ServerIdleTimeout = originalIdleTimeout;
             gate.TrySetResult();
             NamedPipe.UnregisterMessageHandler(handlerId);
         }
@@ -154,7 +212,7 @@ public sealed class NamedPipeTests
         var originalIdleTimeout = NamedPipe.ServerIdleTimeout;
         try
         {
-            await WaitForServerReadyAsync();
+            await WaitForServerReadyAsync(firstPipeName);
 
             // Shrink the idle timeout so the first connection is reaped fast enough to make the
             // stale-connection reuse bug observable without a ~12s wait.
@@ -175,6 +233,36 @@ public sealed class NamedPipeTests
         finally
         {
             NamedPipe.ServerIdleTimeout = originalIdleTimeout;
+            NamedPipe.UnregisterMessageHandler(handlerId);
+        }
+    }
+
+    [Test]
+    public async Task Server_WhenClientSendsInvalidLengthPrefix_KeepsServingNewConnections()
+    {
+        var pipeName = StartServer();
+        var handlerId = NamedPipe.RegisterMessageHandler((_, _) => Task.FromResult<IPipeMessage>(new OpenSettingsResponse { Success = true }));
+        try
+        {
+            await WaitForServerReadyAsync(pipeName);
+
+            // Raw client sends a bogus length prefix (int.MaxValue) — server must reject it
+            await using (var rawClient = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous))
+            {
+                await rawClient.ConnectAsync(5000);
+                var bogusLength = BitConverter.GetBytes(int.MaxValue);
+                await rawClient.WriteAsync(bogusLength);
+
+                // Stay connected briefly so the server reads the prefix and rejects it
+                await Task.Delay(TimeSpan.FromMilliseconds(300));
+            }
+
+            // Normal round-trip must still succeed after the bogus connection was handled
+            var response = await NamedPipe.SendRequestAsync<OpenSettingsResponse>(pipeName, new OpenSettingsRequest());
+            response.Success.Should().BeTrue("the server must keep serving after rejecting an invalid length prefix");
+        }
+        finally
+        {
             NamedPipe.UnregisterMessageHandler(handlerId);
         }
     }

--- a/SoundSwitch.IPC.Tests/NamedPipeTests.cs
+++ b/SoundSwitch.IPC.Tests/NamedPipeTests.cs
@@ -1,0 +1,192 @@
+using System;
+using System.IO.Pipes;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+using MessagePack;
+
+using NUnit.Framework;
+
+using SoundSwitch.IPC.Pipe;
+using SoundSwitch.IPC.Pipe.Messages;
+using SoundSwitch.IPC.Pipe.Messages.OpenSettings;
+using SoundSwitch.IPC.Pipe.Messages.TriggerSwitch;
+
+namespace SoundSwitch.IPC.Tests;
+
+/// <summary>
+/// Covers the request/response guarantees of <see cref="NamedPipe"/>.
+/// NamedPipe is static with process-global state (handler registry, client stream, listener CTS),
+/// so the fixture must not run in parallel and no test may call <see cref="NamedPipe.Cleanup"/>.
+/// </summary>
+[TestFixture]
+[NonParallelizable]
+public sealed class NamedPipeTests
+{
+    // Mirrors the hardcoded idle timeout in NamedPipe.HandleCommunicationAsync; after this long
+    // without traffic the server has disconnected and disposed the connection for sure.
+    private static readonly TimeSpan ServerIdleReapWait = TimeSpan.FromSeconds(12);
+
+    private static string StartServer()
+    {
+        var pipeName = $"SoundSwitch_Test_{Guid.NewGuid():N}";
+        NamedPipe.StartListening(pipeName);
+        return pipeName;
+    }
+
+    private static Task WaitForServerReadyAsync() => Task.Delay(TimeSpan.FromMilliseconds(200));
+
+    [Test]
+    public async Task SendRequestAsync_WhenHandlerResponds_ReturnsResponse()
+    {
+        var pipeName = StartServer();
+        var handlerId = NamedPipe.RegisterMessageHandler((_, _) => Task.FromResult<IPipeMessage>(new OpenSettingsResponse { Success = true }));
+        try
+        {
+            await WaitForServerReadyAsync();
+
+            var response = await NamedPipe.SendRequestAsync<OpenSettingsResponse>(pipeName, new OpenSettingsRequest());
+
+            response.Success.Should().BeTrue();
+        }
+        finally
+        {
+            NamedPipe.UnregisterMessageHandler(handlerId);
+        }
+    }
+
+    [Test]
+    public async Task SendRequestAsync_WhenNoHandlerRegistered_ThrowsNotReadyPipeRequestException()
+    {
+        var pipeName = StartServer();
+        await WaitForServerReadyAsync();
+
+        var act = () => NamedPipe.SendRequestAsync<OpenSettingsResponse>(pipeName, new OpenSettingsRequest());
+
+        var assertion = await act.Should().ThrowAsync<PipeRequestException>();
+        assertion.Which.NotReady.Should().BeTrue("the server reports itself as still starting up when no handler is registered");
+    }
+
+    [Test]
+    public async Task SendRequestAsync_WhenHandlerThrows_ThrowsPipeRequestExceptionWithHandlerError()
+    {
+        var pipeName = StartServer();
+        var handlerId = NamedPipe.RegisterMessageHandler((_, _) => throw new InvalidOperationException("boom"));
+        try
+        {
+            await WaitForServerReadyAsync();
+
+            var act = () => NamedPipe.SendRequestAsync<OpenSettingsResponse>(pipeName, new OpenSettingsRequest());
+
+            var assertion = await act.Should().ThrowAsync<PipeRequestException>();
+            assertion.Which.Message.Should().Contain("boom");
+            assertion.Which.NotReady.Should().BeFalse("a handler was registered, it just failed");
+        }
+        finally
+        {
+            NamedPipe.UnregisterMessageHandler(handlerId);
+        }
+    }
+
+    [Test]
+    public async Task Server_WhenClientDisconnectsAbruptly_KeepsServingNewConnections()
+    {
+        var pipeName = StartServer();
+        var handlerId = NamedPipe.RegisterMessageHandler((_, _) => Task.FromResult<IPipeMessage>(new OpenSettingsResponse { Success = true }));
+        try
+        {
+            await WaitForServerReadyAsync();
+
+            // Connect raw, write a partial length prefix, then vanish mid-request
+            await using (var rawClient = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous))
+            {
+                await rawClient.ConnectAsync(5000);
+                await rawClient.WriteAsync(new byte[] { 0, 0 });
+            }
+
+            var response = await NamedPipe.SendRequestAsync<OpenSettingsResponse>(pipeName, new OpenSettingsRequest());
+
+            response.Success.Should().BeTrue("a broken connection must kill only that connection, not the listener");
+        }
+        finally
+        {
+            NamedPipe.UnregisterMessageHandler(handlerId);
+        }
+    }
+
+    [Test]
+    public async Task SendRequestAsync_WhenServerDoesNotRespondInTime_ThrowsTimeoutException()
+    {
+        var pipeName = StartServer();
+        var originalTimeout = NamedPipe.ResponseTimeout;
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var handlerId = NamedPipe.RegisterMessageHandler(async (_, _) =>
+        {
+            await gate.Task;
+            return (IPipeMessage)new OpenSettingsResponse { Success = true };
+        });
+        try
+        {
+            NamedPipe.ResponseTimeout = TimeSpan.FromMilliseconds(500);
+            await WaitForServerReadyAsync();
+
+            var act = () => NamedPipe.SendRequestAsync<OpenSettingsResponse>(pipeName, new OpenSettingsRequest());
+
+            await act.Should().ThrowAsync<TimeoutException>();
+        }
+        finally
+        {
+            NamedPipe.ResponseTimeout = originalTimeout;
+            // Release the server-side handler so no slow request lingers past this test
+            gate.TrySetResult();
+            NamedPipe.UnregisterMessageHandler(handlerId);
+        }
+    }
+
+    [Test]
+    public async Task SendRequestAsync_WhenPipeNameChanges_ConnectsToTheNamedPipe()
+    {
+        var firstPipeName = StartServer();
+        var secondPipeName = StartServer();
+        var handlerId = NamedPipe.RegisterMessageHandler((request, _) => Task.FromResult<IPipeMessage>(request switch
+        {
+            OpenSettingsRequest => new OpenSettingsResponse { Success = true },
+            TriggerSwitchRequest => new TriggerSwitchResponse { Success = true },
+            _ => new ErrorResponse { Error = $"Unexpected request {request.GetType().Name}" }
+        }));
+        try
+        {
+            await WaitForServerReadyAsync();
+
+            var firstResponse = await NamedPipe.SendRequestAsync<OpenSettingsResponse>(firstPipeName, new OpenSettingsRequest());
+            firstResponse.Success.Should().BeTrue();
+
+            // Regression setup for the client-stream reuse bug: without pipe-name tracking the
+            // second call silently reuses the first pipe's connection. That is only observable
+            // once the first connection is dead, so wait for the server to reap it as idle.
+            // With the fix the client reconnects by name and this wait is harmless.
+            await Task.Delay(ServerIdleReapWait);
+
+            var secondResponse = await NamedPipe.SendRequestAsync<TriggerSwitchResponse>(secondPipeName, new TriggerSwitchRequest());
+            secondResponse.Success.Should().BeTrue("the request must reach the server listening on the requested pipe name");
+        }
+        finally
+        {
+            NamedPipe.UnregisterMessageHandler(handlerId);
+        }
+    }
+
+    [Test]
+    public void ErrorResponse_WhenSerializedAsPipeMessage_RoundTripsThroughUnion()
+    {
+        IPipeMessage original = new ErrorResponse { NotReady = true, Error = "x" };
+
+        var bytes = MessagePackSerializer.Serialize(original, MessagePackSerializerOptions.Standard);
+        var result = MessagePackSerializer.Deserialize<IPipeMessage>(bytes, MessagePackSerializerOptions.Standard);
+
+        var errorResponse = result.Should().BeOfType<ErrorResponse>("union key 15 must map back to ErrorResponse").Which;
+        errorResponse.NotReady.Should().BeTrue();
+        errorResponse.Error.Should().Be("x");
+    }
+}

--- a/SoundSwitch.IPC.Tests/NamedPipeTests.cs
+++ b/SoundSwitch.IPC.Tests/NamedPipeTests.cs
@@ -24,10 +24,6 @@ namespace SoundSwitch.IPC.Tests;
 [NonParallelizable]
 public sealed class NamedPipeTests
 {
-    // Mirrors the hardcoded idle timeout in NamedPipe.HandleCommunicationAsync; after this long
-    // without traffic the server has disconnected and disposed the connection for sure.
-    private static readonly TimeSpan ServerIdleReapWait = TimeSpan.FromSeconds(12);
-
     private static string StartServer()
     {
         var pipeName = $"SoundSwitch_Test_{Guid.NewGuid():N}";
@@ -155,9 +151,14 @@ public sealed class NamedPipeTests
             TriggerSwitchRequest => new TriggerSwitchResponse { Success = true },
             _ => new ErrorResponse { Error = $"Unexpected request {request.GetType().Name}" }
         }));
+        var originalIdleTimeout = NamedPipe.ServerIdleTimeout;
         try
         {
             await WaitForServerReadyAsync();
+
+            // Shrink the idle timeout so the first connection is reaped fast enough to make the
+            // stale-connection reuse bug observable without a ~12s wait.
+            NamedPipe.ServerIdleTimeout = TimeSpan.FromMilliseconds(500);
 
             var firstResponse = await NamedPipe.SendRequestAsync<OpenSettingsResponse>(firstPipeName, new OpenSettingsRequest());
             firstResponse.Success.Should().BeTrue();
@@ -165,14 +166,15 @@ public sealed class NamedPipeTests
             // Regression setup for the client-stream reuse bug: without pipe-name tracking the
             // second call silently reuses the first pipe's connection. That is only observable
             // once the first connection is dead, so wait for the server to reap it as idle.
-            // With the fix the client reconnects by name and this wait is harmless.
-            await Task.Delay(ServerIdleReapWait);
+            // 2s is a bounded 4x margin over the 500ms idle timeout.
+            await Task.Delay(TimeSpan.FromSeconds(2));
 
             var secondResponse = await NamedPipe.SendRequestAsync<TriggerSwitchResponse>(secondPipeName, new TriggerSwitchRequest());
             secondResponse.Success.Should().BeTrue("the request must reach the server listening on the requested pipe name");
         }
         finally
         {
+            NamedPipe.ServerIdleTimeout = originalIdleTimeout;
             NamedPipe.UnregisterMessageHandler(handlerId);
         }
     }

--- a/SoundSwitch.IPC.Tests/SoundSwitch.IPC.Tests.csproj
+++ b/SoundSwitch.IPC.Tests/SoundSwitch.IPC.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NUnit" />
+        <PackageReference Include="NUnit3TestAdapter" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\SoundSwitch.IPC\SoundSwitch.IPC.csproj" />
+    </ItemGroup>
+</Project>

--- a/SoundSwitch.IPC/Pipe/Messages/ErrorResponse.cs
+++ b/SoundSwitch.IPC/Pipe/Messages/ErrorResponse.cs
@@ -1,0 +1,11 @@
+#nullable enable
+using MessagePack;
+
+namespace SoundSwitch.IPC.Pipe.Messages;
+
+[MessagePackObject(keyAsPropertyName: true)]
+public class ErrorResponse : IPipeMessage
+{
+    public bool NotReady { get; set; }
+    public string Error { get; set; } = string.Empty;
+}

--- a/SoundSwitch.IPC/Pipe/Messages/IPipeMessage.cs
+++ b/SoundSwitch.IPC/Pipe/Messages/IPipeMessage.cs
@@ -27,6 +27,7 @@ namespace SoundSwitch.IPC.Pipe.Messages;
 [Union(12, typeof(GetActiveDevicesResponse))]
 [Union(13, typeof(GetSwitchableDevicesRequest))]
 [Union(14, typeof(GetSwitchableDevicesResponse))]
+[Union(15, typeof(ErrorResponse))]
 public interface IPipeMessage
 {
 }

--- a/SoundSwitch.IPC/Pipe/NamedPipe.cs
+++ b/SoundSwitch.IPC/Pipe/NamedPipe.cs
@@ -147,8 +147,15 @@ public static class NamedPipe
                         await serverStream.DisposeAsync();
                     }
 
-                    // Retry creating the server stream after a brief delay
-                    await Task.Delay(1000, token);
+                    try
+                    {
+                        // Retry creating the server stream after a brief delay
+                        await Task.Delay(1000, token);
+                    }
+                    catch (OperationCanceledException) when (token.IsCancellationRequested)
+                    {
+                        break; // Listener is shutting down
+                    }
                 }
             }
         }, token);

--- a/SoundSwitch.IPC/Pipe/NamedPipe.cs
+++ b/SoundSwitch.IPC/Pipe/NamedPipe.cs
@@ -17,6 +17,7 @@ public static class NamedPipe
     private static readonly MessagePackSerializerOptions SerializerOptions = MessagePackSerializerOptions.Standard;
     private static NamedPipeClientStream? _clientStream;
     private const int CONNECTION_TIMEOUT = 5000; // 5 seconds
+    private static readonly TimeSpan ResponseTimeout = TimeSpan.FromSeconds(15);
 
     private static readonly CancellationTokenSource CancellationTokenSource = new();
     private static readonly ConcurrentDictionary<Guid, Func<IPipeMessage, CancellationToken, Task<IPipeMessage>>> MessageHandlers = new();
@@ -24,6 +25,7 @@ public static class NamedPipe
     public static async Task<TResponse> SendRequestAsync<TResponse>(string pipeName, IPipeMessage request, CancellationToken cancellationToken = default) where TResponse : IPipeMessage
     {
         using var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, CancellationTokenSource.Token);
+        linkedTokenSource.CancelAfter(ResponseTimeout);
         var token = linkedTokenSource.Token;
         try
         {
@@ -56,14 +58,30 @@ public static class NamedPipe
                 throw new InvalidOperationException("Received null response from server");
             }
 
+            if (response is ErrorResponse errorResponse)
+            {
+                throw new PipeRequestException(errorResponse.Error, errorResponse.NotReady);
+            }
+
             return (TResponse)response;
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested && !CancellationTokenSource.IsCancellationRequested)
+        {
+            // Cancellation came from our own response timeout, not from the caller or app shutdown
+            DisposeClientStream();
+            throw new TimeoutException("The server did not respond within 15 seconds");
         }
         catch (Exception)
         {
-            _clientStream?.Dispose();
-            _clientStream = null;
+            DisposeClientStream();
             throw;
         }
+    }
+
+    private static void DisposeClientStream()
+    {
+        _clientStream?.Dispose();
+        _clientStream = null;
     }
 
     public static Guid RegisterMessageHandler(Func<IPipeMessage, CancellationToken, Task<IPipeMessage>> handler)
@@ -80,30 +98,39 @@ public static class NamedPipe
 
     public static void StartListening(string pipeName, CancellationToken cancellationToken = default)
     {
-        using var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, CancellationTokenSource.Token);
+        // Not disposed here on purpose: the returned token is used by the listener task and the
+        // per-connection handlers for the whole process lifetime. Disposing the linked source on
+        // method return would make later token registrations throw ObjectDisposedException.
+        var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, CancellationTokenSource.Token);
         var token = linkedTokenSource.Token;
         Task.Run(async () =>
         {
-            using var _ = LogContext.PushProperty("SourceContext", nameof(NamedPipe));
+            using var logContext = LogContext.PushProperty("SourceContext", nameof(NamedPipe));
             Log.Information("Starting named pipe server");
             while (!token.IsCancellationRequested)
             {
+                NamedPipeServerStream? serverStream = null;
                 try
                 {
                     var pipeId = Guid.NewGuid();
-                    var serverStream = new NamedPipeServerStream(pipeName, PipeDirection.InOut, NamedPipeServerStream.MaxAllowedServerInstances, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
+                    serverStream = new NamedPipeServerStream(pipeName, PipeDirection.InOut, NamedPipeServerStream.MaxAllowedServerInstances, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
                     Log.ForContext("PipeId", pipeId).Information("Waiting for connection");
                     await serverStream.WaitForConnectionAsync(token);
 
-                    ClientConnectedAsync(serverStream, pipeId, token);
+                    _ = ClientConnectedAsync(serverStream, pipeId, token);
                 }
                 catch (Exception)
                 {
+                    if (serverStream != null)
+                    {
+                        await serverStream.DisposeAsync();
+                    }
+
                     // Retry creating the server stream after a brief delay
                     await Task.Delay(1000, token);
                 }
             }
-        }, linkedTokenSource.Token);
+        }, token);
     }
 
     private static async Task HandleCommunicationAsync(NamedPipeServerStream stream, Guid id, CancellationToken cancellationToken)
@@ -115,58 +142,51 @@ public static class NamedPipe
         cts.CancelAfter(timeout);
         token.Register(() =>
         {
-            logger.Warning("No message received in the last {Timeout}", timeout);
-            if (stream.IsConnected)
+            try
             {
-                logger.Information("Disconnecting client");
-                stream.Disconnect();
+                logger.Warning("No message received in the last {Timeout}", timeout);
+                if (stream.IsConnected)
+                {
+                    logger.Information("Disconnecting client");
+                    stream.Disconnect();
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.Verbose(ex, "Failed to disconnect idle client");
             }
         });
         while (!token.IsCancellationRequested)
         {
             try
             {
-                // Read request with length prefix
+                // Read request with length prefix (idle timeout applies while waiting)
                 var lengthBuffer = new byte[4];
                 await ReadExactAsync(stream, lengthBuffer, 0, 4, token);
                 var messageLength = BitConverter.ToInt32(lengthBuffer, 0);
                 var messageBuffer = new byte[messageLength];
                 await ReadExactAsync(stream, messageBuffer, 0, messageLength, token);
 
-                cts.CancelAfter(timeout);
+                // Pause the idle timeout while the request is being processed
+                cts.CancelAfter(Timeout.InfiniteTimeSpan);
                 var request = MessagePackSerializer.Deserialize<IPipeMessage>(messageBuffer, SerializerOptions, token);
                 logger.Verbose("Message {MessageType} received", request.GetType().Name);
-                if (!MessageHandlers.IsEmpty)
-                {
-                    IPipeMessage? response = null;
-                    foreach (var handler in MessageHandlers.Values)
-                    {
-                        try
-                        {
-                            response = await handler(request, token);
-                            break;
-                        }
-                        catch (Exception ex)
-                        {
-                            Log.Error(ex, "Error executing message handler");
-                        }
-                    }
 
-                    if (response != null)
-                    {
-                        // Write response with length prefix
-                        var responseBuffer = MessagePackSerializer.Serialize(response, SerializerOptions);
-                        var responseLength = BitConverter.GetBytes(responseBuffer.Length);
-                        await stream.WriteAsync(responseLength, token);
-                        await stream.WriteAsync(responseBuffer, token);
-                        await stream.FlushAsync(token);
-                        logger.Verbose("Response {ResponseType} sent", response.GetType().Name);
-                    }
-                }
+                var response = await ProcessRequestAsync(request, token);
+
+                // Write response with length prefix
+                var responseBuffer = MessagePackSerializer.Serialize(response, SerializerOptions);
+                var responseLength = BitConverter.GetBytes(responseBuffer.Length);
+                await stream.WriteAsync(responseLength, token);
+                await stream.WriteAsync(responseBuffer, token);
+                await stream.FlushAsync(token);
+                logger.Verbose("Response {ResponseType} sent", response.GetType().Name);
             }
-            catch (IOException)
+            catch (IOException ex)
             {
-                await Task.Delay(500, token);
+                // The pipe is dead; spinning on it would never recover
+                logger.Debug(ex, "Pipe connection broken, closing");
+                break;
             }
             catch (OperationCanceledException)
             {
@@ -175,26 +195,76 @@ public static class NamedPipe
             {
                 logger.Error(ex, "Error handling communication");
             }
+            finally
+            {
+                // Re-arm the idle timeout before waiting for the next request
+                cts.CancelAfter(timeout);
+            }
         }
+    }
+
+    private static async Task<IPipeMessage> ProcessRequestAsync(IPipeMessage request, CancellationToken token)
+    {
+        if (MessageHandlers.IsEmpty)
+        {
+            Log.Warning("No message handler registered yet, server is still starting up");
+            return new ErrorResponse { NotReady = true, Error = "Server is still starting up" };
+        }
+
+        Exception? lastException = null;
+        foreach (var handler in MessageHandlers.Values)
+        {
+            try
+            {
+                var response = await handler(request, token);
+                if (response != null)
+                {
+                    return response;
+                }
+            }
+            catch (Exception ex)
+            {
+                lastException = ex;
+                Log.Error(ex, "Error executing message handler");
+            }
+        }
+
+        return new ErrorResponse
+        {
+            Error = lastException != null
+                ? $"All message handlers failed: {lastException.Message}"
+                : "No message handler produced a response"
+        };
     }
 
     private static async Task ClientConnectedAsync(NamedPipeServerStream stream, Guid id, CancellationToken token)
     {
+        var dispose = true;
         try
         {
             await HandleCommunicationAsync(stream, id, token).ConfigureAwait(false);
+            dispose = !stream.IsConnected;
         }
         catch (Exception)
         {
-            Log.ForContext("PipeId", id).Information("Disposing pipe");
-            await stream.DisposeAsync().ConfigureAwait(false);
-            return;
         }
 
-        if (!stream.IsConnected)
+        if (dispose)
+        {
+            await DisposeStreamAsync(stream, id).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task DisposeStreamAsync(NamedPipeServerStream stream, Guid id)
+    {
+        try
         {
             Log.ForContext("PipeId", id).Information("Disposing pipe");
             await stream.DisposeAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            Log.ForContext("PipeId", id).Debug(ex, "Failed to dispose pipe");
         }
     }
 

--- a/SoundSwitch.IPC/Pipe/NamedPipe.cs
+++ b/SoundSwitch.IPC/Pipe/NamedPipe.cs
@@ -16,8 +16,9 @@ public static class NamedPipe
 {
     private static readonly MessagePackSerializerOptions SerializerOptions = MessagePackSerializerOptions.Standard;
     private static NamedPipeClientStream? _clientStream;
+    private static string? _clientPipeName;
     private const int CONNECTION_TIMEOUT = 5000; // 5 seconds
-    private static readonly TimeSpan ResponseTimeout = TimeSpan.FromSeconds(15);
+    internal static TimeSpan ResponseTimeout { get; set; } = TimeSpan.FromSeconds(15);
 
     private static readonly CancellationTokenSource CancellationTokenSource = new();
     private static readonly ConcurrentDictionary<Guid, Func<IPipeMessage, CancellationToken, Task<IPipeMessage>>> MessageHandlers = new();
@@ -29,17 +30,18 @@ public static class NamedPipe
         var token = linkedTokenSource.Token;
         try
         {
-            if (_clientStream is not { IsConnected: true })
+            if (_clientStream is not { IsConnected: true } || _clientPipeName != pipeName)
             {
                 _clientStream?.Dispose();
                 _clientStream = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
+                _clientPipeName = pipeName;
             }
 
             if (!_clientStream.IsConnected)
                 await _clientStream.ConnectAsync(CONNECTION_TIMEOUT, token);
 
             // Write with length prefix
-            var buffer = MessagePackSerializer.Serialize(request, SerializerOptions, cancellationToken);
+            var buffer = MessagePackSerializer.Serialize(request, SerializerOptions, token);
             var length = BitConverter.GetBytes(buffer.Length);
             await _clientStream.WriteAsync(length, token);
             await _clientStream.WriteAsync(buffer, token);
@@ -52,7 +54,7 @@ public static class NamedPipe
             var responseBuffer = new byte[responseLength];
             await ReadExactAsync(_clientStream, responseBuffer, 0, responseLength, token);
 
-            var response = MessagePackSerializer.Deserialize<IPipeMessage>(responseBuffer, SerializerOptions, cancellationToken);
+            var response = MessagePackSerializer.Deserialize<IPipeMessage>(responseBuffer, SerializerOptions, token);
             if (response == null)
             {
                 throw new InvalidOperationException("Received null response from server");
@@ -69,7 +71,7 @@ public static class NamedPipe
         {
             // Cancellation came from our own response timeout, not from the caller or app shutdown
             DisposeClientStream();
-            throw new TimeoutException("The server did not respond within 15 seconds");
+            throw new TimeoutException($"The server did not respond within {ResponseTimeout}");
         }
         catch (Exception)
         {
@@ -82,6 +84,7 @@ public static class NamedPipe
     {
         _clientStream?.Dispose();
         _clientStream = null;
+        _clientPipeName = null;
     }
 
     public static Guid RegisterMessageHandler(Func<IPipeMessage, CancellationToken, Task<IPipeMessage>> handler)
@@ -239,20 +242,17 @@ public static class NamedPipe
 
     private static async Task ClientConnectedAsync(NamedPipeServerStream stream, Guid id, CancellationToken token)
     {
-        var dispose = true;
         try
         {
             await HandleCommunicationAsync(stream, id, token).ConfigureAwait(false);
-            dispose = !stream.IsConnected;
         }
         catch (Exception)
         {
         }
 
-        if (dispose)
-        {
-            await DisposeStreamAsync(stream, id).ConfigureAwait(false);
-        }
+        // Always dispose: IsConnected stays true for a server stream until Disconnect/Dispose,
+        // so it cannot tell us the pipe died via an IOException break.
+        await DisposeStreamAsync(stream, id).ConfigureAwait(false);
     }
 
     private static async Task DisposeStreamAsync(NamedPipeServerStream stream, Guid id)
@@ -298,5 +298,6 @@ public static class NamedPipe
         CancellationTokenSource.Dispose();
         _clientStream?.Dispose();
         _clientStream = null;
+        _clientPipeName = null;
     }
 }

--- a/SoundSwitch.IPC/Pipe/NamedPipe.cs
+++ b/SoundSwitch.IPC/Pipe/NamedPipe.cs
@@ -21,6 +21,7 @@ public static class NamedPipe
     internal static TimeSpan ResponseTimeout { get; set; } = TimeSpan.FromSeconds(15);
     // Idle wait before the server disconnects a silent client; internal/settable for tests.
     internal static TimeSpan ServerIdleTimeout { get; set; } = TimeSpan.FromSeconds(10);
+    private const int MaxMessageSize = 1024 * 1024; // 1 MiB — control messages are a few KB at most
 
     private static readonly CancellationTokenSource CancellationTokenSource = new();
     private static readonly ConcurrentDictionary<Guid, Func<IPipeMessage, CancellationToken, Task<IPipeMessage>>> MessageHandlers = new();
@@ -53,6 +54,11 @@ public static class NamedPipe
             var lengthBuffer = new byte[4];
             await ReadExactAsync(_clientStream, lengthBuffer, 0, 4, token);
             var responseLength = BitConverter.ToInt32(lengthBuffer, 0);
+            if (responseLength <= 0 || responseLength > MaxMessageSize)
+            {
+                throw new InvalidDataException($"Server sent invalid response length {responseLength}");
+            }
+
             var responseBuffer = new byte[responseLength];
             await ReadExactAsync(_clientStream, responseBuffer, 0, responseLength, token);
 
@@ -124,8 +130,18 @@ public static class NamedPipe
 
                     _ = ClientConnectedAsync(serverStream, pipeId, token);
                 }
-                catch (Exception)
+                catch (OperationCanceledException) when (token.IsCancellationRequested)
                 {
+                    if (serverStream != null)
+                    {
+                        await serverStream.DisposeAsync();
+                    }
+
+                    break; // Listener is shutting down
+                }
+                catch (Exception ex)
+                {
+                    Log.Warning(ex, "Pipe accept loop failed, retrying");
                     if (serverStream != null)
                     {
                         await serverStream.DisposeAsync();
@@ -168,6 +184,12 @@ public static class NamedPipe
                 var lengthBuffer = new byte[4];
                 await ReadExactAsync(stream, lengthBuffer, 0, 4, token);
                 var messageLength = BitConverter.ToInt32(lengthBuffer, 0);
+                if (messageLength <= 0 || messageLength > MaxMessageSize)
+                {
+                    logger.Warning("Rejecting message with invalid length {MessageLength}", messageLength);
+                    break;
+                }
+
                 var messageBuffer = new byte[messageLength];
                 await ReadExactAsync(stream, messageBuffer, 0, messageLength, token);
 
@@ -247,8 +269,9 @@ public static class NamedPipe
         {
             await HandleCommunicationAsync(stream, id, token).ConfigureAwait(false);
         }
-        catch (Exception)
+        catch (Exception ex)
         {
+            Log.ForContext("PipeId", id).Debug(ex, "Unhandled exception while handling pipe communication");
         }
 
         // Always dispose: IsConnected stays true for a server stream until Disconnect/Dispose,

--- a/SoundSwitch.IPC/Pipe/NamedPipe.cs
+++ b/SoundSwitch.IPC/Pipe/NamedPipe.cs
@@ -19,6 +19,8 @@ public static class NamedPipe
     private static string? _clientPipeName;
     private const int CONNECTION_TIMEOUT = 5000; // 5 seconds
     internal static TimeSpan ResponseTimeout { get; set; } = TimeSpan.FromSeconds(15);
+    // Idle wait before the server disconnects a silent client; internal/settable for tests.
+    internal static TimeSpan ServerIdleTimeout { get; set; } = TimeSpan.FromSeconds(10);
 
     private static readonly CancellationTokenSource CancellationTokenSource = new();
     private static readonly ConcurrentDictionary<Guid, Func<IPipeMessage, CancellationToken, Task<IPipeMessage>>> MessageHandlers = new();
@@ -141,13 +143,12 @@ public static class NamedPipe
         var logger = Log.ForContext("PipeId", id);
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         var token = cts.Token;
-        var timeout = TimeSpan.FromSeconds(10);
-        cts.CancelAfter(timeout);
+        cts.CancelAfter(ServerIdleTimeout);
         token.Register(() =>
         {
             try
             {
-                logger.Warning("No message received in the last {Timeout}", timeout);
+                logger.Warning("No message received in the last {Timeout}", ServerIdleTimeout);
                 if (stream.IsConnected)
                 {
                     logger.Information("Disconnecting client");
@@ -201,7 +202,7 @@ public static class NamedPipe
             finally
             {
                 // Re-arm the idle timeout before waiting for the next request
-                cts.CancelAfter(timeout);
+                cts.CancelAfter(ServerIdleTimeout);
             }
         }
     }

--- a/SoundSwitch.IPC/Pipe/PipeRequestException.cs
+++ b/SoundSwitch.IPC/Pipe/PipeRequestException.cs
@@ -1,0 +1,19 @@
+#nullable enable
+namespace SoundSwitch.IPC.Pipe;
+
+/// <summary>
+/// Thrown when the pipe server explicitly reports a failure instead of a regular response.
+/// </summary>
+public sealed class PipeRequestException : Exception
+{
+    /// <summary>
+    /// True when the server hadn't registered its message handlers yet (still starting up).
+    /// Callers may retry instead of treating this as a hard failure.
+    /// </summary>
+    public bool NotReady { get; }
+
+    public PipeRequestException(string message, bool notReady = false) : base(message)
+    {
+        NotReady = notReady;
+    }
+}

--- a/SoundSwitch.IPC/SoundSwitch.IPC.csproj
+++ b/SoundSwitch.IPC/SoundSwitch.IPC.csproj
@@ -12,4 +12,8 @@
     <PackageReference Include="MessagePack" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="SoundSwitch.IPC.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/SoundSwitch.sln
+++ b/SoundSwitch.sln
@@ -19,6 +19,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SoundSwitch.IPC", "SoundSwi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SoundSwitch.CLI", "SoundSwitch.CLI\SoundSwitch.CLI.csproj", "{D5655B17-6644-4255-BD7C-2248B8E16789}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SoundSwitch.IPC.Tests", "SoundSwitch.IPC.Tests\SoundSwitch.IPC.Tests.csproj", "{DB481CB8-D056-4258-9AD1-896481633D05}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Beta|Any CPU = Beta|Any CPU
@@ -227,6 +229,30 @@ Global
 		{D5655B17-6644-4255-BD7C-2248B8E16789}.Release|x64.Build.0 = Release|Any CPU
 		{D5655B17-6644-4255-BD7C-2248B8E16789}.Release|x86.ActiveCfg = Release|Any CPU
 		{D5655B17-6644-4255-BD7C-2248B8E16789}.Release|x86.Build.0 = Release|Any CPU
+		{DB481CB8-D056-4258-9AD1-896481633D05}.Beta|Any CPU.ActiveCfg = Debug|Any CPU
+		{DB481CB8-D056-4258-9AD1-896481633D05}.Beta|Any CPU.Build.0 = Debug|Any CPU
+		{DB481CB8-D056-4258-9AD1-896481633D05}.Beta|x64.ActiveCfg = Debug|Any CPU
+		{DB481CB8-D056-4258-9AD1-896481633D05}.Beta|x64.Build.0 = Debug|Any CPU
+		{DB481CB8-D056-4258-9AD1-896481633D05}.Beta|x86.ActiveCfg = Debug|Any CPU
+		{DB481CB8-D056-4258-9AD1-896481633D05}.Beta|x86.Build.0 = Debug|Any CPU
+		{DB481CB8-D056-4258-9AD1-896481633D05}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DB481CB8-D056-4258-9AD1-896481633D05}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DB481CB8-D056-4258-9AD1-896481633D05}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DB481CB8-D056-4258-9AD1-896481633D05}.Debug|x64.Build.0 = Debug|Any CPU
+		{DB481CB8-D056-4258-9AD1-896481633D05}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DB481CB8-D056-4258-9AD1-896481633D05}.Debug|x86.Build.0 = Debug|Any CPU
+		{DB481CB8-D056-4258-9AD1-896481633D05}.Nightly|Any CPU.ActiveCfg = Debug|Any CPU
+		{DB481CB8-D056-4258-9AD1-896481633D05}.Nightly|Any CPU.Build.0 = Debug|Any CPU
+		{DB481CB8-D056-4258-9AD1-896481633D05}.Nightly|x64.ActiveCfg = Debug|Any CPU
+		{DB481CB8-D056-4258-9AD1-896481633D05}.Nightly|x64.Build.0 = Debug|Any CPU
+		{DB481CB8-D056-4258-9AD1-896481633D05}.Nightly|x86.ActiveCfg = Debug|Any CPU
+		{DB481CB8-D056-4258-9AD1-896481633D05}.Nightly|x86.Build.0 = Debug|Any CPU
+		{DB481CB8-D056-4258-9AD1-896481633D05}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DB481CB8-D056-4258-9AD1-896481633D05}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DB481CB8-D056-4258-9AD1-896481633D05}.Release|x64.ActiveCfg = Release|Any CPU
+		{DB481CB8-D056-4258-9AD1-896481633D05}.Release|x64.Build.0 = Release|Any CPU
+		{DB481CB8-D056-4258-9AD1-896481633D05}.Release|x86.ActiveCfg = Release|Any CPU
+		{DB481CB8-D056-4258-9AD1-896481633D05}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SoundSwitch/Model/SoundSwitchApplicationContext.cs
+++ b/SoundSwitch/Model/SoundSwitchApplicationContext.cs
@@ -146,16 +146,32 @@ public class SoundSwitchApplicationContext : ApplicationContext
 
             case OpenSettingsRequest:
                 Log.Information("Asked by other instance to show settings");
-                AppModel.Instance.TrayIcon.ShowSettings();
-                return new OpenSettingsResponse { Success = true };
+                try
+                {
+                    AppModel.Instance.TrayIcon.ShowSettings();
+                    return new OpenSettingsResponse { Success = true };
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, "Failed to show settings");
+                    return new OpenSettingsResponse { Success = false };
+                }
 
             case TriggerProfileRequest profileRequest:
                 Log.Information("Triggering profile: {ProfileName}", profileRequest.ProfileName);
                 var profile = AppModel.Instance.ProfileManager.Profiles.FirstOrDefault(p => p.Name == profileRequest.ProfileName);
                 if (profile != null)
                 {
-                    AppModel.Instance.ProfileManager.SwitchAudio(profile);
-                    return new TriggerProfileResponse { Success = true };
+                    try
+                    {
+                        AppModel.Instance.ProfileManager.SwitchAudio(profile);
+                        return new TriggerProfileResponse { Success = true };
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Error(ex, "Failed to switch audio for profile {ProfileName}", profileRequest.ProfileName);
+                        return new TriggerProfileResponse { Success = false, Error = ex.Message };
+                    }
                 }
 
                 Log.Warning("Profile not found: {ProfileName}", profileRequest.ProfileName);

--- a/SoundSwitch/Program.cs
+++ b/SoundSwitch/Program.cs
@@ -161,9 +161,10 @@ internal static class Program
         _synchronizationContext = new WindowsFormsSynchronizationContext();
         SynchronizationContext.SetSynchronizationContext(_synchronizationContext);
 
+        var appContext = new SoundSwitchApplicationContext();
         NamedPipe.StartListening(userMutexName, mainCts.Token);
 
-        Application.Run(new SoundSwitchApplicationContext());
+        Application.Run(appContext);
 
 
 #if !DEBUG


### PR DESCRIPTION
## Problem

**Sentry issue SOUNDSWITCH-2XQ** ([6349885926](https://soundswitch.sentry.io/issues/6349885926/)) — `System.IO.EndOfStreamException` in `NamedPipe.ReadExactAsync`, **116k+ occurrences / 9.9k users** since 2025-03. The named pipe server accepted a request but closed the connection without ever writing a response, so the client hit EOF reading the response.

### Root causes

1. **Startup race**: `Program.cs` called `NamedPipe.StartListening` before `SoundSwitchApplicationContext` was constructed, so the pipe server accepted connections with **zero message handlers registered**; requests read in that window never got a response, and the 10s idle timeout then disconnected the client → EOF.
2. **Handler failure/null-response paths** wrote nothing, leaving the client hanging until the idle-timeout disconnect.
3. **The 10s idle timeout** kept ticking while a request was being processed, disconnecting slow in-flight requests (e.g. `ShowSettings` marshaling to a busy UI thread).
4. **The linked `CancellationTokenSource`** in `StartListening` was disposed when the (void) method returned, so later token registrations in the listener/connection handlers could fault.

## Fix

- **Server guarantees a response for every request**: new `ErrorResponse` message (union key 15) sent when no handler is registered yet (`NotReady = true`) or when all handlers fail.
- **Idle timeout paused** while a request is being processed; re-armed only while waiting for the next request.
- `IOException` on a dead pipe breaks the read loop instead of spinning.
- **`Program.cs` constructs the application context** (which registers the pipe handler) **BEFORE** `StartListening`, closing the startup race.
- **Client**: 15s response timeout → clear `TimeoutException`; server `ErrorResponse` → new `PipeRequestException` (with `NotReady` flag so callers can distinguish retry-worthy failures).
- **Server stream disposed** when `WaitForConnectionAsync` fails; defensive disposal in `ClientConnectedAsync`; `OpenSettingsRequest`/`TriggerProfileRequest` handlers return failure responses instead of throwing.

## Compatibility

Only additive contract change (union 15). Mixed-version behavior is no worse than before — old client talking to a failing new server got EOF before, gets a deserialization error now; both are caught and logged by existing handlers.

## Testing

- Verified builds on Linux for SoundSwitch.IPC, SoundSwitch (with `EnableWindowsTargeting` workaround), and SoundSwitch.CLI.
- **Full-solution build and runtime pipe behavior need Windows/CI validation** — this repos pipe tests are platform-specific and cannot run on Linux.