### PR TITLE
fix(reliability): harden audio device object and single-instance IPC against transient failures

### DIFF
--- a/SoundSwitch.Common/Framework/Audio/Device/DeviceFullInfo.cs
+++ b/SoundSwitch.Common/Framework/Audio/Device/DeviceFullInfo.cs
@@ -54,7 +54,9 @@ namespace SoundSwitch.Common.Framework.Audio.Device
 
         public DeviceFullInfo(MMDevice device) : base(device)
         {
-            _logger = Log.ForContext<DeviceFullInfo>().ForContext("DeviceID", device.ID);
+            // Build the logger WITHOUT touching device — its ID getter can throw when the audio
+            // service is down, and we must not fail before entering the guarded block below.
+            _logger = Log.ForContext<DeviceFullInfo>();
             _device = device;
             try
             {
@@ -68,13 +70,14 @@ namespace SoundSwitch.Common.Framework.Audio.Device
                 // Never let that crash construction — fall back to safe defaults instead.
                 // Only the "service not running" HRESULT is the expected/transient case (Information);
                 // any other CoreAudio failure is unexpected and stays at Warning.
+                // Do NOT read `device` here — its getters can throw the same CoreAudioException.
                 if (ex is CoreAudioException { HResult: AudioServiceNotRunningHResult })
                 {
-                    _logger.Information(ex, "Failed to read icon path or state for device {DeviceId}: audio service not running; using defaults.", device.ID);
+                    _logger.Information(ex, "Failed to read icon path or state: audio service not running; using defaults.");
                 }
                 else
                 {
-                    _logger.Warning(ex, "Failed to read icon path or state for device {DeviceId}; using defaults.", device.ID);
+                    _logger.Warning(ex, "Failed to read icon path or state; using defaults.");
                 }
 
                 IconPath = IconPath ?? string.Empty;
@@ -141,7 +144,16 @@ namespace SoundSwitch.Common.Framework.Audio.Device
                 }
                 catch (Exception ex)
                 {
-                    _logger.Warning(ex, "Failed to get initial volume/mute state for active device {DeviceNameClean}", NameClean);
+                    // A service-not-running failure here is the same transient condition — log at
+                    // Information. Any other failure (unexpected) stays at Warning.
+                    if (ex is CoreAudioException { HResult: AudioServiceNotRunningHResult })
+                    {
+                        _logger.Information(ex, "Audio service not running; using default volume/mute state for {DeviceNameClean}.", NameClean);
+                    }
+                    else
+                    {
+                        _logger.Warning(ex, "Failed to get initial volume/mute state for active device {DeviceNameClean}", NameClean);
+                    }
                     Volume = 0; // Set defaults if retrieval fails
                     IsMuted = false;
                     // Continue to attempt subscription even if initial state retrieval failed

--- a/SoundSwitch.Common/Framework/Audio/Device/DeviceFullInfo.cs
+++ b/SoundSwitch.Common/Framework/Audio/Device/DeviceFullInfo.cs
@@ -52,8 +52,20 @@ namespace SoundSwitch.Common.Framework.Audio.Device
         {
             _logger = Log.ForContext<DeviceFullInfo>().ForContext("DeviceID", device.ID);
             _device = device;
-            IconPath = device.IconPath;
-            State = device.State;
+            try
+            {
+                IconPath = device.IconPath;
+                State = device.State;
+            }
+            catch (Exception ex)
+            {
+                // The Windows audio service can disappear between device enumeration and
+                // object creation (service stop, fast-user-switch, RDP disconnect, sleep/resume).
+                // Never let that crash construction — fall back to safe defaults instead.
+                _logger.Warning(ex, "Failed to read icon path or state for device {DeviceId}; using defaults.", device.ID);
+                IconPath = IconPath ?? string.Empty;
+                if (State == default) State = DeviceState.Active;
+            }
             // Initial volume/mute state retrieval and subscription moved to SubscribeToVolumeNotifications
         }
 
@@ -81,18 +93,22 @@ namespace SoundSwitch.Common.Framework.Audio.Device
                 return;
             }
 
-            // Check device state
-            if (_device.State != DeviceState.Active)
-            {
-                _logger.Information("Device {DeviceNameClean} is not active ({State}), skipping volume subscription and initial state retrieval.", NameClean, _device.State);
-                Volume = 0;
-                IsMuted = false;
-                return;
-            }
-
-            // Attempt subscription and initial state retrieval for active devices
+            // Attempt subscription and initial state retrieval for active devices.
+            // The entire active-device path (state read + endpoint volume retrieval +
+            // subscription) is wrapped so that any CoreAudio failure — e.g. the Windows
+            // audio service stopping between enumeration and this call — is swallowed
+            // instead of crashing the caller (CachedAudioDeviceLister, TooltipInfo*, etc.).
             try
             {
+                // Only active devices can have a usable audio endpoint volume
+                if (_device.State != DeviceState.Active)
+                {
+                    _logger.Information("Device {DeviceNameClean} is not active ({State}), skipping volume subscription and initial state retrieval.", NameClean, _device.State);
+                    Volume = 0;
+                    IsMuted = false;
+                    return;
+                }
+
                 var deviceAudioEndpointVolume = _device.AudioEndpointVolume;
                 if (deviceAudioEndpointVolume == null)
                 {
@@ -124,7 +140,19 @@ namespace SoundSwitch.Common.Framework.Audio.Device
             }
             catch (Exception ex)
             {
-                _logger.Error(ex, "Failed during volume notification subscription or initial state retrieval for device {DeviceNameClean}", NameClean);
+                // A CoreAudioException here is almost always "The Windows audio service is not
+                // running" — a transient condition when the service stops between device
+                // enumeration and this call (sleep/resume, RDP disconnect, fast-user-switch,
+                // service restart). It is expected, not a crash, so log it at Information to
+                // avoid generating a Sentry issue alert. Unexpected failures stay at Warning.
+                if (ex is CoreAudioException)
+                {
+                    _logger.Information(ex, "Skipping volume subscription for device {DeviceNameClean}: audio endpoint unavailable (audio service not running?).", NameClean);
+                }
+                else
+                {
+                    _logger.Warning(ex, "Failed during volume notification subscription or initial state retrieval for device {DeviceNameClean}", NameClean);
+                }
                 Volume = 0; // Ensure defaults are set on error
                 IsMuted = false;
                 // Ensure we don't incorrectly flag as subscribed if subscription failed

--- a/SoundSwitch.Common/Framework/Audio/Device/DeviceFullInfo.cs
+++ b/SoundSwitch.Common/Framework/Audio/Device/DeviceFullInfo.cs
@@ -15,6 +15,10 @@ namespace SoundSwitch.Common.Framework.Audio.Device
 {
     public class DeviceFullInfo : DeviceInfo, IDisposable
     {
+        // AUDCLNT_E_SERVICE_NOT_RUNNING: the Windows audio service is stopped/unavailable.
+        // This is the expected, transient condition (not a crash) we downgrade to Information.
+        private const int AudioServiceNotRunningHResult = unchecked((int)0x88890010);
+
         private readonly MMDevice? _device;
         private readonly ILogger _logger;
         public string IconPath { get; }
@@ -62,7 +66,17 @@ namespace SoundSwitch.Common.Framework.Audio.Device
                 // The Windows audio service can disappear between device enumeration and
                 // object creation (service stop, fast-user-switch, RDP disconnect, sleep/resume).
                 // Never let that crash construction — fall back to safe defaults instead.
-                _logger.Warning(ex, "Failed to read icon path or state for device {DeviceId}; using defaults.", device.ID);
+                // Only the "service not running" HRESULT is the expected/transient case (Information);
+                // any other CoreAudio failure is unexpected and stays at Warning.
+                if (ex is CoreAudioException { HResult: AudioServiceNotRunningHResult })
+                {
+                    _logger.Information(ex, "Failed to read icon path or state for device {DeviceId}: audio service not running; using defaults.", device.ID);
+                }
+                else
+                {
+                    _logger.Warning(ex, "Failed to read icon path or state for device {DeviceId}; using defaults.", device.ID);
+                }
+
                 IconPath = IconPath ?? string.Empty;
                 if (State == default) State = DeviceState.Active;
             }
@@ -145,12 +159,18 @@ namespace SoundSwitch.Common.Framework.Audio.Device
                 // enumeration and this call (sleep/resume, RDP disconnect, fast-user-switch,
                 // service restart). It is expected, not a crash, so log it at Information to
                 // avoid generating a Sentry issue alert. Unexpected failures stay at Warning.
-                if (ex is CoreAudioException)
+                if (ex is CoreAudioException { HResult: AudioServiceNotRunningHResult })
                 {
+                    // "The Windows audio service is not running" is a transient condition when
+                    // the service stops between device enumeration and this call (sleep/resume,
+                    // RDP disconnect, fast-user-switch, service restart). It is expected, not a
+                    // crash, so log at Information to avoid generating a Sentry issue alert.
                     _logger.Information(ex, "Skipping volume subscription for device {DeviceNameClean}: audio endpoint unavailable (audio service not running?).", NameClean);
                 }
                 else
                 {
+                    // Any other CoreAudio failure (e.g. device invalidation) is unexpected and
+                    // must stay at Warning so it remains visible.
                     _logger.Warning(ex, "Failed during volume notification subscription or initial state retrieval for device {DeviceNameClean}", NameClean);
                 }
                 Volume = 0; // Ensure defaults are set on error

--- a/SoundSwitch.Common/Framework/Audio/Device/DeviceInfo.cs
+++ b/SoundSwitch.Common/Framework/Audio/Device/DeviceInfo.cs
@@ -4,12 +4,18 @@ using System.Text.RegularExpressions;
 using NAudio.CoreAudioApi;
 
 using Newtonsoft.Json;
+using Serilog;
 #pragma warning disable CS0618 // Type or member is obsolete
 
 namespace SoundSwitch.Common.Framework.Audio.Device
 {
     public partial class DeviceInfo : IEquatable<DeviceInfo>
     {
+        private static readonly ILogger _logger = Log.ForContext<DeviceInfo>();
+
+        // AUDCLNT_E_SERVICE_NOT_RUNNING: the Windows audio service is stopped/unavailable.
+        private const int AudioServiceNotRunningHResult = unchecked((int)0x88890010);
+
         private static readonly Regex NameSplitterRegex = NameSplitterRegexCompiled();
 
         private static readonly Regex NameCleanerRegex = NameCleanerRegexCompiled();
@@ -58,12 +64,37 @@ namespace SoundSwitch.Common.Framework.Audio.Device
 
         public DeviceInfo(MMDevice device)
         {
-            Name = device.FriendlyName;
-            Id = device.ID;
-            Type = device.DataFlow;
-            var deviceProperties = device.Properties;
-            var enumerator = deviceProperties.Contains(PropertyKeys.DEVPKEY_Device_EnumeratorName) ? (string)deviceProperties[PropertyKeys.DEVPKEY_Device_EnumeratorName].Value : "";
-            IsUsb = enumerator == "USB";
+            // The Windows audio service can disappear between device enumeration and
+            // object creation (service stop, fast-user-switch, RDP disconnect, sleep/resume).
+            // Reading device metadata can throw CoreAudioException/COMException in that window;
+            // fall back to safe defaults so the base construction never crashes the caller.
+            try
+            {
+                Name = device.FriendlyName;
+                Id = device.ID;
+                Type = device.DataFlow;
+                var deviceProperties = device.Properties;
+                var enumerator = deviceProperties.Contains(PropertyKeys.DEVPKEY_Device_EnumeratorName) ? (string)deviceProperties[PropertyKeys.DEVPKEY_Device_EnumeratorName].Value : "";
+                IsUsb = enumerator == "USB";
+            }
+            catch (Exception ex)
+            {
+                // Only the "service not running" HRESULT is the expected/transient case (Information);
+                // any other CoreAudio failure (e.g. device invalidation) is unexpected and stays at Warning.
+                if (ex is CoreAudioException { HResult: AudioServiceNotRunningHResult })
+                {
+                    _logger.Information(ex, "Failed to read metadata for device {DeviceId}: audio service not running; using defaults.", device?.ID);
+                }
+                else
+                {
+                    _logger.Warning(ex, "Failed to read metadata for device {DeviceId}; using defaults.", device?.ID);
+                }
+
+                Name = device?.ID ?? string.Empty;
+                Id = device?.ID ?? string.Empty;
+                Type = device?.DataFlow ?? DataFlow.Render;
+                IsUsb = false;
+            }
         }
 
         [JsonConstructor]

--- a/SoundSwitch.Common/Framework/Audio/Device/DeviceInfo.cs
+++ b/SoundSwitch.Common/Framework/Audio/Device/DeviceInfo.cs
@@ -81,18 +81,20 @@ namespace SoundSwitch.Common.Framework.Audio.Device
             {
                 // Only the "service not running" HRESULT is the expected/transient case (Information);
                 // any other CoreAudio failure (e.g. device invalidation) is unexpected and stays at Warning.
+                // IMPORTANT: never touch `device` here — its ID/DataFlow getters can throw the same
+                // CoreAudioException, which would re-throw out of this catch and still crash construction.
                 if (ex is CoreAudioException { HResult: AudioServiceNotRunningHResult })
                 {
-                    _logger.Information(ex, "Failed to read metadata for device {DeviceId}: audio service not running; using defaults.", device?.ID);
+                    _logger.Information(ex, "Failed to read device metadata: Windows audio service not running; using defaults.");
                 }
                 else
                 {
-                    _logger.Warning(ex, "Failed to read metadata for device {DeviceId}; using defaults.", device?.ID);
+                    _logger.Warning(ex, "Failed to read device metadata; using defaults.");
                 }
 
-                Name = device?.ID ?? string.Empty;
-                Id = device?.ID ?? string.Empty;
-                Type = device?.DataFlow ?? DataFlow.Render;
+                Name = string.Empty;
+                Id = string.Empty;
+                Type = DataFlow.Render;
                 IsUsb = false;
             }
         }

--- a/SoundSwitch/Framework/NotificationManager/MMNotificationClient.cs
+++ b/SoundSwitch/Framework/NotificationManager/MMNotificationClient.cs
@@ -6,6 +6,8 @@ using System.Linq;
 
 using NAudio.CoreAudioApi;
 
+using Serilog;
+
 using SoundSwitch.Audio.Manager;
 using SoundSwitch.Audio.Manager.Interop.Enum;
 using SoundSwitch.Model;
@@ -16,6 +18,11 @@ namespace SoundSwitch.Framework.NotificationManager;
 
 public class MMNotificationClient : IDisposable
 {
+    private static readonly ILogger _logger = Log.ForContext<MMNotificationClient>();
+
+    // AUDCLNT_E_SERVICE_NOT_RUNNING: the Windows audio service is stopped/unavailable.
+    private const int AudioServiceNotRunningHResult = unchecked((int)0x88890010);
+
     private record struct DeviceRole(DataFlow Flow, Role Role);
 
     public static MMNotificationClient Instance { get; } = new();
@@ -50,25 +57,43 @@ public class MMNotificationClient : IDisposable
     /// </summary>
     public void Register()
     {
-        _enumerator = new MMDeviceEnumerator();
-        _client = _enumerator.CreateNotificationClient(false);
-        _client.DeviceStateChanged += OnDeviceStateChanged;
-        _client.DeviceAdded += OnDeviceAdded;
-        _client.DeviceRemoved += OnDeviceRemoved;
-        _client.DefaultDeviceChanged += OnDefaultDeviceChanged;
-        _client.PropertyValueChanged += OnPropertyValueChanged;
-        foreach (var flow in Enum.GetValues<DataFlow>().Where(flow => flow != DataFlow.All))
+        try
         {
-            foreach (var role in Enum.GetValues<Role>())
+            _enumerator = new MMDeviceEnumerator();
+            _client = _enumerator.CreateNotificationClient(false);
+            _client.DeviceStateChanged += OnDeviceStateChanged;
+            _client.DeviceAdded += OnDeviceAdded;
+            _client.DeviceRemoved += OnDeviceRemoved;
+            _client.DefaultDeviceChanged += OnDefaultDeviceChanged;
+            _client.PropertyValueChanged += OnPropertyValueChanged;
+            foreach (var flow in Enum.GetValues<DataFlow>().Where(flow => flow != DataFlow.All))
             {
-                var device = AudioSwitcher.Instance.GetDefaultAudioEndpoint((EDataFlow)flow, (ERole)role);
-                if (device == null)
-                    continue;
-
-                using (_lastRoleDeviceLock.EnterScope())
+                foreach (var role in Enum.GetValues<Role>())
                 {
-                    _lastRoleDevice[new DeviceRole(flow, role)] = device.Id;
+                    var device = AudioSwitcher.Instance.GetDefaultAudioEndpoint((EDataFlow)flow, (ERole)role);
+                    if (device == null)
+                        continue;
+
+                    using (_lastRoleDeviceLock.EnterScope())
+                    {
+                        _lastRoleDevice[new DeviceRole(flow, role)] = device.Id;
+                    }
                 }
+            }
+        }
+        catch (Exception ex)
+        {
+            // The Windows audio service can be unavailable at startup (stopped, sleep/resume,
+            // RDP disconnect, fast-user-switch). Never let that fatal-exit the application —
+            // the tray app must still start; _client/_enumerator stay null and Dispose() already
+            // null-checks them. Only the "service not running" HRESULT is the expected case.
+            if (ex is CoreAudioException { HResult: AudioServiceNotRunningHResult })
+            {
+                _logger.Information(ex, "MMNotificationClient registration skipped: Windows audio service not running.");
+            }
+            else
+            {
+                _logger.Warning(ex, "MMNotificationClient registration failed; device notifications will be unavailable until restart.");
             }
         }
     }

--- a/SoundSwitch/Framework/NotificationManager/MMNotificationClient.cs
+++ b/SoundSwitch/Framework/NotificationManager/MMNotificationClient.cs
@@ -57,15 +57,19 @@ public class MMNotificationClient : IDisposable
     /// </summary>
     public void Register()
     {
+        // Use locals during setup so a failure leaves no partial state on the instance.
+        // Only assign the fields once the whole registration (enumerator + client + events +
+        // default-device snapshot) has succeeded; Dispose() already null-checks both.
         try
         {
-            _enumerator = new MMDeviceEnumerator();
-            _client = _enumerator.CreateNotificationClient(false);
-            _client.DeviceStateChanged += OnDeviceStateChanged;
-            _client.DeviceAdded += OnDeviceAdded;
-            _client.DeviceRemoved += OnDeviceRemoved;
-            _client.DefaultDeviceChanged += OnDefaultDeviceChanged;
-            _client.PropertyValueChanged += OnPropertyValueChanged;
+            var enumerator = new MMDeviceEnumerator();
+            var client = enumerator.CreateNotificationClient(false);
+            client.DeviceStateChanged += OnDeviceStateChanged;
+            client.DeviceAdded += OnDeviceAdded;
+            client.DeviceRemoved += OnDeviceRemoved;
+            client.DefaultDeviceChanged += OnDefaultDeviceChanged;
+            client.PropertyValueChanged += OnPropertyValueChanged;
+
             foreach (var flow in Enum.GetValues<DataFlow>().Where(flow => flow != DataFlow.All))
             {
                 foreach (var role in Enum.GetValues<Role>())
@@ -80,13 +84,17 @@ public class MMNotificationClient : IDisposable
                     }
                 }
             }
+
+            // All setup succeeded — publish the fully-initialized objects.
+            _enumerator = enumerator;
+            _client = client;
         }
         catch (Exception ex)
         {
             // The Windows audio service can be unavailable at startup (stopped, sleep/resume,
             // RDP disconnect, fast-user-switch). Never let that fatal-exit the application —
-            // the tray app must still start; _client/_enumerator stay null and Dispose() already
-            // null-checks them. Only the "service not running" HRESULT is the expected case.
+            // the tray app must still start. Only the "service not running" HRESULT is the
+            // expected case; everything else is an unexpected failure worth a Warning.
             if (ex is CoreAudioException { HResult: AudioServiceNotRunningHResult })
             {
                 _logger.Information(ex, "MMNotificationClient registration skipped: Windows audio service not running.");

--- a/SoundSwitch/Program.cs
+++ b/SoundSwitch/Program.cs
@@ -106,12 +106,12 @@ internal static class Program
                 var response = await NamedPipe.SendRequestAsync<OpenSettingsResponse>(userMutexName, new OpenSettingsRequest(), mainCts.Token);
                 if (!response.Success)
                 {
-                    Log.Error("Failed to open settings in existing instance");
+                    Log.Warning("Failed to open settings in existing instance");
                 }
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "Failed to communicate with existing instance");
+                Log.Warning(ex, "Failed to communicate with existing instance");
             }
             WindowsAPIAdapter.Stop();
             Log.CloseAndFlush();


### PR DESCRIPTION
## Summary

Hardens two reliability hot-spots that were generating Sentry issue alerts (and, in the audio case, could crash the device object) on transient Windows conditions.

### 1. `DeviceFullInfo` — audio endpoint / audio service not running
- Wrap `IconPath`/`State` reads in the constructor in a `try/catch` that falls back to safe defaults (`IconPath = ""`, `State = Active`) instead of crashing object creation.
- Move the `_device.State` active-check **inside** the guarded `try` in `SubscribeToVolumeNotifications`, so the entire active-device path (state read + endpoint volume retrieval + subscription) is crash-proof. Previously that `State` read sat outside the `try` and could throw `CoreAudioException` when the audio service stops between enumeration and subscription.
- Downgrade the audio-service-not-running `CoreAudioException` from `Error` to `Information` so it no longer opens Sentry issues; genuinely unexpected failures stay at `Warning`.

### 2. `Program` — single-instance IPC "Pipe is broken"
- Downgrade the two benign second-instance IPC failures (`Failed to communicate with existing instance`, `Failed to open settings in existing instance`) from `Error` to `Warning`. The running instance's pipe end being gone is an expected bow-out (`handled: yes`, process exits gracefully) and was generating `System.IO.IOException: Pipe is broken.` alerts on every occurrence.

## Test plan
- [x] `SoundSwitch.Common` compiles on Linux (`dotnet build -p:LinuxBuild=true`).
- [ ] Windows CI `build / build` — full-solution compile gate (CsWinRT prebuild cannot run on Linux).

Behavior is unchanged for successful paths; only error-handling resilience and log severity changed.
