### PR TITLE
fix(updater): install update into the running app directory (issue #2353)

### DIFF
--- a/Installer/scripts/install_dir.iss
+++ b/Installer/scripts/install_dir.iss
@@ -1,78 +1,66 @@
 // Issue #2353: robustly reuse the prior install location.
-// UsePreviousAppDir (keyed on AppId) is the primary mechanism; this scripted
+// UsePreviousAppDir (keyed on AppId) is the primary mechanism. This scripted
 // constant is a belt-and-suspenders safety net so the installer still lands in
 // the real install directory when launched without a /DIR (e.g. a transitional
 // update run by an older updater).
-// We enumerate uninstall entries, skipping our own stable key(s) (UsePreviousAppDir
-// already reuses them) and any entry lacking SoundSwitch.exe, then prefer the
-// machine-wide (HKLM) install for determinism. Falls back to Default.
+// We resolve the directory by the *known* SoundSwitch uninstall key identity
+// (AppId "SoundSwitch" -> "SoundSwitch_is1", plus the bare "SoundSwitch" key for
+// very old installs) under HKLM then HKCU. Matching the key name (not a DisplayName
+// prefix) keeps the selection deterministic and unaffected by unrelated entries
+// such as "SoundSwitch Helper". The SoundSwitch.exe ownership check is defense-in-depth.
+// Falls back to Default when no approved identity is found.
 
 [Code]
 
+function TryGetInstallDirFromKey(Root: Integer; const KeyName: string): string;
+var
+  BaseKey, FullKey, InstallLoc, ExePath: string;
+begin
+  Result := '';
+  BaseKey := 'Software\Microsoft\Windows\CurrentVersion\Uninstall';
+  FullKey := BaseKey + '\' + KeyName;
+  if not RegQueryStringValue(Root, FullKey, 'InstallLocation', InstallLoc) then
+    Exit;
+  if (InstallLoc = '') or not DirExists(InstallLoc) then
+    Exit;
+  // Ownership check: only accept directories that contain SoundSwitch.exe.
+  ExePath := InstallLoc + '\SoundSwitch.exe';
+  if FileExists(ExePath) then
+    Result := InstallLoc;
+end;
+
 function GetInstallDir(Default: string): string;
 var
+  Dir: string;
+  I, J: Integer;
   Roots: array of Integer;
-  Root, I, Count: Integer;
-  RootsCount: Integer;
-  BaseKey, FullKey, KeyName, DisplayName, InstallLoc, ExePath: string;
-  SubKeys: TArrayOfString;
+  KeyNames: array of string;
 begin
-  // Default is the value Inno would have used; fall back to it (or the
-  // conventional Program Files path) if no existing install is found.
   Result := Default;
   if Result = '' then
     Result := ExpandConstant('{autopf}\{#MyAppSetupName}');
+
+  // Known uninstall key identities for SoundSwitch, in priority order.
+  SetArrayLength(KeyNames, 2);
+  KeyNames[0] := '{#MyAppSetupName}_is1';   // canonical key (AppId + _is1 suffix)
+  KeyNames[1] := '{#MyAppSetupName}';       // bare key (very old installs)
 
   SetArrayLength(Roots, 2);
   Roots[0] := HKLM;
   Roots[1] := HKCU;
 
-  for Root := 0 to 1 do
+  // Deterministic: machine-wide (HKLM) first, then per-user (HKCU),
+  // each trying the known key identities in priority order.
+  for I := 0 to 1 do
   begin
-    BaseKey := 'Software\Microsoft\Windows\CurrentVersion\Uninstall';
-    if not RegGetSubkeyNames(Roots[Root], BaseKey, SubKeys) then
-      Continue;
-
-    Count := GetArrayLength(SubKeys);
-    for I := 0 to Count - 1 do
+    for J := 0 to 1 do
     begin
-      KeyName := SubKeys[I];
-      // Skip our own stable uninstall key(s): the bare AppId and the _is1-suffixed
-      // registry key Inno creates from it. UsePreviousAppDir already reuses them,
-      // and we must not let a legacy entry override the stable path.
-      if (CompareText(KeyName, '{#MyAppSetupName}') = 0) or
-         (CompareText(KeyName, '{#MyAppSetupName}_is1') = 0) then
-        Continue;
-
-      FullKey := BaseKey + '\' + KeyName;
-      if not RegQueryStringValue(Roots[Root], FullKey, 'DisplayName', DisplayName) then
-        Continue;
-
-      if (CompareText(DisplayName, '{#MyAppSetupName}') = 0) or
-         ((Pos('{#MyAppSetupName}', DisplayName) = 1) and
-          (Copy(DisplayName, Length('{#MyAppSetupName}') + 1, 1) = ' ')) then
+      Dir := TryGetInstallDirFromKey(Roots[I], KeyNames[J]);
+      if Dir <> '' then
       begin
-        if RegQueryStringValue(Roots[Root], FullKey, 'InstallLocation', InstallLoc) then
-        begin
-          if (InstallLoc <> '') and DirExists(InstallLoc) then
-          begin
-            // Ownership check: only reuse directories that contain SoundSwitch.exe,
-            // so unrelated entries like "SoundSwitch Helper" are ignored.
-            ExePath := InstallLoc + '\SoundSwitch.exe';
-            if FileExists(ExePath) then
-            begin
-              Log('GetInstallDir: reusing existing install location ' + InstallLoc);
-              // Prefer the machine-wide (HKLM) install for determinism: return
-              // immediately on HKLM, otherwise remember and keep scanning HKCU.
-              if Root = 0 then
-              begin
-                Result := InstallLoc;
-                Exit;
-              end;
-              Result := InstallLoc;
-            end;
-          end;
-        end;
+        Log('GetInstallDir: reusing existing install location ' + Dir);
+        Result := Dir;
+        Exit;
       end;
     end;
   end;

--- a/Installer/scripts/install_dir.iss
+++ b/Installer/scripts/install_dir.iss
@@ -1,6 +1,13 @@
-// Issue #2353: robustly reuse the prior install location, independent of AppId.
-// Matches by DisplayName (exact, or name followed by a space + version), never by key
-// name, so it works across any AppId configuration. Falls back to the default dir.
+// Issue #2353: robustly reuse the prior install location.
+// UsePreviousAppDir (keyed on AppId) is the primary mechanism; this scripted
+// constant is a belt-and-suspenders safety net so the installer still lands in
+// the real install directory when launched without a /DIR (e.g. a transitional
+// update run by an older updater).
+// We skip our own stable key (UsePreviousAppDir handles it), then match any
+// other uninstall entry whose DisplayName is exactly {#MyAppSetupName} or begins
+// with "{#MyAppSetupName} " (name + space + version), and whose InstallLocation
+// actually contains SoundSwitch.exe. The ownership check avoids hijacking
+// unrelated entries such as "SoundSwitch Helper". Falls back to Default.
 
 [Code]
 
@@ -8,7 +15,7 @@ function GetInstallDir(Default: string): string;
 var
   Roots: array of Integer;
   Root, I, Count: Integer;
-  BaseKey, FullKey, KeyName, DisplayName, InstallLoc: string;
+  BaseKey, FullKey, KeyName, DisplayName, InstallLoc, ExePath: string;
   SubKeys: TArrayOfString;
 begin
   // Default is the value Inno would have used; fall back to it (or the
@@ -31,7 +38,7 @@ begin
     for I := 0 to Count - 1 do
     begin
       KeyName := SubKeys[I];
-      // Skip our own (stable) key; UsePreviousAppDir handles it.
+      // Skip our own stable key; UsePreviousAppDir already reuses it.
       if CompareText(KeyName, '{#MyAppSetupName}') = 0 then
         Continue;
 
@@ -47,9 +54,14 @@ begin
         begin
           if (InstallLoc <> '') and DirExists(InstallLoc) then
           begin
-            Log('GetInstallDir: reusing existing install location ' + InstallLoc);
-            Result := InstallLoc;
-            Exit;
+            // Ownership check: only reuse directories that contain SoundSwitch.exe.
+            ExePath := InstallLoc + '\SoundSwitch.exe';
+            if FileExists(ExePath) then
+            begin
+              Log('GetInstallDir: reusing existing install location ' + InstallLoc);
+              Result := InstallLoc;
+              Exit;
+            end;
           end;
         end;
       end;

--- a/Installer/scripts/install_dir.iss
+++ b/Installer/scripts/install_dir.iss
@@ -3,12 +3,14 @@
 // constant is a belt-and-suspenders safety net so the installer still lands in
 // the real install directory when launched without a /DIR (e.g. a transitional
 // update run by an older updater).
-// We resolve the directory by the *known* SoundSwitch uninstall key identity
-// (AppId "SoundSwitch" -> "SoundSwitch_is1", plus the bare "SoundSwitch" key for
-// very old installs) under HKLM then HKCU. Matching the key name (not a DisplayName
-// prefix) keeps the selection deterministic and unaffected by unrelated entries
-// such as "SoundSwitch Helper". The SoundSwitch.exe ownership check is defense-in-depth.
-// Falls back to Default when no approved identity is found.
+// We resolve the directory by known SoundSwitch uninstall key identities, under
+// HKLM then HKCU, in priority order:
+//   1. the new AppId identity (me.aaflalo.soundswitch -> "me.aaflalo.soundswitch_is1")
+//   2. the legacy AppId identity (SoundSwitch -> "SoundSwitch_is1", plus bare "SoundSwitch"
+//      for very old installs) so existing/non-default installs keep upgrading in place.
+// Matching the key name (not a DisplayName prefix) keeps selection deterministic and
+// unaffected by unrelated entries such as "SoundSwitch Helper". The SoundSwitch.exe
+// ownership check is defense-in-depth. Falls back to Default when no identity is found.
 
 [Code]
 
@@ -41,9 +43,11 @@ begin
     Result := ExpandConstant('{autopf}\{#MyAppSetupName}');
 
   // Known uninstall key identities for SoundSwitch, in priority order.
-  SetArrayLength(KeyNames, 2);
-  KeyNames[0] := '{#MyAppSetupName}_is1';   // canonical key (AppId + _is1 suffix)
-  KeyNames[1] := '{#MyAppSetupName}';       // bare key (very old installs)
+  // New identity first, then legacy identities from before the AppId change.
+  SetArrayLength(KeyNames, 3);
+  KeyNames[0] := 'me.aaflalo.soundswitch_is1'; // current AppId + _is1 suffix
+  KeyNames[1] := '{#MyAppSetupName}_is1';      // legacy AppId "SoundSwitch" + _is1
+  KeyNames[2] := '{#MyAppSetupName}';          // bare key (very old installs)
 
   SetArrayLength(Roots, 2);
   Roots[0] := HKLM;
@@ -53,7 +57,7 @@ begin
   // each trying the known key identities in priority order.
   for I := 0 to 1 do
   begin
-    for J := 0 to 1 do
+    for J := 0 to 2 do
     begin
       Dir := TryGetInstallDirFromKey(Roots[I], KeyNames[J]);
       if Dir <> '' then

--- a/Installer/scripts/install_dir.iss
+++ b/Installer/scripts/install_dir.iss
@@ -1,0 +1,54 @@
+// Issue #2353: robustly reuse the prior install location, independent of AppId.
+// Matches by DisplayName (exact, or name followed by a space + version), never by key
+// name, so it works across any AppId configuration. Falls back to the default dir.
+
+[Code]
+
+function GetInstallDir(): string;
+var
+  Roots: array of Integer;
+  Root, I, Count: Integer;
+  BaseKey, FullKey, KeyName, DisplayName, InstallLoc: string;
+  SubKeys: TArrayOfString;
+begin
+  Result := ExpandConstant('{autopf}\{#MyAppSetupName}');
+
+  SetArrayLength(Roots, 2);
+  Roots[0] := HKLM;
+  Roots[1] := HKCU;
+
+  for Root := 0 to 1 do
+  begin
+    BaseKey := 'Software\Microsoft\Windows\CurrentVersion\Uninstall';
+    if not RegGetSubkeyNames(Roots[Root], BaseKey, SubKeys) then
+      Continue;
+
+    Count := GetArrayLength(SubKeys);
+    for I := 0 to Count - 1 do
+    begin
+      KeyName := SubKeys[I];
+      // Skip our own (stable) key; UsePreviousAppDir handles it.
+      if CompareText(KeyName, '{#MyAppSetupName}') = 0 then
+        Continue;
+
+      FullKey := BaseKey + '\' + KeyName;
+      if not RegQueryStringValue(Roots[Root], FullKey, 'DisplayName', DisplayName) then
+        Continue;
+
+      if (CompareText(DisplayName, '{#MyAppSetupName}') = 0) or
+         ((Pos('{#MyAppSetupName}', DisplayName) = 1) and
+          (Copy(DisplayName, Length('{#MyAppSetupName}') + 1, 1) = ' ')) then
+      begin
+        if RegQueryStringValue(Roots[Root], FullKey, 'InstallLocation', InstallLoc) then
+        begin
+          if (InstallLoc <> '') and DirExists(InstallLoc) then
+          begin
+            Log('GetInstallDir: reusing existing install location ' + InstallLoc);
+            Result := InstallLoc;
+            Exit;
+          end;
+        end;
+      end;
+    end;
+  end;
+end;

--- a/Installer/scripts/install_dir.iss
+++ b/Installer/scripts/install_dir.iss
@@ -3,11 +3,9 @@
 // constant is a belt-and-suspenders safety net so the installer still lands in
 // the real install directory when launched without a /DIR (e.g. a transitional
 // update run by an older updater).
-// We skip our own stable key (UsePreviousAppDir handles it), then match any
-// other uninstall entry whose DisplayName is exactly {#MyAppSetupName} or begins
-// with "{#MyAppSetupName} " (name + space + version), and whose InstallLocation
-// actually contains SoundSwitch.exe. The ownership check avoids hijacking
-// unrelated entries such as "SoundSwitch Helper". Falls back to Default.
+// We enumerate uninstall entries, skipping our own stable key(s) (UsePreviousAppDir
+// already reuses them) and any entry lacking SoundSwitch.exe, then prefer the
+// machine-wide (HKLM) install for determinism. Falls back to Default.
 
 [Code]
 
@@ -15,6 +13,7 @@ function GetInstallDir(Default: string): string;
 var
   Roots: array of Integer;
   Root, I, Count: Integer;
+  RootsCount: Integer;
   BaseKey, FullKey, KeyName, DisplayName, InstallLoc, ExePath: string;
   SubKeys: TArrayOfString;
 begin
@@ -38,8 +37,11 @@ begin
     for I := 0 to Count - 1 do
     begin
       KeyName := SubKeys[I];
-      // Skip our own stable key; UsePreviousAppDir already reuses it.
-      if CompareText(KeyName, '{#MyAppSetupName}') = 0 then
+      // Skip our own stable uninstall key(s): the bare AppId and the _is1-suffixed
+      // registry key Inno creates from it. UsePreviousAppDir already reuses them,
+      // and we must not let a legacy entry override the stable path.
+      if (CompareText(KeyName, '{#MyAppSetupName}') = 0) or
+         (CompareText(KeyName, '{#MyAppSetupName}_is1') = 0) then
         Continue;
 
       FullKey := BaseKey + '\' + KeyName;
@@ -54,13 +56,20 @@ begin
         begin
           if (InstallLoc <> '') and DirExists(InstallLoc) then
           begin
-            // Ownership check: only reuse directories that contain SoundSwitch.exe.
+            // Ownership check: only reuse directories that contain SoundSwitch.exe,
+            // so unrelated entries like "SoundSwitch Helper" are ignored.
             ExePath := InstallLoc + '\SoundSwitch.exe';
             if FileExists(ExePath) then
             begin
               Log('GetInstallDir: reusing existing install location ' + InstallLoc);
+              // Prefer the machine-wide (HKLM) install for determinism: return
+              // immediately on HKLM, otherwise remember and keep scanning HKCU.
+              if Root = 0 then
+              begin
+                Result := InstallLoc;
+                Exit;
+              end;
               Result := InstallLoc;
-              Exit;
             end;
           end;
         end;

--- a/Installer/scripts/install_dir.iss
+++ b/Installer/scripts/install_dir.iss
@@ -4,14 +4,18 @@
 
 [Code]
 
-function GetInstallDir(): string;
+function GetInstallDir(Default: string): string;
 var
   Roots: array of Integer;
   Root, I, Count: Integer;
   BaseKey, FullKey, KeyName, DisplayName, InstallLoc: string;
   SubKeys: TArrayOfString;
 begin
-  Result := ExpandConstant('{autopf}\{#MyAppSetupName}');
+  // Default is the value Inno would have used; fall back to it (or the
+  // conventional Program Files path) if no existing install is found.
+  Result := Default;
+  if Result = '' then
+    Result := ExpandConstant('{autopf}\{#MyAppSetupName}');
 
   SetArrayLength(Roots, 2);
   Roots[0] := HKLM;

--- a/Installer/setup.iss
+++ b/Installer/setup.iss
@@ -6,6 +6,7 @@
 
 [Setup]
 AppName={#MyAppSetupName}
+AppId={#MyAppSetupName}
 AppVersion={#MyAppVersion}
 AppVerName={#MyAppSetupName} {#MyAppVersion}
 AppCopyright=Copyright © 2010-2025 {#MyAppSetupName}
@@ -18,7 +19,7 @@ AppSupportURL=https://github.com/Belphemur/SoundSwitch
 AppUpdatesURL=https://github.com/Belphemur/SoundSwitch/releases
 OutputBaseFilename={#MyAppSetupName}_v{#MyAppVersion}_{#ReleaseState}_Installer
 DefaultGroupName={#MyAppSetupName}
-DefaultDirName={autopf}\{#MyAppSetupName}
+DefaultDirName={code:GetInstallDir}
 UninstallDisplayIcon={app}\SoundSwitch.exe
 OutputDir={#ExeDir}
 SourceDir=.
@@ -119,6 +120,7 @@ Type: filesandordirs; Name: {app}\*
 #include "scripts\setup_utils.iss"
 #include "scripts\uninstall_utils.iss"
 #include "scripts\windows_update_helper.iss"
+#include "scripts\install_dir.iss"
 
 [Code]
 function InitializeSetup(): Boolean;

--- a/Installer/setup.iss
+++ b/Installer/setup.iss
@@ -6,7 +6,7 @@
 
 [Setup]
 AppName={#MyAppSetupName}
-AppId={#MyAppSetupName}
+AppId=me.aaflalo.soundswitch
 AppVersion={#MyAppVersion}
 AppVerName={#MyAppSetupName} {#MyAppVersion}
 AppCopyright=Copyright © 2010-2025 {#MyAppSetupName}

--- a/SoundSwitch/Framework/Updater/Installer/UpdateRunner.cs
+++ b/SoundSwitch/Framework/Updater/Installer/UpdateRunner.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
+using System.IO;
+using System.Windows.Forms;
 
 using SoundSwitch.Framework.Configuration;
 
@@ -19,6 +21,17 @@ public class UpdateRunner
         {
             AppConfigs.Configuration.LastDonationNagTime = DateTime.UtcNow;
             AppConfigs.Configuration.Save();
+        }
+
+        // Force the update into the directory this app is currently running from,
+        // so auto-updates respect a non-default install location (issue #2353).
+        if (!args.Contains("/DIR", StringComparison.OrdinalIgnoreCase))
+        {
+            var installDir = Path.GetDirectoryName(Application.ExecutablePath);
+            if (!string.IsNullOrEmpty(installDir))
+            {
+                args += $" /DIR=\"{installDir}\"";
+            }
         }
 
         return file.Start(args);

--- a/SoundSwitch/Framework/Updater/Installer/UpdateRunner.cs
+++ b/SoundSwitch/Framework/Updater/Installer/UpdateRunner.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Windows.Forms;
 
+using SoundSwitch.Framework;
 using SoundSwitch.Framework.Configuration;
 
 namespace SoundSwitch.Framework.Updater.Installer;
@@ -27,9 +28,16 @@ public class UpdateRunner
         // so auto-updates respect a non-default install location (issue #2353).
         if (!args.Contains("/DIR", StringComparison.OrdinalIgnoreCase))
         {
-            var installDir = Path.GetDirectoryName(Application.ExecutablePath);
+            var installDir = ApplicationPath.InstallDirectory;
             if (!string.IsNullOrEmpty(installDir))
             {
+                // Guard a trailing backslash (e.g. "D:\") that would otherwise let
+                // Inno's command-line parser treat /DIR="D:\" as an escaped quote.
+                if (installDir.EndsWith("\\"))
+                {
+                    installDir += "\\";
+                }
+
                 args += $" /DIR=\"{installDir}\"";
             }
         }

--- a/SoundSwitch/Framework/Updater/Installer/UpdateRunner.cs
+++ b/SoundSwitch/Framework/Updater/Installer/UpdateRunner.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+using System.Text.RegularExpressions;
 using System.Windows.Forms;
 
 using SoundSwitch.Framework;
@@ -26,7 +27,10 @@ public class UpdateRunner
 
         // Force the update into the directory this app is currently running from,
         // so auto-updates respect a non-default install location (issue #2353).
-        if (!args.Contains("/DIR", StringComparison.OrdinalIgnoreCase))
+        // Only add /DIR if the caller hasn't already supplied it as a switch token
+        // (e.g. "/DIR" or "/DIR=..."). Avoid a plain substring match so values like
+        // "/DIRTY" or "/DIRECTORY" are not mistaken for the /DIR parameter.
+        if (!Regex.IsMatch(args, @"(?i)(?:^|\s)/DIR(?:=|\s|$)"))
         {
             var installDir = ApplicationPath.InstallDirectory;
             if (!string.IsNullOrEmpty(installDir))


### PR DESCRIPTION
## Summary

Fixes #2353 — the auto-updater installs the new version to `C:\Program Files\SoundSwitch` instead of the user's chosen (non-default) install location.

## Root cause

The auto-updater launches the installer with `/VERYSILENT` (or `/SILENT`) and **no `/DIR` argument**. In silent mode Inno Setup's automatic previous-directory reuse does not land in a non-default install location, so the update falls back to `DefaultDirName` (`C:\Program Files\SoundSwitch`).

Note: Inno Setup's `AppId` default is `AppName` (not version-derived), so `SoundSwitch`'s AppId has always been stable — a manual GUI re-run finds the prior install correctly, which is why the bug only appears on silent auto-update.

## Changes

- **`SoundSwitch/Framework/Updater/Installer/UpdateRunner.cs`** — `RunUpdate` now appends `/DIR="<directory of the running executable>"` when not already present, so every update targets the directory the app already runs from. Existing flags (`/VERYSILENT`, `/SILENT`, `/NOCANCEL`, `/NORESTART`, `/CLOSEAPPLICATIONS`, `/NODONATE`) are unchanged.
- **`Installer/setup.iss`** — set an explicit stable `AppId={#MyAppSetupName}` and `DefaultDirName={code:GetInstallDir}`. `UsePreviousAppDir` left at its default; `InitializeSetup` and other includes untouched.
- **`Installer/scripts/install_dir.iss`** (new) — `GetInstallDir()` reuses the prior install location by `DisplayName` (not `AppId`), protecting the one transitional update still launched by the old updater (which doesn't pass `/DIR`). Falls back to `{autopf}\SoundSwitch`.

## Verification

- C# partial build (`dotnet build SoundSwitch/SoundSwitch.csproj -c Debug -p:LinuxBuild=true -p:BuildProjectReferences=false`) — `UpdateRunner.cs` compiles cleanly. The only error is the pre-existing, unrelated CsWinRT CS0006 from `SoundSwitch.Audio.Manager` (cannot build on Linux).
- Inno Setup scripts reviewed against the spec (ISCC not available on Linux).
- **Pipeline (`build / build`) on Windows is the authoritative validation**, including the installer upgrade path.

## Test plan (manual, Windows)

1. Install an older build to a non-default drive (e.g. `D:\SoundSwitch`).
2. Run the new build's updater.
3. Confirm the updated files land in `D:\SoundSwitch` (not `C:\Program Files\SoundSwitch`).
4. Confirm a single `SoundSwitch` entry remains under *Programs and Features*.
