### PR TITLE
fix(audio): report persistent-policy routing failures from SwitchProcessTo

### DIFF
--- a/SoundSwitch.Audio.Manager.Tests/SwitchProcessToRoutingTests.cs
+++ b/SoundSwitch.Audio.Manager.Tests/SwitchProcessToRoutingTests.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Runtime.InteropServices;
+
+using FluentAssertions;
+
+using NUnit.Framework;
+
+using SoundSwitch.Audio.Manager.Interop.Client;
+using SoundSwitch.Audio.Manager.Interop.Client.Extended;
+using SoundSwitch.Audio.Manager.Interop.Enum;
+using SoundSwitch.Audio.Manager.Interop.Interface.Policy.Extended;
+
+namespace SoundSwitch.Audio.Manager.Tests;
+
+[TestFixture]
+public sealed class SwitchProcessToRoutingTests
+{
+    private enum FakeMode
+    {
+        ReturnTrue,
+        ReturnFalse,
+        Throw
+    }
+
+    private sealed class FakePolicyConfig : IAudioPolicyConfig
+    {
+        private readonly FakeMode _mode;
+        private readonly string _getResult;
+
+        public FakePolicyConfig(FakeMode mode, string getResult = null)
+        {
+            _mode = mode;
+            _getResult = getResult;
+        }
+
+        public bool SetPersistedDefaultAudioEndpoint(uint processId, EDataFlow flow, ERole role, string deviceId)
+        {
+            switch (_mode)
+            {
+                case FakeMode.ReturnTrue:
+                    return true;
+                case FakeMode.ReturnFalse:
+                    return false;
+                case FakeMode.Throw:
+                    throw new InvalidComObjectException("forced failure");
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        public string GetPersistedDefaultAudioEndpoint(uint processId, EDataFlow flow, ERole role) => _getResult;
+
+        public void ClearAllPersistedApplicationDefaultEndpoints()
+        {
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private static readonly uint ProcessId = 1234;
+    private const string DeviceId = "test-device";
+    private static readonly ERole[] AllRoles = { ERole.eConsole, ERole.eMultimedia, ERole.eCommunications };
+
+    [Test]
+    public void ExtendedPolicyClient_SetDefaultEndPoint_ReturnsTrue_WhenPolicySucceeds()
+    {
+        var client = new ExtendedPolicyClient(new FakePolicyConfig(FakeMode.ReturnTrue));
+
+        var result = client.SetDefaultEndPoint(DeviceId, EDataFlow.eRender, AllRoles, ProcessId);
+
+        result.Should().BeTrue();
+    }
+
+    [Test]
+    public void ExtendedPolicyClient_SetDefaultEndPoint_ReturnsFalse_WhenPolicyReturnsFalse()
+    {
+        var client = new ExtendedPolicyClient(new FakePolicyConfig(FakeMode.ReturnFalse));
+
+        var result = client.SetDefaultEndPoint(DeviceId, EDataFlow.eRender, AllRoles, ProcessId);
+
+        result.Should().BeFalse();
+    }
+
+    [Test]
+    public void ExtendedPolicyClient_SetDefaultEndPoint_ReturnsFalse_WhenPolicyThrows()
+    {
+        var client = new ExtendedPolicyClient(new FakePolicyConfig(FakeMode.Throw));
+
+        var result = client.SetDefaultEndPoint(DeviceId, EDataFlow.eRender, AllRoles, ProcessId);
+
+        result.Should().BeFalse();
+    }
+
+    [Test]
+    public void ExtendedPolicyClient_SetDefaultEndPoint_ReturnsFalse_WhenDeviceIdIsEmpty()
+    {
+        var client = new ExtendedPolicyClient(new FakePolicyConfig(FakeMode.ReturnTrue));
+
+        var result = client.SetDefaultEndPoint("", EDataFlow.eRender, AllRoles, ProcessId);
+
+        result.Should().BeFalse();
+    }
+
+    [Test]
+    public void ExtendedPolicyClient_SetDefaultEndPoint_ReturnsFalse_ForUnsupportedPolicy()
+    {
+        var client = new ExtendedPolicyClient(new UnsupportedAudioPolicyConfig());
+
+        var result = client.SetDefaultEndPoint(DeviceId, EDataFlow.eRender, AllRoles, ProcessId);
+
+        result.Should().BeFalse();
+    }
+
+    [Test]
+    public void UnsupportedAudioPolicyConfig_SetPersistedDefaultAudioEndpoint_ReturnsFalse()
+    {
+        IAudioPolicyConfig config = new UnsupportedAudioPolicyConfig();
+
+        var result = config.SetPersistedDefaultAudioEndpoint(ProcessId, EDataFlow.eRender, ERole.eConsole, DeviceId);
+
+        result.Should().BeFalse();
+    }
+
+    [Test]
+    [Platform("Win")]
+    public void SwitchProcessTo_ReturnsFalse_WhenEndpointAlreadySelected()
+    {
+        var switcher = SoundSwitch.Audio.Manager.AudioSwitcher.Instance;
+        switcher.SetExtendedPolicyClientForTest(new ExtendedPolicyClient(new FakePolicyConfig(FakeMode.ReturnTrue, DeviceId)));
+
+        var result = switcher.SwitchProcessTo(DeviceId, ERole.ERole_enum_count, EDataFlow.eRender, ProcessId);
+
+        result.Should().BeFalse();
+    }
+
+    [Test]
+    [Platform("Win")]
+    public void SwitchProcessTo_ReturnsTrue_WhenRoutingSucceeds()
+    {
+        var switcher = SoundSwitch.Audio.Manager.AudioSwitcher.Instance;
+        switcher.SetExtendedPolicyClientForTest(new ExtendedPolicyClient(new FakePolicyConfig(FakeMode.ReturnTrue)));
+
+        var result = switcher.SwitchProcessTo(DeviceId, ERole.ERole_enum_count, EDataFlow.eRender, ProcessId);
+
+        result.Should().BeTrue();
+    }
+
+    [Test]
+    [Platform("Win")]
+    public void SwitchProcessTo_ReturnsFalse_WhenRoutingFails()
+    {
+        var switcher = SoundSwitch.Audio.Manager.AudioSwitcher.Instance;
+        switcher.SetExtendedPolicyClientForTest(new ExtendedPolicyClient(new FakePolicyConfig(FakeMode.ReturnFalse)));
+
+        var result = switcher.SwitchProcessTo(DeviceId, ERole.ERole_enum_count, EDataFlow.eRender, ProcessId);
+
+        result.Should().BeFalse();
+    }
+}

--- a/SoundSwitch.Audio.Manager.Tests/SwitchProcessToRoutingTests.cs
+++ b/SoundSwitch.Audio.Manager.Tests/SwitchProcessToRoutingTests.cs
@@ -59,7 +59,7 @@ public sealed class SwitchProcessToRoutingTests
         }
     }
 
-    private static readonly uint ProcessId = 1234;
+    private static uint ProcessId => (uint)Environment.ProcessId;
     private const string DeviceId = "test-device";
     private static readonly ERole[] AllRoles = { ERole.eConsole, ERole.eMultimedia, ERole.eCommunications };
 

--- a/SoundSwitch.Audio.Manager.Tests/SwitchProcessToRoutingTests.cs
+++ b/SoundSwitch.Audio.Manager.Tests/SwitchProcessToRoutingTests.cs
@@ -25,9 +25,9 @@ public sealed class SwitchProcessToRoutingTests
     private sealed class FakePolicyConfig : IAudioPolicyConfig
     {
         private readonly FakeMode _mode;
-        private readonly string _getResult;
+        private readonly string? _getResult;
 
-        public FakePolicyConfig(FakeMode mode, string getResult = null)
+        public FakePolicyConfig(FakeMode mode, string? getResult = null)
         {
             _mode = mode;
             _getResult = getResult;
@@ -48,7 +48,7 @@ public sealed class SwitchProcessToRoutingTests
             }
         }
 
-        public string GetPersistedDefaultAudioEndpoint(uint processId, EDataFlow flow, ERole role) => _getResult;
+        public string? GetPersistedDefaultAudioEndpoint(uint processId, EDataFlow flow, ERole role) => _getResult;
 
         public void ClearAllPersistedApplicationDefaultEndpoints()
         {
@@ -62,6 +62,14 @@ public sealed class SwitchProcessToRoutingTests
     private static uint ProcessId => (uint)Environment.ProcessId;
     private const string DeviceId = "test-device";
     private static readonly ERole[] AllRoles = { ERole.eConsole, ERole.eMultimedia, ERole.eCommunications };
+
+    [TearDown]
+    public void RestoreSingletonClient()
+    {
+        // The tests replace the cached ExtendedPolicyClient on the AudioSwitcher
+        // singleton; restore the default so later tests aren't order-dependent.
+        SoundSwitch.Audio.Manager.AudioSwitcher.Instance.SetExtendedPolicyClientForTest(null);
+    }
 
     [Test]
     public void ExtendedPolicyClient_SetDefaultEndPoint_ReturnsTrue_WhenPolicySucceeds()

--- a/SoundSwitch.Audio.Manager/AudioSwitcher.cs
+++ b/SoundSwitch.Audio.Manager/AudioSwitcher.cs
@@ -59,6 +59,12 @@ namespace SoundSwitch.Audio.Manager
             }
         }
 
+        /// <summary>
+        /// Test seam: inject a pre-built <see cref="ExtendedPolicyClient"/> so callers
+        /// can be exercised without relying on the COM-backed default instance.
+        /// </summary>
+        internal void SetExtendedPolicyClientForTest(ExtendedPolicyClient client) => _extendedPolicyClient = client;
+
         private AudioSwitcher()
         {
         }
@@ -154,8 +160,7 @@ namespace SoundSwitch.Audio.Manager
                     return false;
                 }
 
-                ExtendPolicyClient.SetDefaultEndPoint(deviceId, flow, roles, processId);
-                return true;
+                return ExtendPolicyClient.SetDefaultEndPoint(deviceId, flow, roles, processId);
             }));
         }
 

--- a/SoundSwitch.Audio.Manager/AudioSwitcher.cs
+++ b/SoundSwitch.Audio.Manager/AudioSwitcher.cs
@@ -62,8 +62,9 @@ namespace SoundSwitch.Audio.Manager
         /// <summary>
         /// Test seam: inject a pre-built <see cref="ExtendedPolicyClient"/> so callers
         /// can be exercised without relying on the COM-backed default instance.
+        /// Pass <c>null</c> to clear the injected client and fall back to the default.
         /// </summary>
-        internal void SetExtendedPolicyClientForTest(ExtendedPolicyClient client) => _extendedPolicyClient = client;
+        internal void SetExtendedPolicyClientForTest(ExtendedPolicyClient? client) => _extendedPolicyClient = client;
 
         private AudioSwitcher()
         {

--- a/SoundSwitch.Audio.Manager/Interop/Client/Extended/AudioPolicyConfig.cs
+++ b/SoundSwitch.Audio.Manager/Interop/Client/Extended/AudioPolicyConfig.cs
@@ -125,10 +125,20 @@ namespace SoundSwitch.Audio.Manager.Interop.Client.Extended
             var setPersistedDefaultAudioEndpointPtr = Marshal.PtrToStructure<IntPtr>(_vfTable + (_ptrSize * 25));
             var setPersistedDefaultAudioEndpoint = Marshal.GetDelegateForFunctionPointer<SetPersistedDefaultAudioEndpointDelegate>(setPersistedDefaultAudioEndpointPtr);
             var result = setPersistedDefaultAudioEndpoint(_factory, processId, flow, role, deviceIdHString);
-            if (result != HRESULT.S_OK && result != HRESULT.PROCESS_NO_AUDIO)
-                throw new InvalidComObjectException($"Can't set the persistent audio endpoint: {result}");
+            if (result == HRESULT.S_OK)
+            {
+                return true;
+            }
 
-            return true;
+            // PROCESS_NO_AUDIO (E_INVALIDARG) means the call was a no-op and the
+            // endpoint was not applied. Treat that as a failure so callers don't
+            // report a successful routing when nothing changed.
+            if (result == HRESULT.PROCESS_NO_AUDIO)
+            {
+                return false;
+            }
+
+            throw new InvalidComObjectException($"Can't set the persistent audio endpoint: {result}");
         }
 
         public void ClearAllPersistedApplicationDefaultEndpoints()

--- a/SoundSwitch.Audio.Manager/Interop/Client/Extended/AudioPolicyConfig.cs
+++ b/SoundSwitch.Audio.Manager/Interop/Client/Extended/AudioPolicyConfig.cs
@@ -119,7 +119,7 @@ namespace SoundSwitch.Audio.Manager.Interop.Client.Extended
             }
         }
 
-        public void SetPersistedDefaultAudioEndpoint(uint processId, EDataFlow flow, ERole role, string deviceId)
+        public bool SetPersistedDefaultAudioEndpoint(uint processId, EDataFlow flow, ERole role, string deviceId)
         {
             using var deviceIdHString = HSTRING.FromString(deviceId);
             var setPersistedDefaultAudioEndpointPtr = Marshal.PtrToStructure<IntPtr>(_vfTable + (_ptrSize * 25));
@@ -127,6 +127,8 @@ namespace SoundSwitch.Audio.Manager.Interop.Client.Extended
             var result = setPersistedDefaultAudioEndpoint(_factory, processId, flow, role, deviceIdHString);
             if (result != HRESULT.S_OK && result != HRESULT.PROCESS_NO_AUDIO)
                 throw new InvalidComObjectException($"Can't set the persistent audio endpoint: {result}");
+
+            return true;
         }
 
         public void ClearAllPersistedApplicationDefaultEndpoints()

--- a/SoundSwitch.Audio.Manager/Interop/Client/Extended/UnsupportedAudioPolicyConfig.cs
+++ b/SoundSwitch.Audio.Manager/Interop/Client/Extended/UnsupportedAudioPolicyConfig.cs
@@ -6,8 +6,9 @@ namespace SoundSwitch.Audio.Manager.Interop.Client.Extended;
 
 public class UnsupportedAudioPolicyConfig : IAudioPolicyConfig
 {
-    public void SetPersistedDefaultAudioEndpoint(uint processId, EDataFlow flow, ERole role, string deviceId)
+    public bool SetPersistedDefaultAudioEndpoint(uint processId, EDataFlow flow, ERole role, string deviceId)
     {
+        return false;
     }
 
     public string? GetPersistedDefaultAudioEndpoint(uint processId, EDataFlow flow, ERole role)

--- a/SoundSwitch.Audio.Manager/Interop/Client/ExtendedPolicyClient.cs
+++ b/SoundSwitch.Audio.Manager/Interop/Client/ExtendedPolicyClient.cs
@@ -26,6 +26,12 @@ namespace SoundSwitch.Audio.Manager.Interop.Client
             _log = Log.ForContext(GetType());
         }
 
+        internal ExtendedPolicyClient(IAudioPolicyConfig policyConfig)
+        {
+            _log = Log.ForContext(GetType());
+            _sharedPolicyConfig = policyConfig;
+        }
+
         private IAudioPolicyConfig PolicyConfig
         {
             get
@@ -57,34 +63,47 @@ namespace SoundSwitch.Audio.Manager.Interop.Client
             return deviceId;
         }
 
-        public void SetDefaultEndPoint(string deviceId, EDataFlow flow, IEnumerable<ERole> roles, uint processId)
+        public bool SetDefaultEndPoint(string deviceId, EDataFlow flow, IEnumerable<ERole> roles, uint processId)
         {
             _log.Information("ExtendedPolicyClient SetDefaultEndPoint {DeviceId} [{Flow}] {ProcessId}", deviceId, flow, processId);
+            if (string.IsNullOrEmpty(deviceId))
+            {
+                return false;
+            }
+
+            var deviceIdStr = GenerateDeviceId(deviceId, flow);
+            var anySuccess = false;
             try
             {
-                if (string.IsNullOrEmpty(deviceId))
-                {
-                    return;
-                }
-
-                var deviceIdStr = GenerateDeviceId(deviceId, flow);
                 foreach (var eRole in roles)
                 {
-                    PolicyConfig.SetPersistedDefaultAudioEndpoint(processId, flow, eRole, deviceIdStr);
+                    try
+                    {
+                        if (PolicyConfig.SetPersistedDefaultAudioEndpoint(processId, flow, eRole, deviceIdStr))
+                        {
+                            anySuccess = true;
+                        }
+                    }
+                    catch (InvalidComObjectException)
+                    {
+                        _log.Warning("Set the default endpoint [{DeviceId}]for process {ProcessId}", deviceId, processId);
+                    }
+                    catch (COMException e) when ((e.ErrorCode & ErrorConst.COM_ERROR_MASK) == ErrorConst.COM_ERROR_NOT_FOUND)
+                    {
+                        throw new DeviceNotFoundException($"Can't set default as {deviceId}", e, deviceId);
+                    }
+                    catch (Exception ex)
+                    {
+                        _log.Error(ex, "Can't set the default endpoint");
+                    }
                 }
             }
-            catch (InvalidComObjectException)
+            catch (DeviceNotFoundException)
             {
-                _log.Warning("Set the default endpoint [{DeviceId}]for process {ProcessId}", deviceId, processId);
+                throw;
             }
-            catch (COMException e) when ((e.ErrorCode & ErrorConst.COM_ERROR_MASK) == ErrorConst.COM_ERROR_NOT_FOUND)
-            {
-                throw new DeviceNotFoundException($"Can't set default as {deviceId}", e, deviceId);
-            }
-            catch (Exception ex)
-            {
-                _log.Error(ex, "Can't set the default endpoint");
-            }
+
+            return anySuccess;
         }
 
         /// <summary>

--- a/SoundSwitch.Audio.Manager/Interop/Client/ExtendedPolicyClient.cs
+++ b/SoundSwitch.Audio.Manager/Interop/Client/ExtendedPolicyClient.cs
@@ -28,6 +28,7 @@ namespace SoundSwitch.Audio.Manager.Interop.Client
 
         internal ExtendedPolicyClient(IAudioPolicyConfig policyConfig)
         {
+            ArgumentNullException.ThrowIfNull(policyConfig);
             _log = Log.ForContext(GetType());
             _sharedPolicyConfig = policyConfig;
         }
@@ -86,7 +87,7 @@ namespace SoundSwitch.Audio.Manager.Interop.Client
                     }
                     catch (InvalidComObjectException)
                     {
-                        _log.Warning("Set the default endpoint [{DeviceId}]for process {ProcessId}", deviceId, processId);
+                        _log.Warning("Set the default endpoint [{DeviceId}] for process {ProcessId}", deviceId, processId);
                     }
                     catch (COMException e) when ((e.ErrorCode & ErrorConst.COM_ERROR_MASK) == ErrorConst.COM_ERROR_NOT_FOUND)
                     {

--- a/SoundSwitch.Audio.Manager/Interop/Interface/Policy/Extended/IAudioPolicyConfig.cs
+++ b/SoundSwitch.Audio.Manager/Interop/Interface/Policy/Extended/IAudioPolicyConfig.cs
@@ -14,7 +14,8 @@ public interface IAudioPolicyConfig : IDisposable
     /// <param name="flow"></param>
     /// <param name="role"></param>
     /// <param name="deviceId"></param>
-    void SetPersistedDefaultAudioEndpoint(uint processId, EDataFlow flow, ERole role, string deviceId);
+    /// <returns><c>true</c> if the endpoint was written successfully; <c>false</c> otherwise.</returns>
+    bool SetPersistedDefaultAudioEndpoint(uint processId, EDataFlow flow, ERole role, string deviceId);
 
     /// <summary>
     /// Get Audio endpoint of the process


### PR DESCRIPTION
## Summary

Fixes #2349 — `AudioSwitcher.SwitchProcessTo` reported a successful routing even when the persistent-policy write did not actually take effect.

`ExtendedPolicyClient.SetDefaultEndPoint` previously caught all exceptions and only logged them, so `SwitchProcessTo` returned `true` even when the route was never applied (e.g. the unsupported-policy no-op path, or a runtime COM failure). The `UnsupportedAudioPolicyConfig` implementation is a silent no-op, so on an unsupported OS the routing "succeeded" from the caller's point of view while nothing changed.

### Changes
- `IAudioPolicyConfig.SetPersistedDefaultAudioEndpoint` now returns `bool` (success of the write).
- `AudioPolicyConfig` returns `true` on a successful call to the underlying API; `UnsupportedAudioPolicyConfig` returns `false` (no-op path).
- `ExtendedPolicyClient.SetDefaultEndPoint` returns `true` only if at least one role's write succeeded, `false` otherwise (still logs failures).
- `AudioSwitcher.SwitchProcessTo` returns the result of `SetDefaultEndPoint` instead of unconditionally `true`. The already-selected (`allRolesAlreadyMatch`) path still returns `false` (no change), so callers like `AppSoundLockManager` and `ProfileManager` no longer count a no-op or failed routing as an activation.

### Tests
- Added `SoundSwitch.Audio.Manager.Tests/SwitchProcessToRoutingTests.cs` covering: already-selected returns false, successful routing returns true, unsupported-policy (no-op) returns false, and a failing COM write returns false.

### Notes
- Behavior change is contained to the routing layer; all callers already treat `false` as "no change / not applied".
- `SoundSwitch.Audio.Manager` cannot be built on Linux in this environment (uses `cswinrt.exe`); correctness relies on Windows CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
