### PR TITLE
fix(audio): resolve notification IMMDevice via ComThread to kill InvalidCastException (#2384)

### DIFF
--- a/SoundSwitch.Audio.Manager/AudioSwitcher.cs
+++ b/SoundSwitch.Audio.Manager/AudioSwitcher.cs
@@ -359,6 +359,16 @@ namespace SoundSwitch.Audio.Manager
         public AudioDevice? GetDevice(string deviceId) => ComThread.Invoke(() => EnumeratorClient.GetDevice(deviceId));
 
         /// <summary>
+        /// Resolve the given device (or the default render endpoint when <paramref name="deviceId"/>
+        /// is null or empty) on the ComThread and return a COM stream holding a marshalled
+        /// <c>IMMDevice</c> reference. The caller unmarshals it on its own COM-initialized thread
+        /// via <see cref="Interop.Com.Base.Ole32.CoGetInterfaceAndReleaseStream"/>.
+        /// </summary>
+        /// <param name="deviceId"></param>
+        /// <returns>The marshalled <c>IStream</c> pointer, or <see cref="IntPtr.Zero"/>.</returns>
+        internal IntPtr GetDeviceStream(string? deviceId) => ComThread.Invoke(() => EnumeratorClient.MarshalDeviceToStream(deviceId));
+
+        /// <summary>
         /// Get audio endpoints for the given flow and state
         /// </summary>
         /// <param name="flow"></param>

--- a/SoundSwitch.Audio.Manager/Interop/Client/AudioDeviceEnumerator.cs
+++ b/SoundSwitch.Audio.Manager/Interop/Client/AudioDeviceEnumerator.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
+using SoundSwitch.Audio.Manager.Interop.Com.Base;
 using SoundSwitch.Audio.Manager.Interop.Com.Threading;
 using SoundSwitch.Audio.Manager.Interop.Enum;
 using SoundSwitch.Audio.Manager.Interop.Interface;
@@ -97,6 +98,45 @@ namespace SoundSwitch.Audio.Manager.Interop.Client
             catch
             {
                 return null;
+            }
+        }
+
+        /// <summary>
+        /// Resolves an endpoint — the default render/multimedia endpoint when
+        /// <paramref name="deviceId"/> is null or empty, otherwise the endpoint with that id — and
+        /// marshals its <c>IMMDevice</c> reference into an inter-thread COM stream so a caller on
+        /// another COM-initialized thread can unmarshal it (see
+        /// <see cref="Ole32.CoGetInterfaceAndReleaseStream"/>). Returns <see cref="IntPtr.Zero"/>
+        /// when no endpoint is available.
+        /// </summary>
+        /// <param name="deviceId"></param>
+        /// <returns>The marshalled <c>IStream</c> pointer, or <see cref="IntPtr.Zero"/>.</returns>
+        public IntPtr MarshalDeviceToStream(string? deviceId)
+        {
+            ComThread.Assert();
+            IMMDevice? device = null;
+            try
+            {
+                var hr = string.IsNullOrEmpty(deviceId)
+                    ? _enumerator.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia, out device)
+                    : _enumerator.GetDevice(deviceId, out device);
+                if (hr != HRESULT.S_OK || device == null)
+                    return IntPtr.Zero;
+
+                var iid = new Guid(ComGuid.AUDIO_IMMDEVICE_IID);
+                var marshalResult = Ole32.CoMarshalInterThreadInterfaceInStream(ref iid, device, out var stream);
+                return marshalResult == HRESULT.S_OK && stream != IntPtr.Zero ? stream : IntPtr.Zero;
+            }
+            catch (Exception)
+            {
+                // Mirrors the swallow-and-return-null boundary of GetDefaultEndpoint / GetDevice
+                // (issue #401 semantics): no default endpoint, or an endpoint that vanished.
+                return IntPtr.Zero;
+            }
+            finally
+            {
+                // The stream now owns the marshalled reference; release the local RCW reference.
+                if (device != null) Marshal.ReleaseComObject(device);
             }
         }
 

--- a/SoundSwitch.Audio.Manager/Interop/Com/Base/Ole32.cs
+++ b/SoundSwitch.Audio.Manager/Interop/Com/Base/Ole32.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Runtime.InteropServices;
+
+using SoundSwitch.Audio.Manager.Interop.Enum;
+
+namespace SoundSwitch.Audio.Manager.Interop.Com.Base
+{
+    /// <summary>
+    /// Ole32 interop for the cross-apartment COM marshalling used by the playback path. The
+    /// notification renderer resolves an <c>IMMDevice</c> on the shared ComThread and then
+    /// unmarshals it on its own dedicated STA thread, so the raw interface pointer must cross an
+    /// apartment boundary via COM's standard inter-thread marshalling primitive rather than being
+    /// wrapped directly.
+    /// </summary>
+    internal static class Ole32
+    {
+        /// <summary>
+        /// Marshals an interface pointer into a stream (<c>IStream</c>) so it can be unmarshalled
+        /// in another COM apartment. The returned stream owns the marshalled reference; the caller
+        /// releases its own reference once the marshal has captured it.
+        /// </summary>
+        [DllImport("Ole32.dll", PreserveSig = true)]
+        internal static extern HRESULT CoMarshalInterThreadInterfaceInStream([In] ref Guid riid, [In, MarshalAs(UnmanagedType.IUnknown)] object pUnk, out IntPtr ppStm);
+
+        /// <summary>
+        /// Unmarshals an interface pointer previously written by
+        /// <see cref="CoMarshalInterThreadInterfaceInStream"/>; consumes and releases the stream.
+        /// On success the returned pointer owns one reference and must be released by the caller.
+        /// </summary>
+        [DllImport("Ole32.dll", PreserveSig = true)]
+        internal static extern HRESULT CoGetInterfaceAndReleaseStream(IntPtr pStm, [In] ref Guid riid, out IntPtr ppv);
+    }
+}

--- a/SoundSwitch.Audio.Manager/Playback/WavePlayer.cs
+++ b/SoundSwitch.Audio.Manager/Playback/WavePlayer.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 
 using Serilog;
 
+using SoundSwitch.Audio.Manager.Interop.Com.Base;
 using SoundSwitch.Audio.Manager.Interop.Enum;
 using SoundSwitch.Audio.Manager.Interop.Interface;
 
@@ -17,9 +18,11 @@ namespace SoundSwitch.Audio.Manager.Playback
     /// third-party <c>WasapiOut</c>. One instance renders one buffer of samples once.
     ///
     /// Threading contract: each instance owns a dedicated COM-initialized STA thread. The shared
-    /// <see cref="Interop.Com.Threading.ComThread"/> is never used — a render loop blocking on
-    /// buffer events would stall device switching. Every COM object (enumerator, device, audio
-    /// client, render client) is created, used, and released on that thread.
+    /// <see cref="Interop.Com.Threading.ComThread"/> is never used for the render loop — a render
+    /// loop blocking on buffer events would stall device switching. The endpoint (<c>IMMDevice</c>)
+    /// is resolved on the shared ComThread via <see cref="AudioSwitcher"/> and unmarshalled onto
+    /// this thread; the audio client, render client, and everything the render loop touches are
+    /// then created, used, and released on this thread.
     ///
     /// Completion contract (mirrors the legacy <c>PlaybackStopped</c> semantics):
     /// - The returned <see cref="Task"/> completes when playback has fully drained, the device is
@@ -49,11 +52,6 @@ namespace SoundSwitch.Audio.Manager.Playback
 
         private static readonly Guid IidAudioClient = new("1CB9AD4C-DBFA-4C32-B178-C2F568A703B2");
         private static readonly Guid IidAudioRenderClient = new("F294ACFC-3146-4483-A7BF-ADDCA7C260E2");
-
-        [ComImport, Guid(ComGuid.AUDIO_IMMDEVICE_ENUMERATOR_OBJECT_IID)]
-        private class MMDeviceEnumeratorComObject
-        {
-        }
 
         private readonly byte[] _audioData;
         private readonly WaveFormat _sourceFormat;
@@ -103,16 +101,14 @@ namespace SoundSwitch.Audio.Manager.Playback
         /// <summary>Plays the sound; throws only for initialization-phase failures.</summary>
         private void Play()
         {
-            IMMDeviceEnumerator? enumerator = null;
             IMMDevice? device = null;
             RenderSession? session = null;
             try
             {
-                enumerator = (IMMDeviceEnumerator)new MMDeviceEnumeratorComObject();
-                device = ResolveDevice(enumerator, _deviceId);
+                device = ResolveDevice(_deviceId);
                 if (device == null)
                 {
-                    Logger.Warning("No audio device found for notification playback (device id: {DeviceId}).", _deviceId ?? "<default>");
+                    Logger.Warning("No audio device found for notification playback (device id: {DeviceId}).", string.IsNullOrEmpty(_deviceId) ? "<default>" : _deviceId);
                     return;
                 }
 
@@ -129,7 +125,7 @@ namespace SoundSwitch.Audio.Manager.Playback
                     session?.Dispose();
                     session = null;
                     Marshal.ReleaseComObject(device);
-                    device = ResolveDevice(enumerator, null);
+                    device = ResolveDevice(null);
                     if (device == null)
                         throw new AudioDeviceException(HRESULT.PROCESS_NO_AUDIO, "No default render endpoint available for playback fallback");
                     session = CreateSession(device);
@@ -145,7 +141,6 @@ namespace SoundSwitch.Audio.Manager.Playback
                 // Teardown on the owning thread: stop the stream, then release every COM reference.
                 session?.Dispose();
                 if (device != null) Marshal.ReleaseComObject(device);
-                if (enumerator != null) Marshal.ReleaseComObject(enumerator);
             }
         }
 
@@ -216,15 +211,25 @@ namespace SoundSwitch.Audio.Manager.Playback
             }
         }
 
-        private static IMMDevice? ResolveDevice(IMMDeviceEnumerator enumerator, string? deviceId)
+        private static IMMDevice? ResolveDevice(string? deviceId)
         {
-            var hr = string.IsNullOrEmpty(deviceId)
-                ? enumerator.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia, out var device)
-                : enumerator.GetDevice(deviceId, out device);
-            if (hr == HRESULT.S_OK && device != null) return device;
+            // Resolve the endpoint on the shared ComThread (via AudioSwitcher) and unmarshal the
+            // IMMDevice reference onto this thread. No private enumerator is ever constructed here.
+            var stream = AudioSwitcher.Instance.GetDeviceStream(deviceId);
+            if (stream == IntPtr.Zero)
+                return null;
 
-            if (device != null) Marshal.ReleaseComObject(device);
-            return null;
+            var iid = new Guid(ComGuid.AUDIO_IMMDEVICE_IID);
+            var hr = Ole32.CoGetInterfaceAndReleaseStream(stream, ref iid, out var devicePointer);
+            if (hr != HRESULT.S_OK || devicePointer == IntPtr.Zero)
+            {
+                if (devicePointer != IntPtr.Zero) Marshal.Release(devicePointer);
+                return null;
+            }
+
+            var device = (IMMDevice)Marshal.GetObjectForIUnknown(devicePointer);
+            Marshal.Release(devicePointer);
+            return device;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Fixes #2384 — custom-sound notification playback is 100% silent after the v7.3.0 in-house WASAPI rewrite.

A real user log (47 playback attempts) showed every notification throw:

```
System.InvalidCastException: Unable to cast object of type 'MMDeviceEnumeratorComObject' to type 'MMDeviceEnumeratorComObject'.
   at SoundSwitch.Audio.Manager.Playback.WavePlayer.Play() in ...\WavePlayer.cs:line 111
```

## Root cause

`WavePlayer.cs` declared its **own** `[ComImport, Guid(AUDIO_IMMDEVICE_ENUMERATOR_OBJECT_IID)] class MMDeviceEnumeratorComObject` that **duplicated** the identical class already in `AudioDeviceEnumerator.cs` — same GUID, same assembly. Two `[ComImport]` classes with the same GUID make the CLR's COM type identity for that object ambiguous, so the cast `(IMMDeviceEnumerator)new MMDeviceEnumeratorComObject()` on the renderer's private STA thread throws. Every other path resolves endpoints through `AudioSwitcher.Instance` on the shared `ComThread`, which is why device switching works but notifications never play.

## Fix

- Removed the duplicate `MMDeviceEnumeratorComObject` from `WavePlayer.cs`.
- Resolve the `IMMDevice` on the shared `ComThread` via `AudioSwitcher.Instance.GetDeviceStream(...)` using canonical COM inter-thread marshalling (`CoMarshalInterThreadInterfaceInStream` / `CoGetInterfaceAndReleaseStream`, new `Ole32.cs`). The renderer **unmarshals** the `IMMDevice` onto its own dedicated STA thread.
- The render loop still runs on its own STA thread, so the `ComThread` is never blocked by buffer waits and device switching is unaffected.
- Preserved the specific-device → default-render fallback, the cancellation/teardown (`finally` now releases `session` + `device`), and the `string.IsNullOrEmpty(_deviceId) ? "<default>" : _deviceId` logging convention.

## Files

- `WavePlayer.cs` — drop duplicate ComImport class; resolve `IMMDevice` via `AudioSwitcher`.
- `AudioDeviceEnumerator.cs` — add `MarshalDeviceToStream(...)` (ComThread-only).
- `AudioSwitcher.cs` — add `GetDeviceStream(...)` facade.
- `Interop/Com/Base/Ole32.cs` — new `CoMarshalInterThreadInterfaceInStream` / `CoGetInterfaceAndReleaseStream` P/Invokes.

## Verification

Validated by source review against the codebase's existing COM/threading conventions (the `Marshal.GetObjectForIUnknown` + `Marshal.Release` and `PreserveSig` HRESULT patterns match `AudioDevice.cs` / `AudioSwitcher.cs` exactly). The `dotnet` toolchain is unavailable on this Linux box and the CsWinRT/WinForms projects are Windows-only, so the Windows CI build is the authoritative compile gate.

Fixes #2384
