### PR TITLE
fix(audio): refresh default device after waking from sleep (issue #2009)

### DIFF
--- a/SoundSwitch/Framework/NotificationManager/MMNotificationClient.cs
+++ b/SoundSwitch/Framework/NotificationManager/MMNotificationClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -22,6 +23,7 @@ public class MMNotificationClient : IDisposable
     private MMDeviceNotificationClient _client;
 
     private readonly Dictionary<DeviceRole, string> _lastRoleDevice = new();
+    private readonly Lock _lastRoleDeviceLock = new();
 
     private readonly ConcurrentQueue<DeviceChangedEvent> _deviceChangedEvents = new();
         
@@ -63,7 +65,10 @@ public class MMNotificationClient : IDisposable
                 if (device == null)
                     continue;
 
-                _lastRoleDevice[new DeviceRole(flow, role)] = device.Id;
+                using (_lastRoleDeviceLock.EnterScope())
+                {
+                    _lastRoleDevice[new DeviceRole(flow, role)] = device.Id;
+                }
             }
         }
     }
@@ -74,19 +79,52 @@ public class MMNotificationClient : IDisposable
 
     private void OnDeviceRemoved(object sender, DeviceNotificationEventArgs e) => _deviceChangedEvents.Enqueue(new DeviceChangedEvent(EventType.Removed, e.DeviceId));
 
+    /// <summary>
+    /// Reconcile the cached default device per (flow, role) against the real OS default.
+    /// Enqueues a <see cref="DefaultDeviceChangedEvent"/> whenever the cached value diverges,
+    /// mirroring <see cref="OnDefaultDeviceChanged"/>. Intended to be called on resume from sleep.
+    /// </summary>
+    public void ReconcileDefaultDevices()
+    {
+        foreach (var flow in Enum.GetValues<DataFlow>().Where(flow => flow != DataFlow.All))
+        {
+            foreach (var role in Enum.GetValues<Role>())
+            {
+                using (_lastRoleDeviceLock.EnterScope())
+                {
+                    var device = AudioSwitcher.Instance.GetDefaultAudioEndpoint((EDataFlow)flow, (ERole)role);
+                    if (device == null)
+                        continue;
+
+                    var deviceRole = new DeviceRole(flow, role);
+                    if (_lastRoleDevice.TryGetValue(deviceRole, out var oldDeviceId) && oldDeviceId == device.Id)
+                    {
+                        continue;
+                    }
+
+                    _lastRoleDevice[deviceRole] = device.Id;
+                    _deviceChangedEvents.Enqueue(new DefaultDeviceChangedEvent(EventType.DefaultChanged, device.Id, role));
+                }
+            }
+        }
+    }
+
     private void OnDefaultDeviceChanged(object sender, DefaultDeviceChangedEventArgs e)
     {
         if (e.DeviceId == null)
             return;
 
         var deviceRole = new DeviceRole(e.Flow, e.Role);
-        if (_lastRoleDevice.TryGetValue(deviceRole, out var oldDeviceId) && oldDeviceId == e.DeviceId)
+        using (_lastRoleDeviceLock.EnterScope())
         {
-            return;
-        }
+            if (_lastRoleDevice.TryGetValue(deviceRole, out var oldDeviceId) && oldDeviceId == e.DeviceId)
+            {
+                return;
+            }
 
-        _lastRoleDevice[deviceRole] = e.DeviceId;
-        _deviceChangedEvents.Enqueue(new DefaultDeviceChangedEvent(EventType.DefaultChanged, e.DeviceId, e.Role));
+            _lastRoleDevice[deviceRole] = e.DeviceId;
+            _deviceChangedEvents.Enqueue(new DefaultDeviceChangedEvent(EventType.DefaultChanged, e.DeviceId, e.Role));
+        }
     }
 
     private void OnPropertyValueChanged(object sender, DevicePropertyChangedEventArgs e)

--- a/SoundSwitch/Framework/WinApi/WindowsAPIAdapter.cs
+++ b/SoundSwitch/Framework/WinApi/WindowsAPIAdapter.cs
@@ -90,6 +90,7 @@ public class WindowsAPIAdapter : Form
     public static event EventHandler<WindowDestroyedEvent> WindowDestroyed;
     public static event EventHandler SessionUnlocked;
     public static event EventHandler SystemThemeChanged;
+    public static event EventHandler SystemResumed;
 
     /// <summary>
     ///     Start the Adapter thread
@@ -123,6 +124,8 @@ public class WindowsAPIAdapter : Form
         DeviceChanged = null;
         HotKeyPressed = null;
         SessionUnlocked = null;
+        SystemResumed = null;
+        SystemThemeChanged = null;
 
         if (!_instance.IsDisposed)
         {
@@ -172,6 +175,8 @@ public class WindowsAPIAdapter : Form
 
         // Dispatch to adapter thread to avoid race conditions with _registeredHotkeys
         _instance?.BeginInvoke(new Action(_instance.ReRegisterAllHotkeys));
+
+        SystemResumed?.Invoke(_instance, EventArgs.Empty);
     }
 
     private static void SystemEventsOnSessionSwitch(object sender, SessionSwitchEventArgs e)

--- a/SoundSwitch/Model/AppModel.cs
+++ b/SoundSwitch/Model/AppModel.cs
@@ -19,6 +19,7 @@ using System.Drawing;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 
 using NAudio.CoreAudioApi;
 
@@ -148,6 +149,7 @@ public partial class AppModel : IAppModel
             AppConfigs.Configuration.Save();
 
         WindowsAPIAdapter.HotKeyPressed += HandleHotkeyPress;
+        WindowsAPIAdapter.SystemResumed += OnSystemResumed;
 
         TrayIcon = new TrayIcon();
         _notificationManager.Init();
@@ -177,9 +179,31 @@ public partial class AppModel : IAppModel
 
     public void Dispose()
     {
+        _initialized = false;
         _notificationManager?.Dispose();
         TrayIcon?.Dispose();
         AudioDeviceLister?.Dispose();
         AppSoundLockManager?.Dispose();
+        WindowsAPIAdapter.SystemResumed -= OnSystemResumed;
+    }
+
+    private void OnSystemResumed(object sender, EventArgs e)
+    {
+        if (!_initialized || AudioDeviceLister == null)
+            return;
+
+        Task.Run(() =>
+        {
+            try
+            {
+                Log.Information("System resumed from sleep, refreshing audio devices and reconciling default device");
+                AudioDeviceLister.Refresh(CancellationToken.None);
+                MMNotificationClient.Instance.ReconcileDefaultDevices();
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Failed to refresh audio devices after system resume");
+            }
+        });
     }
 }

--- a/docs/issue-2009-sleep-resume-device-refresh.md
+++ b/docs/issue-2009-sleep-resume-device-refresh.md
@@ -1,0 +1,116 @@
+# Issue #2009 — Tray icon shows stale default device after waking from sleep
+
+## Problem
+
+When the PC resumes from sleep, the tray icon (and its default-device state) can
+show a device that is **not** the one actually producing audio. Sound still plays
+from the correct device, but the icon is wrong until the user switches devices or
+restarts SoundSwitch.
+
+Reported on Windows 11 with two playback devices (e.g. an external "Audient 1/2"
+vs a built-in "Headphone"). After wake, the icon shows the built-in even though
+the external is the active default and audio comes from it.
+
+## Root cause
+
+The tray icon is driven by an in-process cache, not by a live query:
+
+1. `MMNotificationClient` keeps `_lastRoleDevice` — a `Dictionary<(DataFlow, Role), deviceId>`
+   of what it *believes* is the current default per role.
+2. When Windows reports a default-device change, `OnDefaultDeviceChanged` compares
+   the new id against `_lastRoleDevice` and, only if different, enqueues a
+   `DefaultDeviceChangedEvent` (see `MMNotificationClient.OnDefaultDeviceChanged`).
+3. The recurring `ProcessNotificationEventsJob` drains that queue and calls
+   `CachedAudioDeviceLister.ProcessDeviceUpdates`, which raises
+   `_defaultDeviceChanged` for `DefaultChanged` events.
+4. `AppModel.DefaultDeviceChanged` → `TrayIcon` calls `IconChanger.ChangeIcon`,
+   updating the visible icon.
+
+On resume from sleep, Windows may transiently flip / re-assert the default device.
+If the OS ends up with the *same* default it had before sleep (i.e. no real change
+from the OS's point of view), **no `DefaultDeviceChanged` event is fired**. But our
+cache/`_lastRoleDevice` and the tray icon may have been left pointing at a stale
+value during the resume transition. Result: icon and reality diverge, and nothing
+re-syncs them because the OS thinks nothing changed.
+
+Additionally, the device list itself is cached (`CachedAudioDeviceLister`) and is
+only re-enumerated when a `DeviceChanged` event is processed. Devices that
+re-appear after sleep are not guaranteed to be re-read unless something triggers a
+refresh.
+
+## Fix (the chosen approach)
+
+On **resume from sleep**, proactively reconcile the cached default against the
+**actual** OS default, and refresh the cached device list so any device that
+re-appeared after sleep is visible. If the real default differs from what we
+cached, emit a `DefaultDeviceChanged` event through the **existing** pipeline so
+the icon (and everything subscribed to `AppModel.DefaultDeviceChanged`) refreshes
+using the same code path as a genuine OS change.
+
+Concretely:
+
+1. **`WindowsAPIAdapter`** — in `SystemEventsOnPowerModeChanged`, after the existing
+   `ReRegisterAllHotkeys`, also raise a new static event
+   `public static event EventHandler SystemResumed;`. (Keep the existing hotkey
+   re-registration; this is additive.) This mirrors the existing `SessionUnlocked`
+   pattern.
+
+2. **`MMNotificationClient`** — add a public method, e.g.
+   `ReconcileDefaultDevices()`, that:
+   - Iterates every `(DataFlow flow, Role role)` combination (Render + Capture ×
+     Console + Multimedia + Communications), mirroring `MMNotificationClient.Register()`.
+   - For each, reads the **real** current default via
+     `AudioSwitcher.Instance.GetDefaultAudioEndpoint((EDataFlow)flow, (ERole)role)`.
+   - If the returned device id differs from `_lastRoleDevice[(flow, role)]`,
+     update `_lastRoleDevice` and enqueue a
+     `DefaultDeviceChangedEvent(EventType.DefaultChanged, realDeviceId, role)` into
+     `_deviceChangedEvents`, exactly like `OnDefaultDeviceChanged` does.
+   - Skip null results and "no change" cases (same guard as today).
+
+3. **Orchestration in `AppModel`** (or wherever the resume is wired) — on
+   `WindowsAPIAdapter.SystemResumed`:
+   - Call `AudioDeviceLister.Refresh()` first so the device cache is current and the
+     device referenced by the enqueued event actually exists in
+     `PlaybackDevices`/`RecordingDevices` (otherwise `ProcessDeviceUpdates` logs
+     "Can't get device" and drops the icon update).
+   - Then call `MMNotificationClient.Instance.ReconcileDefaultDevices()` so any
+     divergence produces a `DefaultDeviceChanged` event that the recurring job
+     picks up (within ~200 ms) and pushes through to the tray icon.
+
+   Threading: `Refresh()` and `AudioSwitcher` access are COM-marshaled
+   (`ComThread.Invoke`), so calling them off the UI thread is safe. Dispatching via
+   `Task.Run`/the adapter thread is acceptable; do not block the UI thread. Match
+   the existing "avoid race with hotkeys" intent from `SystemEventsOnPowerModeChanged`.
+
+### Why this is correct
+- Reuses the **exact** existing event pipeline — no new icon-update code, no new
+  code path to diverge from real OS changes.
+- Only emits a change event when the real default actually differs from the cache,
+  so a no-op resume produces no spurious icon flicker.
+- Refreshing the lister cache first ensures the enqueued device id resolves in
+  `ProcessDeviceUpdates`.
+- `eCommunications` is already skipped by `IconChangerAbstract.ChangeIcon`, so the
+  icon continues to follow console/multimedia defaults as today.
+
+## Files to change
+- `SoundSwitch/Framework/WinApi/WindowsAPIAdapter.cs` — add `SystemResumed` event;
+  raise it in `SystemEventsOnPowerModeChanged`.
+- `SoundSwitch/Framework/NotificationManager/MMNotificationClient.cs` — add
+  `ReconcileDefaultDevices()`.
+- `SoundSwitch/Model/AppModel.cs` (or the resume wiring) — subscribe to
+  `SystemResumed` and call `AudioDeviceLister.Refresh()` + `MMNotificationClient.Instance.ReconcileDefaultDevices()`.
+
+## Test / validation notes
+- This is Windows-only behavior (COM audio). Linux build cannot validate the
+  runtime; rely on Windows CI (`build` / `build` job) for compilation + the
+  existing `SoundSwitch.Tests`. Add/extend a unit test if a seam exists to inject a
+  fake default (mirror the `AudioSwitcher.SetExtendedPolicyClientForTest` pattern
+  if available), otherwise rely on manual verification on Windows.
+- Confirm no double-refresh storms: `Refresh()` cancels any in-flight refresh, and
+  `ReconcileDefaultDevices` only enqueues on real divergence.
+
+## Out of scope
+- The default-device tooltip text already refreshes on hover (`TooltipInfoManager`);
+  the persistent wrong visual is the icon, which this fix addresses. Tooltip is
+  correct on next hover, so no change needed there.
+- Hotkey re-registration on resume is already handled and is left as-is.

--- a/website/src/.vuepress/config.ts
+++ b/website/src/.vuepress/config.ts
@@ -153,6 +153,7 @@ export default defineUserConfig({
             { text: "Overview", link: "/faq/README.md" },
             { text: "Find SoundSwitch", link: "/faq/finding-soundswitch.md" },
             { text: "Quick Menu", link: "/faq/quick-menu.md" },
+            { text: "Tray icon wrong after sleep", link: "/faq/tray-icon-wrong-after-sleep.md" },
             { text: "Rename a device", link: "/faq/rename-device.md" },
             { text: "Switch profiles", link: "/faq/switching-profiles.md" },
             { text: "Manually check for update", link: "/faq/manually-check-update.md" },

--- a/website/src/faq/README.md
+++ b/website/src/faq/README.md
@@ -11,6 +11,7 @@ Answers to the most common questions, collected over the years from the [GitHub 
 
 - [I can't find SoundSwitch — where did it go?](./finding-soundswitch.md)
 - [What is the menu that appears when I use a hotkey?](./quick-menu.md)
+- [Why does the tray icon show the wrong device after waking from sleep?](./tray-icon-wrong-after-sleep.md)
 
 ## Devices
 

--- a/website/src/faq/tray-icon-wrong-after-sleep.md
+++ b/website/src/faq/tray-icon-wrong-after-sleep.md
@@ -1,0 +1,14 @@
+---
+title: Why does the tray icon show the wrong device after waking from sleep?
+description: After sleep/resume the tray icon can display a device that isn't the one actually playing audio. SoundSwitch now re-syncs the default device on wake.
+---
+
+# Why does the tray icon show the wrong device after waking from sleep?
+
+After the computer wakes from sleep, the SoundSwitch tray icon can briefly show a
+device that is not the one actually playing your audio. This happens because the
+icon's cached view of the default device went out of sync with Windows during the
+resume transition.
+
+SoundSwitch now refreshes the cached default device automatically when the system
+wakes up, so the icon corrects itself within a second or two — no restart required.


### PR DESCRIPTION
## Summary

Fixes #2009 — the tray icon showed a stale default device after waking from sleep (audio came from the real device, but the icon displayed the wrong one until a manual interaction).

## Root cause

On resume from sleep, Windows may transiently re-assert the default device. If the OS ends up with the same default it had before sleep, **no `DefaultDeviceChanged` event is fired**, but the in-process cache (`MMNotificationClient._lastRoleDevice`) and the tray icon could have drifted during the resume transition. Nothing re-synced them, so the icon stayed wrong.

## Fix

- **`WindowsAPIAdapter`**: added a `SystemResumed` static event, raised in the existing `SystemEventsOnPowerModeChanged` handler (right after the existing hotkey re-registration).
- **`MMNotificationClient`**: added `ReconcileDefaultDevices()`, which mirrors `Register()`'s loop — for every `(DataFlow, Role)` it reads the **real** OS default via `AudioSwitcher.Instance.GetDefaultAudioEndpoint`, and if it differs from the cached value, updates the cache and enqueues a `DefaultDeviceChangedEvent`.
- **`AppModel`**: subscribes to `SystemResumed`; on resume it refreshes the device cache (`AudioDeviceLister.Refresh()`) and then reconciles defaults off the UI thread, so any divergence flows through the **existing** `ProcessNotificationEventsJob` → `AppModel.DefaultDeviceChanged` → `TrayIcon.ChangeIcon` pipeline. Only emits a change when the real default actually differs, so a no-op resume produces no icon flicker.

## Notes

- This is Windows-only behavior (COM audio); the Linux build cannot exercise it. The only Linux build failures are the pre-existing `SoundSwitch.Audio.Manager` CsWinRT CS0006 references (`BuildProjectReferences=false`), unrelated to this change — Windows CI is the real validation path.
- Design doc: `docs/issue-2009-sleep-resume-device-refresh.md`.
- Docs: added a short user-facing troubleshooting note.

🤖 Generated with [Hermes Agent](https://github.com/NousResearch/hermes-agent)
