### PR TITLE
fix(audio): log non-cancellation playback failures at Error so they reach Sentry (#2384)

### DIFF
--- a/SoundSwitch/Framework/Audio/Play/PlaySoundJob.cs
+++ b/SoundSwitch/Framework/Audio/Play/PlaySoundJob.cs
@@ -37,10 +37,19 @@ public class PlaySoundJob([CanBeNull] string deviceId, [NotNull] CachedSound sou
 
     private static void OnPlaybackStopped(Exception exception)
     {
-        if (exception != null)
+        if (exception == null)
         {
-            Log.ForContext<PlaySoundJob>().Warning(exception, "Sound notification playback stopped with an error");
+            return;
         }
+
+        if (exception is OperationCanceledException)
+        {
+            return;
+        }
+
+        // Real (non-cancellation) playback failures must surface as errors so they reach Sentry
+        // (see issue #2384: a silent WASAPI render failure shipped unnoticed because this was Warning).
+        Log.ForContext<PlaySoundJob>().Error(exception, "Sound notification playback stopped with an error");
     }
 
     public Task OnFailure(JobException exception)
@@ -50,7 +59,9 @@ public class PlaySoundJob([CanBeNull] string deviceId, [NotNull] CachedSound sou
             return Task.CompletedTask;
         }
 
-        Log.ForContext<PlaySoundJob>().Warning(exception.InnerException ?? (Exception)exception, "Failed to play sound notification");
+        // Real (non-cancellation) playback failures must surface as errors so they reach Sentry
+        // (see issue #2384: a silent WASAPI render failure shipped unnoticed because this was Warning).
+        Log.ForContext<PlaySoundJob>().Error(exception.InnerException ?? (Exception)exception, "Failed to play sound notification");
         return Task.CompletedTask;
     }
 


### PR DESCRIPTION
## Summary

Notification-sound playback failures were logged at **Warning** level in `PlaySoundJob`:

- `OnPlaybackStopped` → `Warning`
- `OnFailure` → `Warning`

Sentry only records `Warning` events as breadcrumbs and **never raises an issue/alert** for them. As a result, the silent WASAPI render failure reported in #2384 shipped without producing a single Sentry issue — we were blind to it.

This change:
- Raises both real (non-cancellation) failures to **`Error`** so they become observable in Sentry.
- Keeps cancellation (`OperationCanceledException`) silent — expected, not a failure.

## Why

Per the `soundswitch-reliability` discipline, real unexpected failures should be `Error`, not swallowed. Both the default bundled sound and custom WAV/MP3 flow through the same `WavePlayer` WASAPI renderer, so a failure there was invisible to monitoring. This makes future playback regressions catchable instead of silent.

## Test plan

- [ ] Windows build (`build / build`) green.
- [ ] Trigger a notification on a machine where playback fails (or temporarily throw in `WavePlayer.Start`) and confirm a Sentry issue is created (not just a breadcrumb).
- [ ] Confirm cancellation still produces no Sentry noise.

## Related

Fixes part of #2384 (monitoring gap). The underlying renderer fix for the silent playback is tracked separately once we get user logs (see comment on #2384 asking for a troubleshooting zip).
