### PR TITLE
fix(audio): include target device id in playback-failure Sentry logs (#2384)

### DIFF
--- a/SoundSwitch/Framework/Audio/Play/PlaySoundJob.cs
+++ b/SoundSwitch/Framework/Audio/Play/PlaySoundJob.cs
@@ -35,7 +35,7 @@ public class PlaySoundJob([CanBeNull] string deviceId, [NotNull] CachedSound sou
         }
     }
 
-    private static void OnPlaybackStopped(Exception exception)
+    private void OnPlaybackStopped(Exception exception)
     {
         if (exception == null)
         {
@@ -49,7 +49,7 @@ public class PlaySoundJob([CanBeNull] string deviceId, [NotNull] CachedSound sou
 
         // Real (non-cancellation) playback failures must surface as errors so they reach Sentry
         // (see issue #2384: a silent WASAPI render failure shipped unnoticed because this was Warning).
-        Log.ForContext<PlaySoundJob>().Error(exception, "Sound notification playback stopped with an error");
+        Log.ForContext<PlaySoundJob>().Error(exception, "Sound notification playback stopped with an error (deviceId: {DeviceId})", deviceId ?? "<default>");
     }
 
     public Task OnFailure(JobException exception)
@@ -61,7 +61,7 @@ public class PlaySoundJob([CanBeNull] string deviceId, [NotNull] CachedSound sou
 
         // Real (non-cancellation) playback failures must surface as errors so they reach Sentry
         // (see issue #2384: a silent WASAPI render failure shipped unnoticed because this was Warning).
-        Log.ForContext<PlaySoundJob>().Error(exception.InnerException ?? (Exception)exception, "Failed to play sound notification");
+        Log.ForContext<PlaySoundJob>().Error(exception.InnerException ?? (Exception)exception, "Failed to play sound notification (deviceId: {DeviceId})", deviceId ?? "<default>");
         return Task.CompletedTask;
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #2388 (merged) addressing Copilot's review thread on that PR.

Copilot noted that once the playback-failure log is promoted to `Error` (and thus creates Sentry issues), it should include structured context — specifically the target playback device id — so the event indicates whether it was aiming at a specific endpoint or the default device.

This commit adds `deviceId` (or `"<default>"` when null) to both:
- `OnPlaybackStopped` → `"Sound notification playback stopped with an error (deviceId: {DeviceId})"`
- `OnFailure` → `"Failed to play sound notification (deviceId: {DeviceId})"`

`OnPlaybackStopped` was `static`; it now reads the instance's `deviceId` capture. No behavior change beyond the added context.

## Related

- Builds on #2388 (Error-level logging for playback failures, #2384 monitoring gap).
- Closes the Copilot review thread on #2388.
