### PR TITLE
fix(audio): treat empty deviceId as default in playback-failure logs (#2384)

### DIFF
--- a/SoundSwitch/Framework/Audio/Play/PlaySoundJob.cs
+++ b/SoundSwitch/Framework/Audio/Play/PlaySoundJob.cs
@@ -49,7 +49,7 @@ public class PlaySoundJob([CanBeNull] string deviceId, [NotNull] CachedSound sou
 
         // Real (non-cancellation) playback failures must surface as errors so they reach Sentry
         // (see issue #2384: a silent WASAPI render failure shipped unnoticed because this was Warning).
-        Log.ForContext<PlaySoundJob>().Error(exception, "Sound notification playback stopped with an error (deviceId: {DeviceId})", deviceId ?? "<default>");
+        Log.ForContext<PlaySoundJob>().Error(exception, "Sound notification playback stopped with an error (deviceId: {DeviceId})", string.IsNullOrEmpty(deviceId) ? "<default>" : deviceId);
     }
 
     public Task OnFailure(JobException exception)
@@ -61,7 +61,7 @@ public class PlaySoundJob([CanBeNull] string deviceId, [NotNull] CachedSound sou
 
         // Real (non-cancellation) playback failures must surface as errors so they reach Sentry
         // (see issue #2384: a silent WASAPI render failure shipped unnoticed because this was Warning).
-        Log.ForContext<PlaySoundJob>().Error(exception.InnerException ?? (Exception)exception, "Failed to play sound notification (deviceId: {DeviceId})", deviceId ?? "<default>");
+        Log.ForContext<PlaySoundJob>().Error(exception.InnerException ?? (Exception)exception, "Failed to play sound notification (deviceId: {DeviceId})", string.IsNullOrEmpty(deviceId) ? "<default>" : deviceId);
         return Task.CompletedTask;
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #2391 (merged) addressing Copilot's post-merge review thread.

`SoundPlayer` treats both `null` **and** empty `deviceId` as the default endpoint, but the playback-failure logs only mapped `null` → `"<default>"`. An empty string would log a blank `DeviceId`, reducing diagnostic value in Sentry.

Fix: use `string.IsNullOrEmpty(deviceId) ? "<default>" : deviceId` in both `OnPlaybackStopped` and `OnFailure` (PR #2391 already added device-id context to these logs).

## Related

- Builds on #2391 / #2388 (Error-level playback-failure logging, #2384 monitoring gap).
- Closes the Copilot review thread on #2391.
