### PR TITLE
fix(audio): serialize device-cache publication with a dedicated .NET 9 Lock (#2389)

### DIFF
--- a/SoundSwitch.Common/Framework/Audio/Device/DeviceFullInfo.cs
+++ b/SoundSwitch.Common/Framework/Audio/Device/DeviceFullInfo.cs
@@ -22,6 +22,8 @@ namespace SoundSwitch.Common.Framework.Audio.Device
         public EDeviceState State { get; }
 
         private int _disposed; // 0 = not disposed, 1 = disposed (Interlocked)
+        [JsonIgnore]
+        public bool IsDisposed => _disposed != 0;
         private bool _isVolumeHandlerSubscribed = false;
 
         [JsonIgnore]

--- a/SoundSwitch.Tests/RefreshDeviceTests.cs
+++ b/SoundSwitch.Tests/RefreshDeviceTests.cs
@@ -212,20 +212,27 @@ public class RefreshDeviceTests
         }));
         recordingProperty!.SetValue(lister, ImmutableDictionary.CreateRange(new Dictionary<string, DeviceFullInfo>()));
 
-        // Refresh's reconcile step computes exactly this delta: reuse when present + alive, dispose
-        // only when absent from the new enumeration. We feed that delta to the real DisposeOldDevices
-        // helper to assert the surviving device is kept and the removed one is disposed once.
-        var newIds = new HashSet<string> { "survive", "new" };
-        var oldDevices = new[] { surviving, removed };
-        var toDispose = oldDevices.Where(d => !newIds.Contains(d.Id)).ToArray();
+        // Refresh's reconcile step publishes a merged cache (reusing surviving instances AND
+        // adding fresh ones), then disposes only old devices absent from that PUBLISHED cache.
+        // The retained set MUST be derived from the published cache, not from the freshly
+        // enumerated ids alone — otherwise a reused (still-published) device would be disposed.
+        // We replicate the corrected contract: published keys = both reused + fresh ids.
+        var publishedPlayback = new Dictionary<string, DeviceFullInfo>
+        {
+            ["survive"] = surviving, // reused from old cache
+            ["new"] = fresh           // freshly enumerated
+        };
+        var retainedIds = new HashSet<string>(publishedPlayback.Keys); // mirrors fixed Refresh
+        var toDispose = oldDevices.Where(d => !retainedIds.Contains(d.Id)).ToArray();
 
         var disposeMethod = typeof(CachedAudioDeviceLister)
             .GetMethod("DisposeOldDevices", BindingFlags.NonPublic | BindingFlags.Instance);
         disposeMethod.Should().NotBeNull();
         disposeMethod!.Invoke(lister, new object[] { toDispose });
 
-        // The removed device is disposed; the surviving one is reused and left intact.
-        removed.Disposed.Should().BeTrue("device absent from the new enumeration must be disposed");
-        surviving.Disposed.Should().BeFalse("surviving device must be reused, not disposed");
+        // The removed device is disposed; the surviving one is published-and-reused, so untouched.
+        removed.Disposed.Should().BeTrue("device absent from the published cache must be disposed");
+        surviving.Disposed.Should().BeFalse("reused device is in the published cache, must NOT be disposed");
+        fresh.Disposed.Should().BeFalse("fresh device is in the published cache, must NOT be disposed");
     }
 }

--- a/SoundSwitch.Tests/RefreshDeviceTests.cs
+++ b/SoundSwitch.Tests/RefreshDeviceTests.cs
@@ -181,4 +181,51 @@ public class RefreshDeviceTests
         };
         fixedPattern.Should().NotThrow();
     }
+
+    [Test]
+    public void Refresh_Reconcile_ReusesSurvivingDevicesAndDisposesOnlyRemoved()
+    {
+        // COM-free verification of the reconcile path: a device present in both the old cache and
+        // the freshly enumerated set must be REUSED (not disposed and not re-subscribed), while a
+        // device absent from the new enumeration must be disposed exactly once.
+        var lister = new CachedAudioDeviceLister(EDeviceState.All);
+
+        // Surviving device: stays across the refresh.
+        var surviving = new TrackedDevice("Speaker", "survive", EDataFlow.eRender, string.Empty, EDeviceState.Active, false);
+        // Removed device: in the old cache but not in the new enumeration.
+        var removed = new TrackedDevice("Headphones", "gone", EDataFlow.eRender, string.Empty, EDeviceState.Active, false);
+        // New device: only in the new enumeration.
+        var fresh = new TrackedDevice("Mic", "new", EDataFlow.eCapture, string.Empty, EDeviceState.Active, false);
+
+        var playbackProperty = typeof(CachedAudioDeviceLister)
+            .GetProperty("PlaybackDevices", BindingFlags.NonPublic | BindingFlags.Instance);
+        var recordingProperty = typeof(CachedAudioDeviceLister)
+            .GetProperty("RecordingDevices", BindingFlags.NonPublic | BindingFlags.Instance);
+        playbackProperty.Should().NotBeNull();
+        recordingProperty.Should().NotBeNull();
+
+        // Seed the cache as if a previous refresh had published these.
+        playbackProperty!.SetValue(lister, ImmutableDictionary.CreateRange(new Dictionary<string, DeviceFullInfo>
+        {
+            ["survive"] = surviving,
+            ["gone"] = removed
+        }));
+        recordingProperty!.SetValue(lister, ImmutableDictionary.CreateRange(new Dictionary<string, DeviceFullInfo>()));
+
+        // Refresh's reconcile step computes exactly this delta: reuse when present + alive, dispose
+        // only when absent from the new enumeration. We feed that delta to the real DisposeOldDevices
+        // helper to assert the surviving device is kept and the removed one is disposed once.
+        var newIds = new HashSet<string> { "survive", "new" };
+        var oldDevices = new[] { surviving, removed };
+        var toDispose = oldDevices.Where(d => !newIds.Contains(d.Id)).ToArray();
+
+        var disposeMethod = typeof(CachedAudioDeviceLister)
+            .GetMethod("DisposeOldDevices", BindingFlags.NonPublic | BindingFlags.Instance);
+        disposeMethod.Should().NotBeNull();
+        disposeMethod!.Invoke(lister, new object[] { toDispose });
+
+        // The removed device is disposed; the surviving one is reused and left intact.
+        removed.Disposed.Should().BeTrue("device absent from the new enumeration must be disposed");
+        surviving.Disposed.Should().BeFalse("surviving device must be reused, not disposed");
+    }
 }

--- a/SoundSwitch.Tests/RefreshDeviceTests.cs
+++ b/SoundSwitch.Tests/RefreshDeviceTests.cs
@@ -222,6 +222,10 @@ public class RefreshDeviceTests
             ["survive"] = surviving, // reused from old cache
             ["new"] = fresh           // freshly enumerated
         };
+        // The old (pre-refresh) cache holds the surviving + removed devices; the published cache
+        // (reused + fresh) holds surviving + fresh. Disposal targets only old devices absent from
+        // the published cache — i.e. the removed one.
+        var oldDevices = new[] { surviving, removed };
         var retainedIds = new HashSet<string>(publishedPlayback.Keys); // mirrors fixed Refresh
         var toDispose = oldDevices.Where(d => !retainedIds.Contains(d.Id)).ToArray();
 

--- a/SoundSwitch/Framework/Audio/Lister/CachedAudioDeviceLister.cs
+++ b/SoundSwitch/Framework/Audio/Lister/CachedAudioDeviceLister.cs
@@ -451,7 +451,14 @@ public class CachedAudioDeviceLister : IAudioDeviceLister
                     DisposeOldDevices(rejectedFresh.ToArray());
                 }
 
-                var retainedIds = new HashSet<string>(playbackDevices.Keys.Concat(recordingDevices.Keys));
+                // Devices to dispose: those published before the refresh but absent from the
+                // NEWLY PUBLISHED merged caches (which include both reused existing instances and
+                // freshly enumerated ones). Deriving the retained set from the published caches —
+                // not from the freshly enumerated dictionaries — is essential: reused instances are
+                // NOT in the fresh-enumeration keys, so using those would schedule still-published
+                // (reused) devices for disposal. Disposal happens outside the lock.
+                var retainedIds = new HashSet<string>(
+                    PlaybackDevices.Keys.Concat(RecordingDevices.Keys));
                 var removedOld = oldDevices.Where(d => !retainedIds.Contains(d.Id)).ToArray();
                 if (removedOld.Length > 0)
                 {

--- a/SoundSwitch/Framework/Audio/Lister/CachedAudioDeviceLister.cs
+++ b/SoundSwitch/Framework/Audio/Lister/CachedAudioDeviceLister.cs
@@ -36,24 +36,18 @@ namespace SoundSwitch.Framework.Audio.Lister;
 
 public class CachedAudioDeviceLister : IAudioDeviceLister
 {
-    // Backing fields are kept separate from the properties so the lock-free CompareExchange
-    // swaps below can pass them by `ref` (auto-properties cannot be passed by ref — CS0206).
-    private ImmutableDictionary<string, DeviceFullInfo> _playbackDevices = ImmutableDictionary<string, DeviceFullInfo>.Empty;
-    private ImmutableDictionary<string, DeviceFullInfo> _recordingDevices = ImmutableDictionary<string, DeviceFullInfo>.Empty;
+    // Dedicated .NET 9 lock serializing the two mutation paths (Refresh's wholesale publish and
+    // ProcessDeviceUpdates' incremental edits). It is held ONLY for the immutable-dictionary
+    // reference swaps (microseconds) — never during COM enumeration, event subscription, or
+    // device disposal. Readers never take it: they read the published immutable snapshot, which
+    // is inherently safe to enumerate.
+    private readonly Lock _cacheLock = new Lock();
 
     /// <inheritdoc />
-    private ImmutableDictionary<string, DeviceFullInfo> PlaybackDevices
-    {
-        get => _playbackDevices;
-        set => _playbackDevices = value;
-    }
+    private ImmutableDictionary<string, DeviceFullInfo> PlaybackDevices { get; set; } = ImmutableDictionary<string, DeviceFullInfo>.Empty;
 
     /// <inheritdoc />
-    private ImmutableDictionary<string, DeviceFullInfo> RecordingDevices
-    {
-        get => _recordingDevices;
-        set => _recordingDevices = value;
-    }
+    private ImmutableDictionary<string, DeviceFullInfo> RecordingDevices { get; set; } = ImmutableDictionary<string, DeviceFullInfo>.Empty;
 
     private readonly ISubject<DefaultDevicePayload> _defaultDeviceChanged = new Subject<DefaultDevicePayload>();
     public IObservable<DefaultDevicePayload> DefaultDeviceChanged => _defaultDeviceChanged.AsObservable();
@@ -78,6 +72,8 @@ public class CachedAudioDeviceLister : IAudioDeviceLister
     /// <exception cref="ArgumentOutOfRangeException"></exception>
     public DeviceReadOnlyCollection<DeviceFullInfo> GetDevices(EDataFlow type, EDeviceState state)
     {
+        // Lock-free read: the published dictionaries are immutable, so enumerating a snapshot
+        // can never throw "Collection was modified" even while another thread swaps the reference.
         return type switch
         {
             EDataFlow.eRender => new DeviceReadOnlyCollection<DeviceFullInfo>(PlaybackDevices.Values.Where(info => state.HasFlag(info.State)), type),
@@ -164,48 +160,6 @@ public class CachedAudioDeviceLister : IAudioDeviceLister
     }
 
     /// <summary>
-    /// Lock-free read-modify-write that replaces (or inserts) <paramref name="device"/> under
-    /// <paramref name="id"/> in the published immutable dictionary, retrying on concurrent
-    /// modification via <see cref="Interlocked.CompareExchange{T}(ref T,T,T)"/>. The dictionary
-    /// reference itself is a single field, so the swap is an atomic reference assignment.
-    /// </summary>
-    private static ImmutableDictionary<string, DeviceFullInfo> SwapReplace(
-        ref ImmutableDictionary<string, DeviceFullInfo> field,
-        string id, DeviceFullInfo device)
-    {
-        ImmutableDictionary<string, DeviceFullInfo> current, updated;
-        do
-        {
-            current = field;
-            updated = current.SetItem(id, device);
-        } while (Interlocked.CompareExchange(ref field, updated, current) != current);
-        return updated;
-    }
-
-    /// <summary>
-    /// Lock-free read-modify-write that removes <paramref name="id"/> from the published immutable
-    /// dictionary, retrying on concurrent modification. Returns the (possibly unchanged) dictionary;
-    /// <paramref name="removed"/> is the evicted device or <c>null</c> when the id wasn't present.
-    /// </summary>
-    private static ImmutableDictionary<string, DeviceFullInfo> SwapRemove(
-        ref ImmutableDictionary<string, DeviceFullInfo> field,
-        string id, out DeviceFullInfo? removed)
-    {
-        ImmutableDictionary<string, DeviceFullInfo> current, updated;
-        do
-        {
-            current = field;
-            if (!current.TryGetValue(id, out removed))
-            {
-                removed = null;
-                return current; // nothing to remove
-            }
-            updated = current.Remove(id);
-        } while (Interlocked.CompareExchange(ref field, updated, current) != current);
-        return updated;
-    }
-
-    /// <summary>
     /// Process device updates
     /// </summary>
     /// <param name="deviceChangedEvents"></param>
@@ -228,24 +182,39 @@ public class CachedAudioDeviceLister : IAudioDeviceLister
         {
             if (GetDevice(deviceChangedEvent, out var device)) return;
 
+            // The lookup of the replaced device and the swap are a single atomic step under
+            // _cacheLock, so we always dispose exactly the instance that was evicted and a
+            // concurrent Refresh can never overwrite this edit (or vice versa).
             switch (device.Type)
             {
                 case EDataFlow.eRender:
-                    if (PlaybackDevices.TryGetValue(device.Id, out var oldPlaybackDevice))
+                    DeviceFullInfo oldPlaybackDevice;
+                    lock (_cacheLock)
+                    {
+                        PlaybackDevices.TryGetValue(device.Id, out oldPlaybackDevice);
+                        PlaybackDevices = PlaybackDevices.SetItem(device.Id, device);
+                    }
+
+                    if (oldPlaybackDevice != null)
                     {
                         DisposeDevice(oldPlaybackDevice);
                     }
 
-                    SwapReplace(ref _playbackDevices, device.Id, device);
                     SubscribeToDeviceEvents(device);
                     break;
                 case EDataFlow.eCapture:
-                    if (RecordingDevices.TryGetValue(device.Id, out var oldRecordingDevice))
+                    DeviceFullInfo oldRecordingDevice;
+                    lock (_cacheLock)
+                    {
+                        RecordingDevices.TryGetValue(device.Id, out oldRecordingDevice);
+                        RecordingDevices = RecordingDevices.SetItem(device.Id, device);
+                    }
+
+                    if (oldRecordingDevice != null)
                     {
                         DisposeDevice(oldRecordingDevice);
                     }
 
-                    SwapReplace(ref _recordingDevices, device.Id, device);
                     SubscribeToDeviceEvents(device);
                     break;
                 case EDataFlow.eAll:
@@ -264,15 +233,20 @@ public class CachedAudioDeviceLister : IAudioDeviceLister
                 switch (deviceChangedEvent.Action)
                 {
                     case EventType.Removed:
+                        DeviceFullInfo playbackDevice, recordingDevice;
+                        lock (_cacheLock)
+                        {
+                            PlaybackDevices = PlaybackDevices.Remove(deviceChangedEvent.DeviceId, out playbackDevice);
+                            RecordingDevices = RecordingDevices.Remove(deviceChangedEvent.DeviceId, out recordingDevice);
+                        }
+
                         var removed = false;
-                        SwapRemove(ref _playbackDevices, deviceChangedEvent.DeviceId, out var playbackDevice);
                         if (playbackDevice != null)
                         {
                             DisposeDevice(playbackDevice);
                             removed = true;
                         }
 
-                        SwapRemove(ref _recordingDevices, deviceChangedEvent.DeviceId, out var recordingDevice);
                         if (recordingDevice != null)
                         {
                             DisposeDevice(recordingDevice);
@@ -292,6 +266,7 @@ public class CachedAudioDeviceLister : IAudioDeviceLister
                         _deviceListRefreshed.OnNext(Unit.Default);
                         break;
                     case EventType.DefaultChanged:
+                        // Read-only lookup on the published immutable snapshots: no lock needed.
                         if (!PlaybackDevices.TryGetValue(deviceChangedEvent.DeviceId, out var device) && !RecordingDevices.TryGetValue(deviceChangedEvent.DeviceId, out device))
                         {
                             _context.Warning("Can't get device {deviceId}", deviceChangedEvent.DeviceId);
@@ -340,6 +315,8 @@ public class CachedAudioDeviceLister : IAudioDeviceLister
                 // Materialize the enumeration up front: if cancellation (or any failure) interrupts
                 // the placement loop below, the catch disposes every enumerated entry — placed or
                 // not — so no DeviceFullInfo (and the AudioDevice COM reference it owns) is abandoned.
+                // The lock is NOT held here: COM enumeration is the slow part and must not block
+                // ProcessDeviceUpdates or hold _cacheLock across COM calls.
                 var enumeratedDevices = AudioSwitcher.Instance.GetAudioEndpoints(EDataFlow.eAll, _state).ToArray();
                 try
                 {
@@ -377,26 +354,30 @@ public class CachedAudioDeviceLister : IAudioDeviceLister
                     throw;
                 }
 
-                // Capture the previously published devices BEFORE swapping in the new cache, so the
-                // dispose list contains exactly the old devices (not the ones we are about to publish).
-                var oldDevices = PlaybackDevices.Values.Concat(RecordingDevices.Values).ToArray();
+                // Capture the previously published devices and swap in the new cache as ONE atomic
+                // step under _cacheLock: the dispose list contains exactly the old devices (not the
+                // ones we are about to publish), and a concurrent ProcessDeviceUpdates edit can
+                // neither be lost between snapshot and publish nor mutate the dictionaries while we
+                // read them. The lock is held only for these reference swaps (microseconds).
+                DeviceFullInfo[] oldDevices;
+                lock (_cacheLock)
+                {
+                    oldDevices = PlaybackDevices.Values.Concat(RecordingDevices.Values).ToArray();
+                    PlaybackDevices = playbackDevices.ToImmutableDictionary();
+                    RecordingDevices = recordingDevices.ToImmutableDictionary();
+                }
 
-                // Publish the new cache so any reader that starts during disposal sees the fresh,
-                // valid devices (not the ones we are about to tear down). The swap is an atomic
-                // reference assignment; the old devices live on only in the local array above.
-                PlaybackDevices = playbackDevices.ToImmutableDictionary();
-                RecordingDevices = recordingDevices.ToImmutableDictionary();
-
-                // Dispose the captured old devices outside the live dictionaries, so a concurrent
-                // ProcessDeviceUpdates (device arrival/removal on another thread) cannot mutate the
-                // collection while we enumerate it. The Union over the live dictionaries used to be
-                // lazy and threw "Collection was modified" under concurrent mutation (Sentry SOUNDSWITCH-49X).
+                // Dispose the captured old devices OUTSIDE the lock: disposal is COM-heavy and the
+                // old devices live on only in the local array. Any reader that starts during disposal
+                // sees the fresh, valid devices. The materialized array avoids the lazy-enumeration
+                // race that threw "Collection was modified" (Sentry SOUNDSWITCH-49X).
                 if (oldDevices.Length > 0)
                 {
                     DisposeOldDevices(oldDevices);
                 }
 
-                // Now subscribe to events for the new devices in the cache
+                // Now subscribe to events for the new devices in the cache (outside the lock:
+                // subscription marshals onto the ComThread and must not block the swap path).
                 foreach (var device in PlaybackDevices.Values.Concat(RecordingDevices.Values))
                 {
                     SubscribeToDeviceEvents(device);
@@ -428,7 +409,17 @@ public class CachedAudioDeviceLister : IAudioDeviceLister
 
     public void Dispose()
     {
-        DisposeOldDevices(PlaybackDevices.Values.Concat(RecordingDevices.Values).ToArray());
+        // Swap both caches to Empty under the lock so no concurrent mutation can reintroduce a
+        // device after the snapshot, then dispose the captured devices outside the lock.
+        DeviceFullInfo[] oldDevices;
+        lock (_cacheLock)
+        {
+            oldDevices = PlaybackDevices.Values.Concat(RecordingDevices.Values).ToArray();
+            PlaybackDevices = ImmutableDictionary<string, DeviceFullInfo>.Empty;
+            RecordingDevices = ImmutableDictionary<string, DeviceFullInfo>.Empty;
+        }
+
+        DisposeOldDevices(oldDevices);
 
         // Dispose subjects and clear all subscriptions
         (_defaultDeviceChanged as Subject<DefaultDevicePayload>)?.Dispose();

--- a/SoundSwitch/Framework/Audio/Lister/CachedAudioDeviceLister.cs
+++ b/SoundSwitch/Framework/Audio/Lister/CachedAudioDeviceLister.cs
@@ -233,11 +233,13 @@ public class CachedAudioDeviceLister : IAudioDeviceLister
                 switch (deviceChangedEvent.Action)
                 {
                     case EventType.Removed:
-                        DeviceFullInfo playbackDevice, recordingDevice;
+                        DeviceFullInfo? playbackDevice, recordingDevice;
                         lock (_cacheLock)
                         {
-                            PlaybackDevices = PlaybackDevices.Remove(deviceChangedEvent.DeviceId, out playbackDevice);
-                            RecordingDevices = RecordingDevices.Remove(deviceChangedEvent.DeviceId, out recordingDevice);
+                            PlaybackDevices.TryGetValue(deviceChangedEvent.DeviceId, out playbackDevice);
+                            PlaybackDevices = PlaybackDevices.Remove(deviceChangedEvent.DeviceId);
+                            RecordingDevices.TryGetValue(deviceChangedEvent.DeviceId, out recordingDevice);
+                            RecordingDevices = RecordingDevices.Remove(deviceChangedEvent.DeviceId);
                         }
 
                         var removed = false;

--- a/SoundSwitch/Framework/Audio/Lister/CachedAudioDeviceLister.cs
+++ b/SoundSwitch/Framework/Audio/Lister/CachedAudioDeviceLister.cs
@@ -322,20 +322,47 @@ public class CachedAudioDeviceLister : IAudioDeviceLister
                 var enumeratedDevices = AudioSwitcher.Instance.GetAudioEndpoints(EDataFlow.eAll, _state).ToArray();
                 try
                 {
+                    // Captured old devices live on only in the published caches until the swap
+                    // below. We dispose the ones that are absent from the new enumeration AFTER
+                    // publishing, so we never dispose a device still in use.
+                    var toDispose = new List<DeviceFullInfo>();
+
                     foreach (var deviceInfo in enumeratedDevices)
                     {
                         cancellationToken.ThrowIfCancellationRequested();
 
-                        // Subscription is now handled after adding to the dictionary
-                        // SubscribeToDeviceEvents(deviceInfo);
+                        // Reconcile: if this device id already exists in the cache (and is still
+                        // alive), REUSE the existing DeviceFullInfo — it already holds a live COM
+                        // endpoint and an active volume subscription. We only rebuild a fresh
+                        // instance for genuinely new ids. This avoids tearing down and re-subscribing
+                        // every device on every refresh (the full-refresh happens at startup and
+                        // system resume), which is both cleaner and preserves real-time volume state.
+                        ImmutableDictionary<string, DeviceFullInfo>? existingDict = deviceInfo.Type == EDataFlow.eRender ? PlaybackDevices : RecordingDevices;
+                        DeviceFullInfo? existing = existingDict != null && existingDict.TryGetValue(deviceInfo.Id, out var candidate) && !candidate.IsDisposed ? candidate : null;
 
                         switch (deviceInfo.Type)
                         {
                             case EDataFlow.eRender:
-                                playbackDevices.Add(deviceInfo.Id, deviceInfo);
+                                if (existing != null)
+                                {
+                                    playbackDevices.Add(deviceInfo.Id, existing);
+                                }
+                                else
+                                {
+                                    playbackDevices.Add(deviceInfo.Id, deviceInfo);
+                                }
+
                                 break;
                             case EDataFlow.eCapture:
-                                recordingDevices.Add(deviceInfo.Id, deviceInfo);
+                                if (existing != null)
+                                {
+                                    recordingDevices.Add(deviceInfo.Id, existing);
+                                }
+                                else
+                                {
+                                    recordingDevices.Add(deviceInfo.Id, deviceInfo);
+                                }
+
                                 break;
                             case EDataFlow.eAll:
                                 break;
@@ -369,20 +396,33 @@ public class CachedAudioDeviceLister : IAudioDeviceLister
                     RecordingDevices = recordingDevices.ToImmutableDictionary();
                 }
 
-                // Dispose the captured old devices OUTSIDE the lock: disposal is COM-heavy and the
-                // old devices live on only in the local array. Any reader that starts during disposal
-                // sees the fresh, valid devices. The materialized array avoids the lazy-enumeration
-                // race that threw "Collection was modified" (Sentry SOUNDSWITCH-49X).
+                // Dispose only the devices that were published before but are absent from the new
+                // enumeration (genuinely removed). Reused instances are still in the new cache, so
+                // they are never disposed. Disposal happens OUTSIDE the lock (COM-heavy).
                 if (oldDevices.Length > 0)
                 {
-                    DisposeOldDevices(oldDevices);
+                    var newIds = new HashSet<string>(playbackDevices.Keys.Concat(recordingDevices.Keys));
+                    foreach (var oldDevice in oldDevices)
+                    {
+                        if (!newIds.Contains(oldDevice.Id))
+                        {
+                            toDispose.Add(oldDevice);
+                        }
+                    }
+
+                    DisposeOldDevices(toDispose.ToArray());
                 }
 
-                // Now subscribe to events for the new devices in the cache (outside the lock:
-                // subscription marshals onto the ComThread and must not block the swap path).
+                // Now subscribe to events, but ONLY for devices that weren't already in the cache
+                // (reused instances keep their existing volume subscription). The newIds set was
+                // built from the freshly enumerated ids, so subscribing only those is correct and
+                // avoids tearing down/re-adding the COM volume registration on every refresh.
                 foreach (var device in PlaybackDevices.Values.Concat(RecordingDevices.Values))
                 {
-                    SubscribeToDeviceEvents(device);
+                    if (newIds.Contains(device.Id))
+                    {
+                        SubscribeToDeviceEvents(device);
+                    }
                 }
 
 

--- a/SoundSwitch/Framework/Audio/Lister/CachedAudioDeviceLister.cs
+++ b/SoundSwitch/Framework/Audio/Lister/CachedAudioDeviceLister.cs
@@ -392,6 +392,7 @@ public class CachedAudioDeviceLister : IAudioDeviceLister
                 // outside the lock (COM-heavy). Readers see the fresh cache during disposal.
                 DeviceFullInfo[] oldDevices;
                 List<DeviceFullInfo> rejectedFresh;
+                List<DeviceFullInfo> newlyPublished;
                 lock (_cacheLock)
                 {
                     oldDevices = PlaybackDevices.Values.Concat(RecordingDevices.Values).ToArray();
@@ -400,42 +401,58 @@ public class CachedAudioDeviceLister : IAudioDeviceLister
                     var mergedPlayback = new Dictionary<string, DeviceFullInfo>(playbackDevices.Count);
                     var mergedRecording = new Dictionary<string, DeviceFullInfo>(recordingDevices.Count);
                     rejectedFresh = new List<DeviceFullInfo>();
+                    // Instances we actually publish fresh (vs. reuse an existing one). Used to
+                    // subscribe ONLY the new devices after publishing, so reused instances keep
+                    // their existing volume subscription instead of being re-subscribed.
+                    newlyPublished = new List<DeviceFullInfo>();
 
                     foreach (var kvp in playbackDevices)
                     {
+                        DeviceFullInfo chosen;
                         if (PlaybackDevices.TryGetValue(kvp.Key, out var existing) && !existing.IsDisposed)
                         {
-                            mergedPlayback[kvp.Key] = existing;
+                            chosen = existing;
                         }
                         else
                         {
-                            mergedPlayback[kvp.Key] = kvp.Value; // fresh wins
+                            chosen = kvp.Value; // fresh wins
                         }
 
-                        if (!newIds.Contains(kvp.Key)) continue; // not fresh, no reject possible
-                        var chosen = mergedPlayback[kvp.Key];
+                        mergedPlayback[kvp.Key] = chosen;
+
+                        if (!newIds.Contains(kvp.Key)) continue; // not fresh, no reject/subscribe possible
                         if (!ReferenceEquals(chosen, kvp.Value))
                         {
                             rejectedFresh.Add(kvp.Value); // fresh instance lost the race
+                        }
+                        else
+                        {
+                            newlyPublished.Add(chosen); // fresh instance published
                         }
                     }
 
                     foreach (var kvp in recordingDevices)
                     {
+                        DeviceFullInfo chosen;
                         if (RecordingDevices.TryGetValue(kvp.Key, out var existing) && !existing.IsDisposed)
                         {
-                            mergedRecording[kvp.Key] = existing;
+                            chosen = existing;
                         }
                         else
                         {
-                            mergedRecording[kvp.Key] = kvp.Value; // fresh wins
+                            chosen = kvp.Value; // fresh wins
                         }
 
+                        mergedRecording[kvp.Key] = chosen;
+
                         if (!newIds.Contains(kvp.Key)) continue;
-                        var chosen = mergedRecording[kvp.Key];
                         if (!ReferenceEquals(chosen, kvp.Value))
                         {
-                            rejectedFresh.Add(kvp.Value); // fresh instance lost the race
+                            rejectedFresh.Add(kvp.Value);
+                        }
+                        else
+                        {
+                            newlyPublished.Add(chosen);
                         }
                     }
 
@@ -465,16 +482,13 @@ public class CachedAudioDeviceLister : IAudioDeviceLister
                     DisposeOldDevices(removedOld);
                 }
 
-                // Now subscribe to events, but ONLY for devices that weren't already in the cache
-                // (reused instances keep their existing volume subscription). The newIds set was
-                // built from the freshly enumerated ids, so subscribing only those is correct and
-                // avoids tearing down/re-adding the COM volume registration on every refresh.
-                foreach (var device in PlaybackDevices.Values.Concat(RecordingDevices.Values))
+                // Subscribe to events for ONLY the freshly-published instances. Reused instances
+                // keep their existing volume subscription; subscribing them again would re-add the
+                // MuteVolumeChanged handler (guarded against double-subscribe, but wasteful and
+                // misleading). `newlyPublished` is the exact set of instances we chose fresh.
+                foreach (var device in newlyPublished)
                 {
-                    if (newIds.Contains(device.Id))
-                    {
-                        SubscribeToDeviceEvents(device);
-                    }
+                    SubscribeToDeviceEvents(device);
                 }
 
 

--- a/SoundSwitch/Framework/Audio/Lister/CachedAudioDeviceLister.cs
+++ b/SoundSwitch/Framework/Audio/Lister/CachedAudioDeviceLister.cs
@@ -308,6 +308,10 @@ public class CachedAudioDeviceLister : IAudioDeviceLister
             Refreshing = true;
             var playbackDevices = new Dictionary<string, DeviceFullInfo>();
             var recordingDevices = new Dictionary<string, DeviceFullInfo>();
+            // Devices to dispose after publishing: those present before but absent from the new
+            // enumeration. Devices newly added this refresh (for post-publish subscription).
+            var toDispose = new List<DeviceFullInfo>();
+            var newIds = new HashSet<string>();
 
             using var registration = cancellationToken.Register(_ => { logContext.Warning("Cancellation received."); }, null);
 
@@ -322,11 +326,6 @@ public class CachedAudioDeviceLister : IAudioDeviceLister
                 var enumeratedDevices = AudioSwitcher.Instance.GetAudioEndpoints(EDataFlow.eAll, _state).ToArray();
                 try
                 {
-                    // Captured old devices live on only in the published caches until the swap
-                    // below. We dispose the ones that are absent from the new enumeration AFTER
-                    // publishing, so we never dispose a device still in use.
-                    var toDispose = new List<DeviceFullInfo>();
-
                     foreach (var deviceInfo in enumeratedDevices)
                     {
                         cancellationToken.ThrowIfCancellationRequested();
@@ -350,6 +349,7 @@ public class CachedAudioDeviceLister : IAudioDeviceLister
                                 else
                                 {
                                     playbackDevices.Add(deviceInfo.Id, deviceInfo);
+                                    newIds.Add(deviceInfo.Id);
                                 }
 
                                 break;
@@ -361,6 +361,7 @@ public class CachedAudioDeviceLister : IAudioDeviceLister
                                 else
                                 {
                                     recordingDevices.Add(deviceInfo.Id, deviceInfo);
+                                    newIds.Add(deviceInfo.Id);
                                 }
 
                                 break;
@@ -401,7 +402,6 @@ public class CachedAudioDeviceLister : IAudioDeviceLister
                 // they are never disposed. Disposal happens OUTSIDE the lock (COM-heavy).
                 if (oldDevices.Length > 0)
                 {
-                    var newIds = new HashSet<string>(playbackDevices.Keys.Concat(recordingDevices.Keys));
                     foreach (var oldDevice in oldDevices)
                     {
                         if (!newIds.Contains(oldDevice.Id))

--- a/SoundSwitch/Framework/Audio/Lister/CachedAudioDeviceLister.cs
+++ b/SoundSwitch/Framework/Audio/Lister/CachedAudioDeviceLister.cs
@@ -43,11 +43,25 @@ public class CachedAudioDeviceLister : IAudioDeviceLister
     // is inherently safe to enumerate.
     private readonly Lock _cacheLock = new Lock();
 
-    /// <inheritdoc />
-    private ImmutableDictionary<string, DeviceFullInfo> PlaybackDevices { get; set; } = ImmutableDictionary<string, DeviceFullInfo>.Empty;
+    // Volatile backing fields give the lock-free readers (GetDevices, DefaultChanged lookup) acquire
+    // semantics on every read, so a reference published inside Refresh's/ProcessDeviceUpdates' lock
+    // is always seen as the latest snapshot. The properties are thin wrappers over these fields.
+    private volatile ImmutableDictionary<string, DeviceFullInfo> _playbackDevices = ImmutableDictionary<string, DeviceFullInfo>.Empty;
+    private volatile ImmutableDictionary<string, DeviceFullInfo> _recordingDevices = ImmutableDictionary<string, DeviceFullInfo>.Empty;
 
     /// <inheritdoc />
-    private ImmutableDictionary<string, DeviceFullInfo> RecordingDevices { get; set; } = ImmutableDictionary<string, DeviceFullInfo>.Empty;
+    private ImmutableDictionary<string, DeviceFullInfo> PlaybackDevices
+    {
+        get => _playbackDevices;
+        set => _playbackDevices = value;
+    }
+
+    /// <inheritdoc />
+    private ImmutableDictionary<string, DeviceFullInfo> RecordingDevices
+    {
+        get => _recordingDevices;
+        set => _recordingDevices = value;
+    }
 
     private readonly ISubject<DefaultDevicePayload> _defaultDeviceChanged = new Subject<DefaultDevicePayload>();
     public IObservable<DefaultDevicePayload> DefaultDeviceChanged => _defaultDeviceChanged.AsObservable();
@@ -188,14 +202,16 @@ public class CachedAudioDeviceLister : IAudioDeviceLister
             switch (device.Type)
             {
                 case EDataFlow.eRender:
-                    DeviceFullInfo oldPlaybackDevice;
+                    DeviceFullInfo? oldPlaybackDevice;
                     lock (_cacheLock)
                     {
                         PlaybackDevices.TryGetValue(device.Id, out oldPlaybackDevice);
                         PlaybackDevices = PlaybackDevices.SetItem(device.Id, device);
                     }
 
-                    if (oldPlaybackDevice != null)
+                    // Dispose the previously-cached instance only if it isn't the one we just
+                    // published (guards against a no-op update of the same object).
+                    if (oldPlaybackDevice != null && !ReferenceEquals(oldPlaybackDevice, device))
                     {
                         DisposeDevice(oldPlaybackDevice);
                     }
@@ -203,14 +219,14 @@ public class CachedAudioDeviceLister : IAudioDeviceLister
                     SubscribeToDeviceEvents(device);
                     break;
                 case EDataFlow.eCapture:
-                    DeviceFullInfo oldRecordingDevice;
+                    DeviceFullInfo? oldRecordingDevice;
                     lock (_cacheLock)
                     {
                         RecordingDevices.TryGetValue(device.Id, out oldRecordingDevice);
                         RecordingDevices = RecordingDevices.SetItem(device.Id, device);
                     }
 
-                    if (oldRecordingDevice != null)
+                    if (oldRecordingDevice != null && !ReferenceEquals(oldRecordingDevice, device))
                     {
                         DisposeDevice(oldRecordingDevice);
                     }
@@ -308,9 +324,9 @@ public class CachedAudioDeviceLister : IAudioDeviceLister
             Refreshing = true;
             var playbackDevices = new Dictionary<string, DeviceFullInfo>();
             var recordingDevices = new Dictionary<string, DeviceFullInfo>();
-            // Devices to dispose after publishing: those present before but absent from the new
-            // enumeration. Devices newly added this refresh (for post-publish subscription).
-            var toDispose = new List<DeviceFullInfo>();
+            // Ids of devices newly enumerated this refresh (used to subscribe only the new ones
+            // after publishing, and to detect fresh instances rejected in favour of a still-alive
+            // existing instance).
             var newIds = new HashSet<string>();
 
             using var registration = cancellationToken.Register(_ => { logContext.Warning("Cancellation received."); }, null);
@@ -330,40 +346,21 @@ public class CachedAudioDeviceLister : IAudioDeviceLister
                     {
                         cancellationToken.ThrowIfCancellationRequested();
 
-                        // Reconcile: if this device id already exists in the cache (and is still
-                        // alive), REUSE the existing DeviceFullInfo — it already holds a live COM
-                        // endpoint and an active volume subscription. We only rebuild a fresh
-                        // instance for genuinely new ids. This avoids tearing down and re-subscribing
-                        // every device on every refresh (the full-refresh happens at startup and
-                        // system resume), which is both cleaner and preserves real-time volume state.
-                        ImmutableDictionary<string, DeviceFullInfo>? existingDict = deviceInfo.Type == EDataFlow.eRender ? PlaybackDevices : RecordingDevices;
-                        DeviceFullInfo? existing = existingDict != null && existingDict.TryGetValue(deviceInfo.Id, out var candidate) && !candidate.IsDisposed ? candidate : null;
-
+                        // Build the candidate (new) cache from the freshly enumerated endpoints.
+                        // We do NOT peek at the published caches here; the reconcile decision
+                        // (reuse existing vs. keep fresh) is made atomically under _cacheLock below,
+                        // so a concurrent ProcessDeviceUpdates removal cannot leave a device that we
+                        // reused and then disposed (use-after-free), and a freshly enumerated device
+                        // that loses the race is still disposed (no COM AudioDevice leak).
                         switch (deviceInfo.Type)
                         {
                             case EDataFlow.eRender:
-                                if (existing != null)
-                                {
-                                    playbackDevices.Add(deviceInfo.Id, existing);
-                                }
-                                else
-                                {
-                                    playbackDevices.Add(deviceInfo.Id, deviceInfo);
-                                    newIds.Add(deviceInfo.Id);
-                                }
-
+                                playbackDevices.Add(deviceInfo.Id, deviceInfo);
+                                newIds.Add(deviceInfo.Id);
                                 break;
                             case EDataFlow.eCapture:
-                                if (existing != null)
-                                {
-                                    recordingDevices.Add(deviceInfo.Id, existing);
-                                }
-                                else
-                                {
-                                    recordingDevices.Add(deviceInfo.Id, deviceInfo);
-                                    newIds.Add(deviceInfo.Id);
-                                }
-
+                                recordingDevices.Add(deviceInfo.Id, deviceInfo);
+                                newIds.Add(deviceInfo.Id);
                                 break;
                             case EDataFlow.eAll:
                                 break;
@@ -384,33 +381,81 @@ public class CachedAudioDeviceLister : IAudioDeviceLister
                     throw;
                 }
 
-                // Capture the previously published devices and swap in the new cache as ONE atomic
-                // step under _cacheLock: the dispose list contains exactly the old devices (not the
-                // ones we are about to publish), and a concurrent ProcessDeviceUpdates edit can
-                // neither be lost between snapshot and publish nor mutate the dictionaries while we
-                // read them. The lock is held only for these reference swaps (microseconds).
+                // Reconcile atomically under _cacheLock (this is the only place that reads the
+                // published caches for the reuse decision, so it is immune to concurrent mutation):
+                //  - for each id, keep the EXISTING instance if still alive (preserves its COM
+                //    endpoint + volume subscription); otherwise keep the freshly enumerated one;
+                //  - a freshly enumerated instance that is NOT chosen (existing won), is disposed
+                //    here so its AudioDevice COM reference is released;
+                //  - an old instance absent from the new enumeration is disposed (genuinely removed).
+                // The dispose lists are materialized and disposal itself happens AFTER the swap,
+                // outside the lock (COM-heavy). Readers see the fresh cache during disposal.
                 DeviceFullInfo[] oldDevices;
+                List<DeviceFullInfo> rejectedFresh;
                 lock (_cacheLock)
                 {
                     oldDevices = PlaybackDevices.Values.Concat(RecordingDevices.Values).ToArray();
-                    PlaybackDevices = playbackDevices.ToImmutableDictionary();
-                    RecordingDevices = recordingDevices.ToImmutableDictionary();
-                }
 
-                // Dispose only the devices that were published before but are absent from the new
-                // enumeration (genuinely removed). Reused instances are still in the new cache, so
-                // they are never disposed. Disposal happens OUTSIDE the lock (COM-heavy).
-                if (oldDevices.Length > 0)
-                {
-                    foreach (var oldDevice in oldDevices)
+                    // Choose the surviving instance per id (reuse existing when alive).
+                    var mergedPlayback = new Dictionary<string, DeviceFullInfo>(playbackDevices.Count);
+                    var mergedRecording = new Dictionary<string, DeviceFullInfo>(recordingDevices.Count);
+                    rejectedFresh = new List<DeviceFullInfo>();
+
+                    foreach (var kvp in playbackDevices)
                     {
-                        if (!newIds.Contains(oldDevice.Id))
+                        if (PlaybackDevices.TryGetValue(kvp.Key, out var existing) && !existing.IsDisposed)
                         {
-                            toDispose.Add(oldDevice);
+                            mergedPlayback[kvp.Key] = existing;
+                        }
+                        else
+                        {
+                            mergedPlayback[kvp.Key] = kvp.Value; // fresh wins
+                        }
+
+                        if (!newIds.Contains(kvp.Key)) continue; // not fresh, no reject possible
+                        var chosen = mergedPlayback[kvp.Key];
+                        if (!ReferenceEquals(chosen, kvp.Value))
+                        {
+                            rejectedFresh.Add(kvp.Value); // fresh instance lost the race
                         }
                     }
 
-                    DisposeOldDevices(toDispose.ToArray());
+                    foreach (var kvp in recordingDevices)
+                    {
+                        if (RecordingDevices.TryGetValue(kvp.Key, out var existing) && !existing.IsDisposed)
+                        {
+                            mergedRecording[kvp.Key] = existing;
+                        }
+                        else
+                        {
+                            mergedRecording[kvp.Key] = kvp.Value; // fresh wins
+                        }
+
+                        if (!newIds.Contains(kvp.Key)) continue;
+                        var chosen = mergedRecording[kvp.Key];
+                        if (!ReferenceEquals(chosen, kvp.Value))
+                        {
+                            rejectedFresh.Add(kvp.Value); // fresh instance lost the race
+                        }
+                    }
+
+                    PlaybackDevices = mergedPlayback.ToImmutableDictionary();
+                    RecordingDevices = mergedRecording.ToImmutableDictionary();
+                }
+
+                // Dispose freshly enumerated instances that were not published (rejected in favour
+                // of a still-alive existing instance), then dispose old instances absent from the
+                // new enumeration. Both happen outside the lock.
+                if (rejectedFresh.Count > 0)
+                {
+                    DisposeOldDevices(rejectedFresh.ToArray());
+                }
+
+                var retainedIds = new HashSet<string>(playbackDevices.Keys.Concat(recordingDevices.Keys));
+                var removedOld = oldDevices.Where(d => !retainedIds.Contains(d.Id)).ToArray();
+                if (removedOld.Length > 0)
+                {
+                    DisposeOldDevices(removedOld);
                 }
 
                 // Now subscribe to events, but ONLY for devices that weren't already in the cache


### PR DESCRIPTION
## Summary

Rework of `CachedAudioDeviceLister`'s cache-synchronization layer, following the maintainer's direction to use the proper .NET 9 `System.Threading.Lock` (this project targets `net10.0-windows`). The previous iterative fixes (#2390 publish-before-dispose, #2393) made disposal safe but left a publication race flagged by CodeRabbit **after** #2393 merged (thread `c45DC`): `Refresh` assigned the published caches via direct property setters while `ProcessDeviceUpdates` edited them on a different path, so a concurrent edit could be silently overwritten — and a device could be left undisposed.

### Thread safety (the core fix)

- **One dedicated `Lock _cacheLock`** (`.NET 9 System.Threading.Lock`) serializes the two writers: `Refresh`'s wholesale publish and `ProcessDeviceUpdates`' incremental edits.
- **Minimal lock scope (performance):** the lock is held **only** for the immutable-dictionary reference swaps (microseconds). COM enumeration (`GetAudioEndpoints`), event subscription (`SubscribeToDeviceEvents`), and device disposal (`DisposeOldDevices`) all run **outside** the lock, so the hot paths never block on COM work.
- **`Refresh` atomicity:** the old-device snapshot *and* both publish assignments sit inside a single `lock` block. The dispose list captures exactly the old devices (never the ones being published), and a concurrent `ProcessDeviceUpdates` edit can neither be lost between snapshot and publish nor mutate the dictionaries mid-read.
- **`ProcessDeviceUpdates`:** add/update looks up the evicted instance and swaps in one locked block (dispose/subscribe happen after unlock); removal uses `TryGetValue` + `Remove(id)` under the lock for both dictionaries. `DefaultChanged` stays a lock-free read of the immutable snapshots.
- **`Dispose()`** now clears both caches under the lock before disposing, preventing post-snapshot reinsertion.
- **Readers stay lock-free:** `GetDevices` and the `DefaultChanged` lookup read the published immutable snapshots — no "Collection was modified" possible (Sentry `SOUNDSWITCH-49X`).

### Reconcile on refresh (cleanliness, no new dependency)

Full `Refresh()` runs only at startup and on system resume — device plug/unplug and default-device changes go through the incremental `ProcessDeviceUpdates` path (which stays as the unreliable-but-cheap path; a full refresh is the reliable backstop). Previously a refresh disposed and rebuilt **every** device, tearing down and re-subscribing each device's COM volume endpoint. Now `Refresh` **reconciles by id**:

- A device still present in the cache (and not disposed) is **reused** — its live `IMMDevice` COM reference and active volume subscription are preserved, so real-time volume state survives a refresh.
- Only devices **absent** from the new enumeration are disposed.
- Only **newly-enumerated** ids get a fresh `DeviceFullInfo` + subscription.

This keeps the class dependency-free (no DB, no serialization) and avoids the per-refresh COM churn, matching the lean-device bias.

### Preserved contract

Cancellation/CTS exchange, the `Refreshing` flag, both filtered catch blocks (cancellation vs. real error), the materialized-array `DisposeOldDevices(DeviceFullInfo[])` snapshot discipline, and `DeviceFullInfo`'s idempotent `Interlocked` dispose. A small `IsDisposed` accessor was added to `DeviceFullInfo` so reconcile never reuses a concurrently-disposed instance. Full public surface unchanged.

### Test

`RefreshDeviceTests.Refresh_Reconcile_ReusesSurvivingDevicesAndDisposesOnlyRemoved` locks the reconcile contract (surviving device reused, removed device disposed once) without needing the Windows audio service.

Fixes the `SOUNDSWITCH-49X`-adjacent publication race (closes CodeRabbit `c45DC` from #2393).