### PR TITLE
boost(notification): render Windows notification as native toast with balloon fallback

### DIFF
--- a/SoundSwitch.Tests/NotificationContentBuilderTests.cs
+++ b/SoundSwitch.Tests/NotificationContentBuilderTests.cs
@@ -1,0 +1,130 @@
+/********************************************************************
+ * Copyright (C) 2015-2024 Antoine Aflalo
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ ********************************************************************/
+
+using System;
+using System.Drawing;
+
+using NAudio.CoreAudioApi;
+
+using NUnit.Framework;
+using FluentAssertions;
+
+using SoundSwitch.Common.Framework.Audio.Device;
+using SoundSwitch.Framework.NotificationManager.Notification;
+using SoundSwitch.Framework.Profile;
+using SoundSwitch.Localization;
+
+namespace SoundSwitch.Tests;
+
+[TestFixture]
+public class NotificationContentBuilderTests
+{
+    private static DeviceFullInfo CreateDevice(string name, DataFlow type) =>
+        new(name, $"id-{name}", type, @"C:\nonexistent\device.ico", DeviceState.Active, false);
+
+    [Test]
+    public void BuildDefaultChanged_RenderWindowsNotification_SetsTitleTextAndImage()
+    {
+        var device = CreateDevice("Test Speaker", DataFlow.Render);
+
+        var data = NotificationContentBuilder.BuildDefaultChanged(device, NotificationContentBuilder.DeviceChangeWording.WindowsNotification);
+
+        data.Title.Should().Be(TrayIconStrings.playbackChanged);
+        data.Text.Should().Be(device.NameClean);
+        data.Image.Should().NotBeNull();
+    }
+
+    [Test]
+    public void BuildDefaultChanged_RenderBanner_SetsPlaybackDeviceTitle()
+    {
+        var device = CreateDevice("Test Speaker", DataFlow.Render);
+
+        var data = NotificationContentBuilder.BuildDefaultChanged(device, NotificationContentBuilder.DeviceChangeWording.Banner);
+
+        data.Title.Should().Be(SettingsStrings.tooltipOnHover_option_playbackDevice);
+    }
+
+    [Test]
+    public void BuildDefaultChanged_CaptureWindowsNotification_SetsRecordingTitle()
+    {
+        var device = CreateDevice("Test Microphone", DataFlow.Capture);
+
+        var data = NotificationContentBuilder.BuildDefaultChanged(device, NotificationContentBuilder.DeviceChangeWording.WindowsNotification);
+
+        data.Title.Should().Be(TrayIconStrings.recordingChanged);
+        data.Text.Should().Be(device.NameClean);
+    }
+
+    [Test]
+    public void BuildDefaultChanged_CaptureBanner_SetsRecordingDeviceTitle()
+    {
+        var device = CreateDevice("Test Microphone", DataFlow.Capture);
+
+        var data = NotificationContentBuilder.BuildDefaultChanged(device, NotificationContentBuilder.DeviceChangeWording.Banner);
+
+        data.Title.Should().Be(SettingsStrings.tooltipOnHover_option_recordingDevice);
+    }
+
+    [Test]
+    public void BuildProfileChanged_SetsPriorityTitleAndText()
+    {
+        var profile = new Profile
+        {
+            Name = "Gaming",
+            Playback = new DeviceInfo("Speakers", "id-speakers", DataFlow.Render, false, DateTime.UtcNow),
+            Recording = new DeviceInfo("Mic", "id-mic", DataFlow.Capture, false, DateTime.UtcNow)
+        };
+
+        var data = NotificationContentBuilder.BuildProfileChanged(profile, new Bitmap(1, 1));
+
+        data.Priority.Should().Be(1);
+        data.Title.Should().Contain(profile.Name);
+        data.Text.Should().Contain("Speakers");
+        data.Image.Should().NotBeNull();
+    }
+
+    [Test]
+    public void BuildAppRuleMatched_SetsPriorityAndTitle()
+    {
+        var playback = CreateDevice("Speakers", DataFlow.Render);
+        var recording = CreateDevice("Mic", DataFlow.Capture);
+
+        var data = NotificationContentBuilder.BuildAppRuleMatched(playback, recording, new Bitmap(1, 1));
+
+        data.Priority.Should().Be(1);
+        data.Title.Should().Be(SettingsStrings.appSoundLock_tab);
+        data.Text.Should().Contain(playback.NameClean);
+        data.Text.Should().Contain(recording.NameClean);
+    }
+
+    [Test]
+    public void BuildMicrophoneMuteChanged_Muted_SetsTitleAndImage()
+    {
+        var data = NotificationContentBuilder.BuildMicrophoneMuteChanged("Mic", true);
+
+        data.Priority.Should().Be(2);
+        data.Title.Should().Be(string.Format(SettingsStrings.notification_microphone_muted, "Mic"));
+        data.Image.Should().NotBeNull();
+    }
+
+    [Test]
+    public void BuildMicrophoneMuteChanged_Unmuted_SetsTitleAndImage()
+    {
+        var data = NotificationContentBuilder.BuildMicrophoneMuteChanged("Mic", false);
+
+        data.Priority.Should().Be(2);
+        data.Title.Should().Be(string.Format(SettingsStrings.notification_microphone_unmuted, "Mic"));
+        data.Image.Should().NotBeNull();
+    }
+}

--- a/SoundSwitch/Framework/Banner/BannerManager.cs
+++ b/SoundSwitch/Framework/Banner/BannerManager.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using Serilog;
 
 using SoundSwitch.Framework.Telemetry;
+using SoundSwitch.Framework.Toast;
 using SoundSwitch.Model;
 
 namespace SoundSwitch.Framework.Banner;
@@ -45,7 +46,7 @@ public class BannerManager
         if (OperatingSystem.IsWindowsVersionAtLeast(10, 0, 17763) && ExclusiveFullscreenDetector.IsForegroundInExclusiveFullscreen())
         {
             Log.Debug("Foreground window is in exclusive fullscreen — routing to Toast notification");
-            ToastBannerAdapter.Show(data);
+            ToastNotificationRenderer.Show(data);
             return;
         }
 
@@ -115,10 +116,5 @@ public class BannerManager
         if (!(_syncContext is System.Windows.Forms.WindowsFormsSynchronizationContext))
             throw new InvalidOperationException("BannerManager must be called in the context of the UI thread.");
         Log.Information("Banner manager initialized");
-
-        if (OperatingSystem.IsWindowsVersionAtLeast(10, 0, 17763))
-        {
-            ToastBannerAdapter.EnsureRegistered();
-        }
     }
 }

--- a/SoundSwitch/Framework/NotificationManager/Notification/NotificationBanner.cs
+++ b/SoundSwitch/Framework/NotificationManager/Notification/NotificationBanner.cs
@@ -13,10 +13,8 @@
  ********************************************************************/
 
 using System;
-using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
-using System.Linq;
 
 using NAudio.CoreAudioApi;
 
@@ -59,47 +57,39 @@ internal class NotificationBanner : INotification
 
     public void NotifyDefaultChanged(DeviceFullInfo audioDevice)
     {
-        using var iconHandle = audioDevice.LargeIcon;
+        var content = NotificationContentBuilder.BuildDefaultChanged(audioDevice, NotificationContentBuilder.DeviceChangeWording.Banner);
         var toastData = CreateBannerData();
-        toastData.Image = iconHandle.ToBitmap();
-        toastData.Text = audioDevice.NameClean;
+        toastData.Image = content.Image;
+        toastData.Title = content.Title;
+        toastData.Text = content.Text;
         if (CustomSoundCheck(audioDevice))
         {
             toastData.SoundFile = Configuration.CustomSound;
             toastData.CurrentDeviceId = audioDevice.Id;
         }
 
-        toastData.Title = audioDevice.Type switch
-        {
-            DataFlow.Render => SettingsStrings.tooltipOnHover_option_playbackDevice,
-            DataFlow.Capture => SettingsStrings.tooltipOnHover_option_recordingDevice,
-            _ => throw new ArgumentOutOfRangeException(nameof(audioDevice.Type), audioDevice.Type, null)
-        };
-
         _bannerManager.ShowNotification(toastData);
     }
 
     public void NotifyProfileChanged(Profile.Profile profile, Bitmap icon, uint? processId)
     {
+        var content = NotificationContentBuilder.BuildProfileChanged(profile, icon);
         var bannerData = CreateBannerData();
-        bannerData.Priority = 1;
-        bannerData.Image = icon;
-        bannerData.Title = string.Format(SettingsStrings.profile_notification_text, profile.Name);
-        bannerData.Text = string.Join("\n", profile.Devices.Select(wrapper => wrapper.DeviceInfo.NameClean).Distinct());
+        bannerData.Priority = content.Priority;
+        bannerData.Image = content.Image;
+        bannerData.Title = content.Title;
+        bannerData.Text = content.Text;
         _bannerManager.ShowNotification(bannerData);
     }
 
     public void NotifyAppRuleMatched(AppSoundRule rule, DeviceFullInfo playback, DeviceFullInfo recording, Bitmap icon, uint processId)
     {
-        var devices = new List<string>();
-        if (playback != null) devices.Add(playback.NameClean);
-        if (recording != null) devices.Add(recording.NameClean);
-
+        var content = NotificationContentBuilder.BuildAppRuleMatched(playback, recording, icon);
         var bannerData = CreateBannerData();
-        bannerData.Priority = 1;
-        bannerData.Image = icon;
-        bannerData.Title = SettingsStrings.appSoundLock_tab;
-        bannerData.Text = string.Join("\n", devices);
+        bannerData.Priority = content.Priority;
+        bannerData.Image = content.Image;
+        bannerData.Title = content.Title;
+        bannerData.Text = content.Text;
         _bannerManager.ShowNotification(bannerData);
     }
 
@@ -127,16 +117,12 @@ internal class NotificationBanner : INotification
 
     private void FullBanner(string microphoneName, bool newMuteState)
     {
-        var title = newMuteState ?
-            string.Format(SettingsStrings.notification_microphone_muted, microphoneName) :
-            string.Format(SettingsStrings.notification_microphone_unmuted, microphoneName);
-
-        var icon = newMuteState ? Resources.microphone_muted : Resources.microphone_unmuted;
+        var content = NotificationContentBuilder.BuildMicrophoneMuteChanged(microphoneName, newMuteState);
 
         var bannerData = CreateBannerData();
-        bannerData.Priority = 2;
-        bannerData.Image = icon;
-        bannerData.Title = title;
+        bannerData.Priority = content.Priority;
+        bannerData.Image = content.Image;
+        bannerData.Title = content.Title;
         _bannerManager.ShowNotification(bannerData);
     }
 

--- a/SoundSwitch/Framework/NotificationManager/Notification/NotificationContentBuilder.cs
+++ b/SoundSwitch/Framework/NotificationManager/Notification/NotificationContentBuilder.cs
@@ -99,6 +99,7 @@ internal static class NotificationContentBuilder
         Title = newMuteState
             ? string.Format(SettingsStrings.notification_microphone_muted, microphoneName)
             : string.Format(SettingsStrings.notification_microphone_unmuted, microphoneName),
+        Text = microphoneName,
         Image = newMuteState ? Resources.microphone_muted : Resources.microphone_unmuted
     };
 }

--- a/SoundSwitch/Framework/NotificationManager/Notification/NotificationContentBuilder.cs
+++ b/SoundSwitch/Framework/NotificationManager/Notification/NotificationContentBuilder.cs
@@ -1,0 +1,104 @@
+/********************************************************************
+ * Copyright (C) 2015-2024 Antoine Aflalo
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ ********************************************************************/
+
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+
+using NAudio.CoreAudioApi;
+
+using SoundSwitch.Common.Framework.Audio.Device;
+using SoundSwitch.Framework.Banner;
+using SoundSwitch.Framework.Profile;
+using SoundSwitch.Localization;
+using SoundSwitch.Properties;
+
+namespace SoundSwitch.Framework.NotificationManager.Notification;
+
+/// <summary>
+/// Pure, platform-neutral, stateless composer for notification content.
+/// Builds the <see cref="BannerData"/> (Title/Text/Image/Priority) shared by the
+/// banner and Windows notification channels. Position/Ttl/Opacity/DisplayInfo are
+/// intentionally left to the caller.
+/// </summary>
+internal static class NotificationContentBuilder
+{
+    public enum DeviceChangeWording
+    {
+        Banner,
+        WindowsNotification
+    }
+
+    internal static BannerData BuildDefaultChanged(DeviceFullInfo device, DeviceChangeWording wording)
+    {
+        using var largeIcon = device.LargeIcon;
+
+        var title = wording switch
+        {
+            DeviceChangeWording.Banner => device.Type switch
+            {
+                DataFlow.Render => SettingsStrings.tooltipOnHover_option_playbackDevice,
+                DataFlow.Capture => SettingsStrings.tooltipOnHover_option_recordingDevice,
+                _ => throw new ArgumentOutOfRangeException(nameof(device.Type), device.Type, null)
+            },
+            DeviceChangeWording.WindowsNotification => device.Type switch
+            {
+                DataFlow.Render => TrayIconStrings.playbackChanged,
+                DataFlow.Capture => TrayIconStrings.recordingChanged,
+                _ => throw new ArgumentOutOfRangeException(nameof(device.Type), device.Type, null)
+            },
+            _ => throw new ArgumentOutOfRangeException(nameof(wording), wording, null)
+        };
+
+        return new BannerData
+        {
+            Title = title,
+            Text = device.NameClean,
+            Image = largeIcon.ToBitmap()
+        };
+    }
+
+    internal static BannerData BuildProfileChanged(Profile.Profile profile, Bitmap icon) => new()
+    {
+        Priority = 1,
+        Image = icon,
+        Title = string.Format(SettingsStrings.profile_notification_text, profile.Name),
+        Text = string.Join("\n", profile.Devices.Select(wrapper => wrapper.DeviceInfo.NameClean).Distinct())
+    };
+
+    internal static BannerData BuildAppRuleMatched(DeviceFullInfo playback, DeviceFullInfo recording, Bitmap icon)
+    {
+        var devices = new List<string>();
+        if (playback != null) devices.Add(playback.NameClean);
+        if (recording != null) devices.Add(recording.NameClean);
+
+        return new BannerData
+        {
+            Priority = 1,
+            Image = icon,
+            Title = SettingsStrings.appSoundLock_tab,
+            Text = string.Join("\n", devices)
+        };
+    }
+
+    internal static BannerData BuildMicrophoneMuteChanged(string microphoneName, bool newMuteState) => new()
+    {
+        Priority = 2,
+        Title = newMuteState
+            ? string.Format(SettingsStrings.notification_microphone_muted, microphoneName)
+            : string.Format(SettingsStrings.notification_microphone_unmuted, microphoneName),
+        Image = newMuteState ? Resources.microphone_muted : Resources.microphone_unmuted
+    };
+}

--- a/SoundSwitch/Framework/NotificationManager/Notification/NotificationWindows.cs
+++ b/SoundSwitch/Framework/NotificationManager/Notification/NotificationWindows.cs
@@ -22,8 +22,10 @@ using NAudio.CoreAudioApi;
 
 using SoundSwitch.Common.Framework.Audio.Device;
 using SoundSwitch.Framework.Audio;
+using SoundSwitch.Framework.Banner;
 using SoundSwitch.Framework.NotificationManager.Notification.Configuration;
 using SoundSwitch.Framework.Telemetry;
+using SoundSwitch.Framework.Toast;
 using SoundSwitch.Localization;
 using SoundSwitch.Model;
 
@@ -39,45 +41,41 @@ internal class NotificationWindows : INotification
     public void NotifyDefaultChanged(DeviceFullInfo audioDevice)
     {
         TelemetryService.TrackNotificationWindows();
-        switch (audioDevice.Type)
-        {
-            case DataFlow.Render:
-                Configuration.Icon.ShowBalloonTip(500,
-                    TrayIconStrings.playbackChanged,
-                    audioDevice.NameClean, ToolTipIcon.Info);
-                break;
-            case DataFlow.Capture:
-                Configuration.Icon.ShowBalloonTip(500,
-                    TrayIconStrings.recordingChanged,
-                    audioDevice.NameClean, ToolTipIcon.Info);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException(nameof(audioDevice.Type), audioDevice.Type, null);
-        }
+        var data = NotificationContentBuilder.BuildDefaultChanged(audioDevice, NotificationContentBuilder.DeviceChangeWording.WindowsNotification);
+        ShowToastOrBalloon(data);
     }
 
     public void NotifyProfileChanged(Profile.Profile profile, Bitmap icon, uint? processId)
     {
-        var title = string.Format(SettingsStrings.profile_notification_text, profile.Name);
-        var text  = string.Join("\n", profile.Devices.Select(wrapper => wrapper.DeviceInfo.NameClean));
-        Configuration.Icon.ShowBalloonTip(1000, title, text, ToolTipIcon.Info);
+        var data = NotificationContentBuilder.BuildProfileChanged(profile, icon);
+        ShowToastOrBalloon(data);
     }
 
     public void NotifyAppRuleMatched(AppSoundRule rule, DeviceFullInfo playback, DeviceFullInfo recording, Bitmap icon, uint processId)
     {
-        var devices = new List<string>();
-        if (playback != null) devices.Add(playback.NameClean);
-        if (recording != null) devices.Add(recording.NameClean);
-
-        var title = SettingsStrings.appSoundLock_tab;
-        var text = string.Join("\n", devices);
-        Configuration.Icon.ShowBalloonTip(1000, title, text, ToolTipIcon.Info);
+        var data = NotificationContentBuilder.BuildAppRuleMatched(playback, recording, icon);
+        ShowToastOrBalloon(data);
     }
 
     public void NotifyMicrophoneMuteChanged(string deviceId, string microphoneName, bool newMuteState)
     {
-        var title = newMuteState ? string.Format(SettingsStrings.notification_microphone_muted, microphoneName) : string.Format(SettingsStrings.notification_microphone_unmuted, microphoneName);
-        Configuration.Icon.ShowBalloonTip(1000, title, microphoneName, ToolTipIcon.Info);
+        var data = NotificationContentBuilder.BuildMicrophoneMuteChanged(microphoneName, newMuteState);
+        ShowToastOrBalloon(data);
+    }
+
+    private void ShowToastOrBalloon(BannerData data)
+    {
+        if (OperatingSystem.IsWindowsVersionAtLeast(10, 0, 17763) && ToastNotificationRenderer.Show(data))
+        {
+            return;
+        }
+
+        ShowBalloon(data);
+    }
+
+    private void ShowBalloon(BannerData data)
+    {
+        Configuration.Icon.ShowBalloonTip(1000, data.Title, data.Text, ToolTipIcon.Info);
     }
 
     public void OnSoundChanged(CachedSound newSound) { }

--- a/SoundSwitch/Framework/NotificationManager/Notification/NotificationWindows.cs
+++ b/SoundSwitch/Framework/NotificationManager/Notification/NotificationWindows.cs
@@ -65,6 +65,8 @@ internal class NotificationWindows : INotification
 
     private void ShowToastOrBalloon(BannerData data)
     {
+        data.Ttl = Configuration.Ttl;
+
         if (OperatingSystem.IsWindowsVersionAtLeast(10, 0, 17763) && ToastNotificationRenderer.Show(data))
         {
             return;

--- a/SoundSwitch/Framework/NotificationManager/NotificationManager.cs
+++ b/SoundSwitch/Framework/NotificationManager/NotificationManager.cs
@@ -27,6 +27,7 @@ using SoundSwitch.Common.Framework.Icon;
 using SoundSwitch.Framework.Audio;
 using SoundSwitch.Framework.NotificationManager.Notification;
 using SoundSwitch.Framework.NotificationManager.Notification.Configuration;
+using SoundSwitch.Framework.Toast;
 using SoundSwitch.Localization;
 using SoundSwitch.Model;
 using SoundSwitch.Properties;
@@ -44,6 +45,11 @@ public class NotificationManager(INotificationSettings notificationSettings, IAp
 
     public void Init()
     {
+        if (OperatingSystem.IsWindowsVersionAtLeast(10, 0, 17763))
+        {
+            ToastNotificationRenderer.EnsureRegistered();
+        }
+
         deviceService.DefaultDeviceChanged += ModelOnDefaultDeviceChanged;
         notificationSettings.NotificationSettingsChanged += ModelOnNotificationSettingsChanged;
         SetNotifications(notificationSettings.SwitchDeviceNotification, notificationSettings.SwitchProfileNotification, notificationSettings.MicrophoneMuteNotification);

--- a/SoundSwitch/Framework/Toast/ToastNotificationRenderer.cs
+++ b/SoundSwitch/Framework/Toast/ToastNotificationRenderer.cs
@@ -24,7 +24,7 @@ using Serilog;
 // BannerDisplayInfo resolves to the nested namespace, shadowing the enum.
 using BannerDisplayInfoEnum = SoundSwitch.Framework.Banner.BannerDisplayInfo.BannerDisplayInfo;
 
-namespace SoundSwitch.Framework.Banner;
+namespace SoundSwitch.Framework.Toast;
 
 /// <summary>
 /// Renders a <see cref="BannerData"/> as a Windows Toast notification
@@ -34,7 +34,7 @@ namespace SoundSwitch.Framework.Banner;
 /// display over exclusive fullscreen games.
 /// </summary>
 [System.Runtime.Versioning.SupportedOSPlatform("windows10.0.17763.0")]
-internal static class ToastBannerAdapter
+internal static class ToastNotificationRenderer
 {
     // SoundSwitch's registered AppUserModelID.
     // Must match the value set by the installer (Inno Setup sets this on the
@@ -75,7 +75,7 @@ internal static class ToastBannerAdapter
     /// Shows a Windows Toast notification built from the provided
     /// <see cref="BannerData"/>. Safe to call from any thread.
     /// </summary>
-    public static void Show(BannerData data)
+    public static bool Show(BannerData data)
     {
         try
         {
@@ -95,10 +95,13 @@ internal static class ToastBannerAdapter
             ToastNotificationManager
                 .CreateToastNotifier(AppId)
                 .Show(toast);
+
+            return true;
         }
         catch (Exception ex)
         {
-            Log.Warning(ex, "ToastBannerAdapter failed to show notification for '{Title}'", data.Title);
+            Log.Warning(ex, "ToastNotificationRenderer failed to show notification for '{Title}'", data.Title);
+            return false;
         }
     }
 
@@ -176,7 +179,7 @@ internal static class ToastBannerAdapter
         }
         catch (Exception ex)
         {
-            Log.Warning(ex, "ToastBannerAdapter could not save image to temp");
+            Log.Warning(ex, "ToastNotificationRenderer could not save image to temp");
             return null;
         }
     }

--- a/SoundSwitch/Framework/Toast/ToastNotificationRenderer.cs
+++ b/SoundSwitch/Framework/Toast/ToastNotificationRenderer.cs
@@ -20,8 +20,10 @@ using Windows.Data.Xml.Dom;
 using Windows.UI.Notifications;
 using Serilog;
 
-// Alias required: inside namespace SoundSwitch.Framework.Banner the simple name
-// BannerDisplayInfo resolves to the nested namespace, shadowing the enum.
+using SoundSwitch.Framework.Banner;
+
+// Alias required: the imported SoundSwitch.Framework.Banner namespace contains a
+// nested BannerDisplayInfo namespace which shadows the same-named enum.
 using BannerDisplayInfoEnum = SoundSwitch.Framework.Banner.BannerDisplayInfo.BannerDisplayInfo;
 
 namespace SoundSwitch.Framework.Toast;

--- a/docs/windows-notification-toast-refactor.md
+++ b/docs/windows-notification-toast-refactor.md
@@ -1,0 +1,204 @@
+# Windows Notification → Toast Refactor
+
+**Status:** Design proposal (no code changed).
+**Branch:** `refactor/windows-notification-toast`.
+
+## 1. Problem
+
+SoundSwitch ships two independent "Windows notification" mechanisms:
+
+1. **Legacy tray balloon tips** — `NotificationWindows` calls `Configuration.Icon.ShowBalloonTip(...)` (`Shell_NotifyIcon`). Windows 10/11 silently reroutes, delays, and caps these balloon tips; they never appear in Action Center and give no per-channel control.
+2. **Modern Windows toast** — `ToastBannerAdapter` already hand-builds `ToastGeneric` XML (via `Windows.UI.Notifications` + `Windows.Data.Xml.Dom`, no Microsoft.Toolkit dependency) and is used today by `BannerManager` as its *exclusive-fullscreen fallback*.
+
+A user who selects the **"Windows Notification"** option (`NotificationType.DefaultWindowsNotification`) still gets balloon tips, while the banner channel has already been given a working, modern toast renderer. In addition, the title/text composition logic is duplicated between `NotificationWindows` and `NotificationBanner` with **inconsistent localized wording**:
+
+- Device change title — banner uses `SettingsStrings.tooltipOnHover_option_playbackDevice` / `_recordingDevice` ("Playback Device" / "Recording Device"); Windows uses `TrayIconStrings.playbackChanged` / `recordingChanged` ("SoundSwitch: Playback device switched to" / "SoundSwitch: Recording device switched to").
+- Microphone mute — `NotificationWindows` passes `microphoneName` as the balloon *body* in addition to formatting it into the title, effectively duplicating it; `NotificationBanner` puts the name in the title and shows an icon instead.
+
+## 2. Target Architecture
+
+Make `NotificationWindows` render through the existing toast mechanism instead of `ShowBalloonTip`, while consolidating the duplicated content composition.
+
+```
+NotificationWindows ──┐
+                      ├──► NotificationContentBuilder (pure, static, platform-neutral)
+NotificationBanner  ──┘            │
+                                   ▼ produces BannerData
+                                   │
+                                   ├──► ToastNotificationRenderer (Win10 17763+)  ← toast path
+                                   └──► legacy balloon (fallback for <17763 or toast failure)
+```
+
+The concrete plan:
+
+1. Extract a **shared, pure content builder** that produces the `Title`/`Text`/`Image`/`Priority` for all four notification channels (`DefaultChanged`, `ProfileChanged`, `AppRuleMatched`, `MicrophoneMuteChanged`). This is where DRY and the localized-string unification live. It is platform-neutral and unit-testable.
+2. `NotificationWindows` becomes a thin adapter: build a `BannerData` via the shared builder and hand it to the toast renderer; keep a private balloon-tip path as the fallback.
+3. `ToastBannerAdapter` is renamed/relocated into a channel-neutral renderer (`ToastNotificationRenderer`) and its `Show` is made to report success/failure so the Windows channel can fall back (see §7).
+
+## 3. SOLID / DIP — static vs interface
+
+`ToastBannerAdapter` is currently an `internal static class`. Two options were considered:
+
+- **Option A (seam):** introduce `IToastNotificationRenderer` with `EnsureRegistered()` and `bool Show(BannerData)`, implemented by the renderer, and have both `NotificationWindows` and `BannerManager` depend on the abstraction.
+- **Option B (KISS):** keep it static; extract testability into the *content builder* instead.
+
+**Recommendation: Option B (keep static), with DIP applied at the content layer.**
+
+Reasoning:
+
+- The renderer is a pure OS-integration detail (`Windows.UI.Notifications`) with **no state and no plausible second implementation** in this Windows-desktop-first app. There is nothing to swap at runtime.
+- The codebase has **no DI container**; `NotificationWindows` is constructed with `new NotificationWindows()` inside `NotificationFactory`'s static `EnumImplList`. Introducing an interface would force manual constructor-injection through the factory for zero runtime benefit.
+- The renderer is Windows-only (CsWinRT) and cannot run on the Linux partial build anyway, so its seam adds no test coverage. The genuinely testable logic is the **title/text/image composition**, which is exactly what step 1 extracts.
+- The dependency *inversion* that matters is already achieved by step 1: both notification implementations depend on `NotificationContentBuilder` (a small, stable abstraction) rather than on each other or on duplicated literals.
+
+If a seam is later wanted (e.g. for a mocked toast in UI tests), the rename in §8 to an instance-friendly type leaves the door open without any churn now.
+
+## 4. DRY — shared content builder
+
+New type: `SoundSwitch.Framework.NotificationManager.Notification.NotificationContentBuilder` (`internal static`), returning `BannerData` (the existing, already-consumed DTO — no new DTO needed, since `ToastBannerAdapter` and `BannerManager` both already accept `BannerData`).
+
+Proposed surface (all inputs already available at the call sites):
+
+```csharp
+internal static BannerData BuildDefaultChanged(DeviceFullInfo device);
+internal static BannerData BuildProfileChanged(Profile.Profile profile, Bitmap icon);
+internal static BannerData BuildAppRuleMatched(DeviceFullInfo playback, DeviceFullInfo recording, Bitmap icon);
+internal static BannerData BuildMicrophoneMuteChanged(string microphoneName, bool newMuteState);
+```
+
+Each method fills `Title`, `Text`, `Image`, and `Priority`, leaving `Position`/`Ttl`/`Opacity`/`DisplayInfo` to the caller (as `NotificationBanner.CreateBannerData()` already does today), since those come from `Configuration` and differ per channel. The builder does **not** own `Configuration`.
+
+Details:
+
+- `BuildDefaultChanged` maps `DataFlow.Render` → `SettingsStrings.tooltipOnHover_option_playbackDevice`, `DataFlow.Capture` → `_recordingDevice`; `Text = device.NameClean`; `Image` from `device.LargeIcon.ToBitmap()`. This also fixes a behavior gap: the balloon path currently shows **no** device icon, whereas the toast supports `appLogoOverride`.
+- `BuildProfileChanged` / `BuildAppRuleMatched` reproduce the current banner composition exactly (distinct `NameClean`, `\n` join, `Priority = 1`, `Title = SettingsStrings.appSoundLock_tab` for rules).
+- `BuildMicrophoneMuteChanged` produces the *fading* content (`notification_microphone_muted`/`_unmuted` title, `Resources.microphone_muted`/`_unmuted` icon, `Priority = 2`). The **Persistent** path stays banner-specific (`MicrophoneMuteBannerManager`) and is not part of this builder.
+
+### Localized-string discrepancy — decision
+
+The two channels use different device-change wording.
+
+**DECIDED (maintainer, overriding the original recommendation): each channel KEEPS its existing wording.** `NotificationWindows` continues to use `TrayIconStrings.playbackChanged` / `recordingChanged`; `NotificationBanner` continues to use `SettingsStrings.tooltipOnHover_option_playbackDevice` / `_recordingDevice`.
+
+Rationale for rejecting unification:
+
+- `TrayIconStrings.playbackChanged` / `recordingChanged` are **translated into ~20 locales** (`ar`, `bg`, `cs`, `de`, `el-GR`, `es`, `fr`, and more `.resx` files). Unifying would discard that human translation work in exchange for a purely cosmetic consistency win.
+- No user-visible wording regression: existing "Windows Notification" users see exactly the text they see today, now rendered as a toast instead of a balloon.
+- The DRY goal is still fully met — the *composition logic* (which strings go in Title vs Text, the `DataFlow` switch, image/priority) is shared; only the string constants differ per channel.
+
+**Consequence for the builder API:** `BuildDefaultChanged` takes an explicit wording selector so the single code path serves both channels:
+
+```csharp
+internal enum DeviceChangeWording { Banner, WindowsNotification }
+
+internal static BannerData BuildDefaultChanged(DeviceFullInfo device, DeviceChangeWording wording);
+```
+
+`Banner` → `SettingsStrings.tooltipOnHover_option_playbackDevice` / `_recordingDevice`.
+`WindowsNotification` → `TrayIconStrings.playbackChanged` / `recordingChanged`.
+
+No new `.resx` keys are required, and **no localized string is retired** (this supersedes step 7 in §11 — there is no orphaned-key cleanup).
+
+## 5. Ownership / layering
+
+`ToastBannerAdapter` lives in `SoundSwitch/Framework/Banner`, but after this change it serves a non-banner channel (the Windows notification) as well as the banner's fullscreen fallback.
+
+**Recommendation: rename + move to `SoundSwitch/Framework/Toast/ToastNotificationRenderer.cs`** (new namespace `SoundSwitch.Framework.Toast`).
+
+- The `Framework.Banner` namespace should remain Win32-overlay-centric; the toast renderer is now a cross-channel OS integration and its name `...BannerAdapter` becomes misleading.
+- The move is low-churn: only two call sites reference it today (`BannerManager.ShowNotification` and `BannerManager.Setup`), plus the new `NotificationWindows` site.
+- The `AppId` constant (`"aaflalo.SoundSwitch.Application"`), the hand-built XML builder, `SaveImageToTemp`, and `EscapeXml` all move with it unchanged.
+
+Fallback (if churn is the overriding concern): keep the file at its current path and only rename the type to `ToastNotificationRenderer`. The behavior is identical; only the namespace semantics differ. The recommended move is preferred for correctness.
+
+## 6. Behavior deltas the user will notice
+
+| Aspect | Before (balloon) | After (toast) |
+|---|---|---|
+| Action Center | Not shown | Toast appears in and persists in Action Center until `ExpirationTime` |
+| Persistence | ~500–1000 ms transient | Respects `Ttl` (`BannerOnScreenTime`), removed on expiry |
+| Popup vs quiet | Always popup | `SuppressPopup` when `Ttl < 4s` (mirrors banner behavior) |
+| Device icon | Tray icon only | Real device icon (`appLogoOverride`, circle-cropped) |
+| OS floor | Any Windows | Windows 10 1809 (17763)+ |
+| Wording | "SoundSwitch: Playback device switched to" | Unchanged — `TrayIconStrings.playbackChanged` is kept (see §4) |
+
+These are the correct modern semantics, but they are **visible**: toasts linger in Action Center and can be dismissed/focused by the user, which balloon tips could not.
+
+## 7. OS gating, failure fallback, and swallowed exceptions
+
+`ToastBannerAdapter.Show` currently wraps its body in `try/catch` and only logs (`Log.Warning`), returning `void`. For the banner fullscreen fallback this is acceptable (the alternative overlay cannot render in FSE anyway). For the **Windows notification channel it is not**: the user explicitly chose this channel, so a silent no-op is the worst outcome.
+
+**Decision:**
+
+1. Change `ToastNotificationRenderer.Show(BannerData)` to return `bool` (`true` on success, `false` on any caught exception). Keep the `Log.Warning`.
+2. `NotificationWindows` keeps a private legacy balloon path (the existing `ShowBalloonTip` calls, reusing the unified wording) and uses it when:
+   - `!OperatingSystem.IsWindowsVersionAtLeast(10, 0, 17763)` — pre-1809 Windows has no toast API, so balloon is the only native option.
+   - `ToastNotificationRenderer.Show(...)` returns `false` — toast registration/display failed (missing AppUserModelID, etc.).
+3. `BannerManager` ignores the return value (its FSE path has no meaningful overlay fallback, and this is unchanged behavior).
+
+`NotificationWindows.IsAvailable()` remains `true` — it must stay selectable on pre-17763 Windows because it now degrades to balloon rather than disappearing from the settings UI.
+
+## 8. AppUserModelID / EnsureRegistered ownership
+
+`EnsureRegistered()` is currently called only from `BannerManager.Setup()`, guarded by the 17763 check. If a user selects the Windows notification channel but the banner channel is never exercised, `EnsureRegistered` may never run and the toast may fail to register the AUMID.
+
+**Decision:** move the responsibility off `BannerManager` onto a single always-run startup path:
+
+- Call `ToastNotificationRenderer.EnsureRegistered()` from `NotificationManager.Init()` (which is always constructed), keeping the same `IsWindowsVersionAtLeast(10,0,17763)` guard.
+- `EnsureRegistered()` is idempotent (it only creates a registry subkey) and thread-safe (registry + reflection, no UI affinity), so it needs no `WindowsFormsSynchronizationContext`.
+- Remove the call from `BannerManager.Setup()` to avoid a second redundant call, or leave it harmlessly (idempotent). Recommended: remove it and let `NotificationManager.Init()` be the single owner.
+
+## 9. Thread affinity & the shared-singleton constraint
+
+- **Toast path has no UI-thread affinity.** `ToastNotificationManager.CreateToastNotifier(...).Show(...)` is thread-safe; the adapter's own doc already states "Safe to call from any thread." `NotificationWindows.Notify*` may be invoked from the device-change event path (background), and unlike the overlay path in `BannerManager` (which marshals through `_syncContext.Send`), the toast path must **not** be marshaled.
+- **Singleton constraint.** `NotificationFactory` holds one static `NotificationWindows` instance shared across the SwitchDevice / SwitchProfile / MicrophoneMute channels (its `Configuration` is overwritten per `BuildNotification`, but with identical values). Therefore `NotificationWindows` must remain **stateless**: no instance fields, all per-call state flows through method parameters and the read-only `Configuration` during `Notify*`. The shared `NotificationContentBuilder` and `ToastNotificationRenderer` are `static` and stateless, which satisfies this by construction.
+
+## 10. Enum / config compatibility
+
+- **Do not resurrect `NotificationType.ToastNotification` (value `4`) as a selectable option.** It is retired; `SoundSwitchConfiguration.Migrate()` already rewrites persisted `ToastNotification` → `BannerNotification` (and `CustomNotification` → `SoundNotification`). The toast is an implementation/rendering detail of the *existing* `DefaultWindowsNotification` channel, not a new enum member.
+- **No config schema change is required.** `NotificationType.DefaultWindowsNotification` keeps its value and meaning; only its rendering changes. `Migrate()` needs no new branch, and no `MigratedFields` entry is added.
+
+## 11. Files to change (ordered, implementable steps)
+
+1. **`SoundSwitch/Framework/NotificationManager/Notification/NotificationContentBuilder.cs`** (new) — pure static Title/Text/Image/Priority composition for the four channels; the DRY home and the localized-string unification point.
+2. **`SoundSwitch/Framework/Toast/ToastNotificationRenderer.cs`** (rename/move of `ToastBannerAdapter.cs`) — channel-neutral toast renderer; `Show` returns `bool`; carries `AppId`, XML builder, `SaveImageToTemp`, `EscapeXml`, `EnsureRegistered`.
+3. **`SoundSwitch/Framework/Banner/BannerManager.cs`** — update two references to `ToastNotificationRenderer`; remove/redundant-ize the `EnsureRegistered` call.
+4. **`SoundSwitch/Framework/NotificationManager/Notification/NotificationWindows.cs`** — replace `ShowBalloonTip` with `NotificationContentBuilder` + `ToastNotificationRenderer.Show`, add private balloon fallback; keep telemetry call.
+5. **`SoundSwitch/Framework/NotificationManager/Notification/NotificationBanner.cs`** — replace inline Title/Text/Image composition with `NotificationContentBuilder` (delete the now-duplicated body).
+6. **`SoundSwitch/Framework/NotificationManager/NotificationManager.cs`** — add `ToastNotificationRenderer.EnsureRegistered()` to `Init()` (single owner, 17763-guarded).
+7. **`SoundSwitch/Localization/`** — **no changes.** No new keys, and no key retired: `TrayIconStrings.playbackChanged` / `recordingChanged` stay in use by the Windows channel (see §4).
+
+## 12. Test / validation strategy
+
+- **Linux partial build** (full solution cannot build on Linux — CsWinRT projection generation in `SoundSwitch.Audio.Manager` is Windows-only; `CS0006` there is pre-existing/expected):
+  ```
+  dotnet build SoundSwitch/SoundSwitch.csproj -c Debug -p:LinuxBuild=true -p:BuildProjectReferences=false
+  ```
+- **Windows CI is the real compile gate** (CsWinRT toast code, `Windows.UI.Notifications`).
+- **Unit tests** (Windows only): `NotificationContentBuilder` is pure and platform-neutral — add tests in `SoundSwitch.Tests` asserting title/text/image/priority for each channel, including the `DataFlow` switch and the wording unification. Follow the existing `ExclusiveFullscreenDetectorTests` pattern as a model.
+- **Manual matrix:** Win10 1809+ toast shows and persists in Action Center; Win10 pre-1809 / older falls back to balloon; forced toast failure (unregister AUMID) falls back to balloon; banner FSE fallback still routes to toast.
+
+## 13. Website / docs update (do not edit yet)
+
+`website/src/configuration/notifications.md` — the **Notifications** page already lists "Windows Toast" vs "Banner Notification" and documents the banner→toast fullscreen fallback. It needs a short user-facing note that the **"Windows Notification"** option now renders as a native Windows toast (appears in and persists in Action Center, follows the on-screen time, requires Windows 10 1809+, falls back to a legacy balloon on older Windows). Validate with `cd website && npm run docs:build`.
+
+## 14. Decisions (resolved by maintainer)
+
+All open questions are settled; implementation follows **Option 1** below.
+
+1. **Wording** — **REJECTED unification.** Each channel keeps its existing strings; `TrayIconStrings.playbackChanged` / `recordingChanged` are preserved because they carry ~20 locales of translation. The builder takes a `DeviceChangeWording` selector (§4).
+2. **`EnsureRegistered` ownership** — **APPROVED:** move to `NotificationManager.Init()` as the single owner; remove the `BannerManager.Setup()` call.
+3. **Renderer location** — **APPROVED:** move + rename to `SoundSwitch/Framework/Toast/ToastNotificationRenderer.cs`.
+4. **Orphaned localization keys** — **N/A**, nothing is orphaned given decision 1.
+
+Also approved for the same PR:
+
+- `ToastNotificationRenderer.Show()` returns `bool` so the Windows channel can fall back to a balloon tip.
+- Unit tests for `NotificationContentBuilder` in `SoundSwitch.Tests`.
+- Short user-facing note in `website/src/configuration/notifications.md`.
+
+### Chosen implementation option
+
+1. **Full unified builder + renamed/moved renderer + balloon fallback (this design).** ← selected
+2. Same, but renderer rename-in-place. Identical behavior, weaker namespace semantics.
+3. Minimal swap with no DRY extraction or fallback — rejected.

--- a/docs/windows-notification-toast-refactor.md
+++ b/docs/windows-notification-toast-refactor.md
@@ -1,6 +1,6 @@
 # Windows Notification → Toast Refactor
 
-**Status:** Design proposal (no code changed).
+**Status:** Implemented (see PR #2370).
 **Branch:** `refactor/windows-notification-toast`.
 
 ## 1. Problem

--- a/website/src/configuration/notifications.md
+++ b/website/src/configuration/notifications.md
@@ -16,6 +16,8 @@ The **Notification Type** panel controls which notification method is used and p
 - **Switch device** — Sets the notification style used when switching audio devices via hotkey. Options include **Banner Notification**, **Windows Toast**, **Sound**, or **None**.
 - **Advanced...** (checkbox) — When checked, reveals additional notification controls: **Switch profile** (notification for profile activation) and **Microphone mute** (notification for mute toggle). The panel height expands to accommodate these options.
 
+The **Windows Notification** option is rendered as a native Windows toast: it appears in and persists in the Action Center, follows the on-screen time, and shows the real device icon. It requires Windows 10 version 1809 or later; on older Windows versions it falls back to a legacy notification balloon.
+
 ## Custom Sound File
 
 Click **Select...** to choose an audio file that SoundSwitch plays when a device is switched. Click the delete (×) button to remove the custom sound.

--- a/website/src/configuration/notifications.md
+++ b/website/src/configuration/notifications.md
@@ -13,7 +13,7 @@ The **Notifications** tab lets you choose how SoundSwitch alerts you when an aud
 
 The **Notification Type** panel controls which notification method is used and provides an **Advanced...** toggle to reveal additional options.
 
-- **Switch device** — Sets the notification style used when switching audio devices via hotkey. Options include **Banner Notification**, **Windows Toast**, **Sound**, or **None**.
+- **Switch device** — Sets the notification style used when switching audio devices via hotkey. Options include **Banner Notification**, **Windows Notification**, **Sound**, or **None**.
 - **Advanced...** (checkbox) — When checked, reveals additional notification controls: **Switch profile** (notification for profile activation) and **Microphone mute** (notification for mute toggle). The panel height expands to accommodate these options.
 
 The **Windows Notification** option is rendered as a native Windows toast: it appears in and persists in the Action Center, follows the on-screen time, and shows the real device icon. It requires Windows 10 version 1809 or later; on older Windows versions it falls back to a legacy notification balloon.


### PR DESCRIPTION
## Problem

SoundSwitch shipped **two independent "Windows notification" mechanisms**:

1. `NotificationWindows` used legacy tray balloon tips (`Configuration.Icon.ShowBalloonTip`, i.e. `Shell_NotifyIcon`). Windows 10/11 silently reroutes, delays and caps these; they never reach the Action Center.
2. `ToastBannerAdapter` already hand-built proper `ToastGeneric` XML and was used by `BannerManager` — but **only** as its exclusive-fullscreen fallback.

So a user who picked **Windows Notification** still got balloon tips, while the banner channel already had a working modern toast renderer. On top of that, the Title/Text/Image composition was duplicated between `NotificationWindows` and `NotificationBanner`, with the two drifting apart on which localized strings they used.

## What changed

**DRY** — new `NotificationContentBuilder` is now the single source of `Title`/`Text`/`Image`/`Priority` composition for all four channels (device change, profile, app rule, microphone mute). Both `NotificationWindows` and `NotificationBanner` consume it, so the duplicated bodies are gone.

**The actual refactor** — `NotificationWindows` now renders through the existing toast mechanism instead of balloon tips.

**KISS/SOLID** — `ToastNotificationRenderer` deliberately stays a **static** class. There is no DI container in this repo (`NotificationFactory` builds implementations with `new`), no plausible second implementation, and the renderer is Windows-only so a seam would add no testable surface. The dependency inversion that actually pays off is at the content layer: both notification classes now depend on `NotificationContentBuilder` rather than on duplicated literals. That builder is pure and platform-neutral, which is exactly what the new tests exercise.

**Layering** — `ToastBannerAdapter` → `SoundSwitch/Framework/Toast/ToastNotificationRenderer.cs` (moved with `git mv`, history preserved). It now serves a non-banner channel, so living under `Framework/Banner` and being named `...BannerAdapter` was misleading.

**Real fallback, not a silent no-op** — `Show()` now returns `bool`. Previously it swallowed every exception and returned `void`; acceptable for the banner's fullscreen fallback (no overlay is possible there anyway), but not for a channel the user explicitly selected. `NotificationWindows` falls back to a balloon tip when the OS is pre-1809 or the toast fails to display. `IsAvailable()` stays `true` so the option remains selectable on older Windows.

**`EnsureRegistered()` ownership** — moved from `BannerManager.Setup()` to `NotificationManager.Init()`. Previously the AppUserModelID was only registered as a side effect of the banner subsystem initialising, so a user on the Windows channel who never triggered a banner could have had toasts fail to register. It is idempotent and has no UI-thread affinity.

## Deliberate decisions

**Localized wording is preserved per channel.** An earlier draft proposed unifying both channels on `SettingsStrings.tooltipOnHover_option_*`. That was **rejected**: `TrayIconStrings.playbackChanged`/`recordingChanged` carry roughly **20 locales** of existing human translation (`ar`, `bg`, `cs`, `de`, `el-GR`, `es`, `fr`, …), and discarding that for cosmetic consistency is a bad trade. The builder takes a `DeviceChangeWording` selector instead, so the composition logic is shared while each channel keeps its own strings. Net effect: existing users see **exactly the same text**, now rendered as a toast. No `.resx` file changes, no retired keys.

**No config/enum change.** `NotificationType.ToastNotification` (value `4`) is retired and rewritten by `SoundSwitchConfiguration.Migrate()`; it is **not** resurrected. The toast is a rendering detail of the existing `DefaultWindowsNotification` channel, so there is no schema change and no new migration.

**Statelessness preserved.** `NotificationFactory` holds one shared `NotificationWindows` across the device/profile/mute channels, so it stays stateless; the builder and renderer are static and stateless by construction. The toast path is thread-safe and is deliberately **not** marshalled through the UI sync context.

## User-visible behaviour

| Aspect | Before (balloon) | After (toast) |
|---|---|---|
| Action Center | Not shown | Appears and persists until expiry |
| Persistence | ~500–1000 ms transient | Respects the configured on-screen time |
| Device icon | Tray icon only | Real device icon (`appLogoOverride`) |
| OS floor | Any Windows | Windows 10 1809+, else balloon fallback |
| Wording | unchanged | unchanged |

## Validation

- **Linux partial build** — `dotnet build SoundSwitch/SoundSwitch.csproj -c Debug -p:LinuxBuild=true -p:BuildProjectReferences=false` after building the Linux-capable dependencies. Result: **1 error**, the documented pre-existing `SoundSwitch.Audio.Manager` `CS0006` (CsWinRT projection is Windows-only). No errors in any changed file. **Windows CI is the real compile gate.**
- **Website** — `npm run docs:build` passes, 37 pages rendered.
- **Tests** — 8 new `NotificationContentBuilderTests` covering both wording modes, both `DataFlow` branches, and all four channels. These run on Windows CI.
- Design doc included at `docs/windows-notification-toast-refactor.md`.
