### PR TITLE
fix(audio): publish new device cache before disposing old devices in Refresh (#2389)

### DIFF
--- a/SoundSwitch/Framework/Audio/Play/PlaySoundJob.cs
+++ b/SoundSwitch/Framework/Audio/Play/PlaySoundJob.cs
@@ -49,7 +49,7 @@ public class PlaySoundJob([CanBeNull] string deviceId, [NotNull] CachedSound sou
 
         // Real (non-cancellation) playback failures must surface as errors so they reach Sentry
         // (see issue #2384: a silent WASAPI render failure shipped unnoticed because this was Warning).
-        Log.ForContext<PlaySoundJob>().Error(exception, "Sound notification playback stopped with an error (deviceId: {DeviceId})", deviceId ?? "<default>");
+        Log.ForContext<PlaySoundJob>().Error(exception, "Sound notification playback stopped with an error (deviceId: {DeviceId})", string.IsNullOrEmpty(deviceId) ? "<default>" : deviceId);
     }
 
     public Task OnFailure(JobException exception)
@@ -61,7 +61,7 @@ public class PlaySoundJob([CanBeNull] string deviceId, [NotNull] CachedSound sou
 
         // Real (non-cancellation) playback failures must surface as errors so they reach Sentry
         // (see issue #2384: a silent WASAPI render failure shipped unnoticed because this was Warning).
-        Log.ForContext<PlaySoundJob>().Error(exception.InnerException ?? (Exception)exception, "Failed to play sound notification (deviceId: {DeviceId})", deviceId ?? "<default>");
+        Log.ForContext<PlaySoundJob>().Error(exception.InnerException ?? (Exception)exception, "Failed to play sound notification (deviceId: {DeviceId})", string.IsNullOrEmpty(deviceId) ? "<default>" : deviceId);
         return Task.CompletedTask;
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #2390 (merged) addressing CodeRabbit's post-merge review thread.

`Refresh` disposed the old devices **while they were still the published cache**. Two issues:
- A concurrent reader (e.g. `GetDevices`) could grab a `DeviceFullInfo` whose underlying `AudioDevice` was being released.
- A concurrent `ProcessDeviceUpdates` could publish a replacement that `Refresh` then overwrote, leaving it undisposed.

Fix: swap the new immutable cache in **first** (atomic reference assignment), then snapshot-and-dispose the previous devices from the local array. Readers always see valid devices during disposal; the old devices live on only in the local `oldDevices` snapshot, so the concurrent-mutation safety (SOUNDSWITCH-49X) is preserved.

## Related

- Builds on #2390 (ImmutableDictionary + idempotent Dispose hardening for the device-lister race).
- Closes the CodeRabbit review thread on #2390.
