### PR TITLE
fix(banner): reuse active banner for same device+title instead of stacking (issue #2355)

### DIFF
--- a/SoundSwitch/Framework/Banner/BannerData.cs
+++ b/SoundSwitch/Framework/Banner/BannerData.cs
@@ -107,4 +107,13 @@ public class BannerData
     /// </summary>
     [AllowNull]
     public EventHandler OnClick { get; internal set; }
+
+    /// <summary>
+    /// Key used to deduplicate concurrently shown banners. Banners sharing the
+    /// same key (same device + same title) update the existing banner instead of
+    /// stacking a new one. This is what makes the "Only one banner" setting hold
+    /// when several notifications for the same device are raised in quick succession
+    /// (e.g. a default-device switch with "Switch default communication device" on).
+    /// </summary>
+    public string DedupKey => $"{CurrentDeviceId ?? string.Empty}|{Title ?? string.Empty}";
 }

--- a/SoundSwitch/Framework/Banner/BannerManager.cs
+++ b/SoundSwitch/Framework/Banner/BannerManager.cs
@@ -31,6 +31,9 @@ public class BannerManager
     private readonly Dictionary<Guid, BannerForm> _bannerForms = new();
     private BannerForm _singleBanner;
     private BannerForm _customPositionBanner;
+    private string _lastSingleBannerText;
+    private DateTime _lastSingleBannerTimeUtc;
+    private const int SingleBannerCoalesceMs = 500;
     private const int SPACING = 10;
 
     /// <summary>
@@ -61,12 +64,29 @@ public class BannerManager
             return;
         }
 
+        // Single-banner mode reuses one form. Coalesce rapid notifications for the
+        // same device (e.g. "Switch default communication device" raises console,
+        // multimedia and communications role changes for the same device in quick
+        // succession) so only one banner is shown. See issue #2355.
+        if (_lastSingleBannerText != null && _lastSingleBannerText == data.Text &&
+            (DateTime.UtcNow - _lastSingleBannerTimeUtc).TotalMilliseconds < SingleBannerCoalesceMs)
+        {
+            return;
+        }
+
+        _lastSingleBannerText = data.Text;
+        _lastSingleBannerTimeUtc = DateTime.UtcNow;
+
         _syncContext.Send(_ =>
         {
             if (_singleBanner == null)
             {
                 _singleBanner = new BannerForm();
-                _singleBanner.Disposed += (s, e) => { _singleBanner = null; };
+                _singleBanner.Disposed += (s, e) =>
+                {
+                    _singleBanner = null;
+                    _lastSingleBannerText = null;
+                };
             }
 
             _singleBanner.SetData(data);

--- a/SoundSwitch/Framework/Banner/BannerManager.cs
+++ b/SoundSwitch/Framework/Banner/BannerManager.cs
@@ -31,9 +31,6 @@ public class BannerManager
     private readonly Dictionary<Guid, BannerForm> _bannerForms = new();
     private BannerForm _singleBanner;
     private BannerForm _customPositionBanner;
-    private string _lastSingleBannerText;
-    private DateTime _lastSingleBannerTimeUtc;
-    private const int SingleBannerCoalesceMs = 500;
     private const int SPACING = 10;
 
     /// <summary>
@@ -64,29 +61,12 @@ public class BannerManager
             return;
         }
 
-        // Single-banner mode reuses one form. Coalesce rapid notifications for the
-        // same device (e.g. "Switch default communication device" raises console,
-        // multimedia and communications role changes for the same device in quick
-        // succession) so only one banner is shown. See issue #2355.
-        if (_lastSingleBannerText != null && _lastSingleBannerText == data.Text &&
-            (DateTime.UtcNow - _lastSingleBannerTimeUtc).TotalMilliseconds < SingleBannerCoalesceMs)
-        {
-            return;
-        }
-
-        _lastSingleBannerText = data.Text;
-        _lastSingleBannerTimeUtc = DateTime.UtcNow;
-
         _syncContext.Send(_ =>
         {
             if (_singleBanner == null)
             {
                 _singleBanner = new BannerForm();
-                _singleBanner.Disposed += (s, e) =>
-                {
-                    _singleBanner = null;
-                    _lastSingleBannerText = null;
-                };
+                _singleBanner.Disposed += (s, e) => { _singleBanner = null; };
             }
 
             _singleBanner.SetData(data);

--- a/SoundSwitch/Framework/Banner/BannerManager.cs
+++ b/SoundSwitch/Framework/Banner/BannerManager.cs
@@ -29,6 +29,7 @@ public class BannerManager
 {
     private static System.Threading.SynchronizationContext _syncContext;
     private readonly Dictionary<Guid, BannerForm> _bannerForms = new();
+    private readonly Dictionary<string, Guid> _bannerByKey = new();
     private BannerForm _singleBanner;
     private BannerForm _customPositionBanner;
     private const int SPACING = 10;
@@ -92,8 +93,28 @@ public class BannerManager
         // Execute the banner in the context of the UI thread
         _syncContext.Send(_ =>
         {
+            // If a banner for the same device + title is already shown, update it
+            // in place instead of stacking a new one. This keeps the "Only one banner"
+            // behavior even when several notifications for the same device are raised
+            // in quick succession (e.g. a default-device switch with
+            // "Switch default communication device" enabled).
+            if (_bannerByKey.TryGetValue(data.DedupKey, out var existingId)
+                && _bannerForms.TryGetValue(existingId, out var existingBanner)
+                && !existingBanner.IsDisposed)
+            {
+                existingBanner.SetData(data);
+                return;
+            }
+
             var banner = new BannerForm();
-            banner.Disposed += (s, e) => { _bannerForms.Remove(banner.Id); };
+            banner.Disposed += (s, e) =>
+            {
+                _bannerForms.Remove(banner.Id);
+                if (_bannerByKey.TryGetValue(data.DedupKey, out var keyedId) && keyedId == banner.Id)
+                {
+                    _bannerByKey.Remove(data.DedupKey);
+                }
+            };
             banner.SetData(data);
             foreach (var bannerForm in _bannerForms.Values)
             {
@@ -101,6 +122,7 @@ public class BannerManager
             }
 
             _bannerForms.Add(banner.Id, banner);
+            _bannerByKey[data.DedupKey] = banner.Id;
         }, null);
     }
 


### PR DESCRIPTION
## Summary

Fixes #2355 — with the **"Only one banner"** setting enabled, switching the default device (especially with **"Switch default communication device"** on) showed multiple stacked banners instead of a single, updating one.

### Root cause

`BannerManager.MultipleBannerShow` (the path used when `MaxNumberNotification > 1`) created a **new `BannerForm` on every `ShowNotification` call with no deduplication**. The 6.15 notification-settings split (3 channels) + the new `AppSoundLockManager` raised the number of notifications a single switch can emit (default + communications + optional profile/rule), and each stacked a separate form. The "Only one banner" intent was never enforced once the call count exceeded one.

Diagnosis (with OpenCode) confirmed:
- There is exactly **one** `NotificationBanner` instance (via `NotificationFactory`), so all banner channels share one `BannerManager` — multiple `BannerManager` instances were *not* the cause.
- A single switch already collapses to one `ShowNotification` via the `SortedSet`/`_lastDeviceId` dedup; the stacking itself happens inside `MultipleBannerShow`.
- The dedup `DeviceChangedEvent.CompareTo` / migration / serialization layers are unchanged since v6.14.2, so this is not a config-reset regression.

### Fix

Track active banners by a **device + title key** (`BannerData.DedupKey`). When the same key is shown again, update the existing banner in place instead of stacking a new form. Genuinely distinct device/title notifications still stack as before, so the multi-banner feature is preserved.

### Files

- `SoundSwitch/Framework/Banner/BannerData.cs` — adds `DedupKey` (device id + title).
- `SoundSwitch/Framework/Banner/BannerManager.cs` — `_bannerByKey` lookup; `MultipleBannerShow` reuses/updates the existing banner.

### Validation

Partial Linux build cannot compile `SoundSwitch`'s own sources (the Windows-only `SoundSwitch.Audio.Manager` CsWinRT projection fails first — pre-existing, unrelated). Real compile + behavior are covered by `windows-latest` CI. The change is confined to banner display logic and preserves existing public behavior.

### Note

The earlier approach in the now-closed #2358 (a 500ms time-window drop) was a band-aid and is withdrawn; this PR addresses the actual stacking path.
