### PR TITLE
fix(audio): refresh cached device list on connect/disconnect swap (#2404)

### DIFF
--- a/SoundSwitch.Tests/RefreshDeviceTests.cs
+++ b/SoundSwitch.Tests/RefreshDeviceTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 
 using FluentAssertions;

--- a/SoundSwitch.Tests/RefreshDeviceTests.cs
+++ b/SoundSwitch.Tests/RefreshDeviceTests.cs
@@ -245,11 +245,15 @@ public class RefreshDeviceTests
 
     /// <summary>
     /// Records how many times Refresh() was invoked, so the test can observe whether an
-    /// inconclusive incremental update escalates to a full refresh (the #2404 fix).
+    /// inconclusive incremental update escalates to a full refresh (the #2404 fix). The
+    /// real Refresh runs on Windows CI; here we just count invocations (no COM) and optionally
+    /// signal a completion source once the bounded retry cascade has drained.
     /// </summary>
     private sealed class CountingLister : CachedAudioDeviceLister
     {
         public int RefreshCount { get; private set; }
+
+        public TaskCompletionSource<int>? CascadeCompletion { get; set; }
 
         public CountingLister(EDeviceState state) : base(state)
         {
@@ -259,8 +263,19 @@ public class RefreshDeviceTests
         {
             RefreshCount++;
             // Do not touch COM; the real Refresh runs on Windows CI. The escalate logic only
-            // cares that Refresh was requested.
+            // cares that Refresh was requested. Signal the test ONLY once the bounded retry
+            // cascade has fully drained (RefreshCount == MaxRetries), so the test doesn't wake
+            // early and assert the count before the background retries finish.
+            if (RefreshCount >= MaxRetries)
+            {
+                CascadeCompletion?.TrySetResult(RefreshCount);
+            }
         }
+
+        // Expose the retry-cap so the test can wait for the cascade to complete deterministically
+        // without flaking on timing. The cascade does (maxRetries) refreshes, so after that many
+        // invocations it has fully drained.
+        public int MaxRetries => 3;
     }
 
     [Test]
@@ -284,6 +299,34 @@ public class RefreshDeviceTests
 
         lister.RefreshCount.Should().BeGreaterThan(0,
             "an inconclusive incremental update must trigger a full refresh (issue #2404)");
+    }
+
+    [Test]
+    public void ForceRefresh_RetriesUntilEndpointAppears()
+    {
+        // Regression for the CodeRabbit finding on #2404: a single Refresh() snapshot can still miss
+        // an endpoint that only registers AFTER that snapshot was taken (mid Bluetooth-swap). The
+        // fix must retry a BOUNDED number of times so a late-appearing endpoint is eventually
+        // picked up, and must not retry forever (no storm / no hang).
+        var lister = new CountingLister(EDeviceState.Active | EDeviceState.Unplugged);
+
+        // Wait for the cascade to fully drain (the retry loop stops after MaxRetries refreshes).
+        var drained = new TaskCompletionSource<int>();
+        lister.CascadeCompletion = drained;
+
+        // Trigger the cascade the same way ProcessDeviceUpdates does on an inconclusive update.
+        lister.GetType()
+            .GetMethod("ForceRefresh", BindingFlags.Public | BindingFlags.Instance)!
+            .Invoke(lister, null);
+
+        // The bounded retry (MaxRetries = 3) must complete within a few seconds; if it retried
+        // forever this would time out / hang the test.
+        drained.Task.Wait(TimeSpan.FromSeconds(5))
+            .Should().BeTrue("the bounded ForceRefresh retry cascade must drain without hanging");
+
+        lister.RefreshCount.Should().Be(lister.MaxRetries,
+            "ForceRefresh must retry a bounded number of times (not once, not forever) so a " +
+            "late-registering endpoint is eventually captured (issue #2404)");
     }
 
     [Test]

--- a/SoundSwitch.Tests/RefreshDeviceTests.cs
+++ b/SoundSwitch.Tests/RefreshDeviceTests.cs
@@ -239,4 +239,87 @@ public class RefreshDeviceTests
         surviving.Disposed.Should().BeFalse("reused device is in the published cache, must NOT be disposed");
         fresh.Disposed.Should().BeFalse("fresh device is in the published cache, must NOT be disposed");
     }
+
+    /// <summary>
+    /// Records how many times Refresh() was invoked, so the test can observe whether an
+    /// inconclusive incremental update escalates to a full refresh (the #2404 fix).
+    /// </summary>
+    private sealed class CountingLister : CachedAudioDeviceLister
+    {
+        public int RefreshCount { get; private set; }
+
+        public CountingLister(EDeviceState state) : base(state)
+        {
+        }
+
+        public override void Refresh(CancellationToken cancellationToken = default)
+        {
+            RefreshCount++;
+            // Do not touch COM; the real Refresh runs on Windows CI. The escalate logic only
+            // cares that Refresh was requested.
+        }
+    }
+
+    [Test]
+    public void ProcessDeviceUpdates_InconclusiveEndpoint_EscalatesToForceRefresh()
+    {
+        // Regression for #2404: when the OS reports a device lifecycle change but the endpoint
+        // isn't queryable yet (transient mid Bluetooth-swap), ProcessDeviceUpdates must NOT
+        // silently drop the change. It must escalate to a full Refresh() so the cache self-heals
+        // instead of diverging until a restart.
+        var lister = new CountingLister(EDeviceState.Active | EDeviceState.Unplugged);
+
+        // An Added event whose endpoint can't be resolved (GetAudioEndpoint returns null on the
+        // real AudioSwitcher; here we rely on the same inconclusive branch being hit because the
+        // backing AudioSwitcher has no such device).
+        var events = new[]
+        {
+            new DeviceChangedEvent(EventType.Added, "nonexistent-device-id")
+        };
+
+        lister.ProcessDeviceUpdates(events);
+
+        lister.RefreshCount.Should().BeGreaterThan(0,
+            "an inconclusive incremental update must trigger a full refresh (issue #2404)");
+    }
+
+    [Test]
+    public void ProcessDeviceUpdates_SwapScenario_ReflectsDeviceRemoval()
+    {
+        // COM-free reproduction of the swap scenario: Device1 is removed and Device2 is added.
+        // After processing, Device1 must be gone from the cache and Device2 present, and the
+        // DeviceListRefreshed signal must have fired.
+        var lister = new CachedAudioDeviceLister(EDeviceState.Active | EDeviceState.Unplugged);
+
+        var playbackProperty = typeof(CachedAudioDeviceLister)
+            .GetProperty("PlaybackDevices", BindingFlags.NonPublic | BindingFlags.Instance);
+        var recordingProperty = typeof(CachedAudioDeviceLister)
+            .GetProperty("RecordingDevices", BindingFlags.NonPublic | BindingFlags.Instance);
+        playbackProperty.Should().NotBeNull();
+        recordingProperty.Should().NotBeNull();
+
+        // Seed only Device1 in the playback cache.
+        playbackProperty!.SetValue(lister, ImmutableDictionary.CreateRange(new Dictionary<string, DeviceFullInfo>
+        {
+            ["device1"] = new TrackedDevice("Buds A", "device1", EDataFlow.eRender, string.Empty, EDeviceState.Active, false)
+        }));
+        recordingProperty!.SetValue(lister, ImmutableDictionary.CreateRange(new Dictionary<string, DeviceFullInfo>()));
+
+        // The real AudioSwitcher won't resolve these ids on Linux, so Added(Device2) is
+        // inconclusive and escalates to Refresh() (which is a no-op here without COM). That still
+        // exercises the removal path: Removed(Device1) must evict it from the cache.
+        var refreshed = new List<Unit>();
+        using var sub = lister.DeviceListRefreshed.Subscribe(u => refreshed.Add(u));
+
+        lister.ProcessDeviceUpdates(new[]
+        {
+            new DeviceChangedEvent(EventType.Removed, "device1"),
+            new DeviceChangedEvent(EventType.Added, "device2")
+        });
+
+        var playback = (ImmutableDictionary<string, DeviceFullInfo>)playbackProperty.GetValue(lister)!;
+        playback.ContainsKey("device1").Should().BeFalse("removed device must be evicted from the cache");
+
+        refreshed.Should().NotBeEmpty("a removal must emit DeviceListRefreshed so the UI updates");
+    }
 }

--- a/SoundSwitch.Tests/RefreshDeviceTests.cs
+++ b/SoundSwitch.Tests/RefreshDeviceTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Reactive;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,6 +18,7 @@ using Serilog.Events;
 using SoundSwitch.Audio.Manager.Interop.Enum;
 using SoundSwitch.Common.Framework.Audio.Device;
 using SoundSwitch.Framework.Audio.Lister;
+using SoundSwitch.Model;
 
 namespace SoundSwitch.Tests;
 

--- a/SoundSwitch/Framework/Audio/Lister/CachedAudioDeviceLister.cs
+++ b/SoundSwitch/Framework/Audio/Lister/CachedAudioDeviceLister.cs
@@ -71,6 +71,13 @@ public class CachedAudioDeviceLister : IAudioDeviceLister
 
     private readonly ISubject<Unit> _deviceListRefreshed = new Subject<Unit>();
 
+    // Throttle for ForceRefresh so a burst of inconclusive incremental updates (e.g. several
+    // devices swapping within a few hundred ms) collapses into a single full re-enumeration
+    // instead of a refresh storm.
+    private readonly object _forceRefreshLock = new object();
+    private long _lastForceRefreshAt = -1;
+    private const long _forceRefreshWindow = 2000; // ms
+
     /// <summary>
     /// Observable that emits when the device list has been successfully and fully refreshed.
     /// Does not emit when a refresh is cancelled or fails.
@@ -180,6 +187,8 @@ public class CachedAudioDeviceLister : IAudioDeviceLister
     /// <exception cref="ArgumentOutOfRangeException"></exception>
     public void ProcessDeviceUpdates(IEnumerable<DeviceChangedEvent> deviceChangedEvents)
     {
+        var inconclusive = false;
+
         bool GetDevice(DeviceChangedEvent deviceChangedEvent, out DeviceFullInfo device)
         {
             device = AudioSwitcher.Instance.GetAudioEndpoint(deviceChangedEvent.DeviceId);
@@ -192,9 +201,15 @@ public class CachedAudioDeviceLister : IAudioDeviceLister
             return false;
         }
 
-        void UpdateDeviceCache(DeviceChangedEvent deviceChangedEvent)
+        // Returns false when the update was inconclusive (the endpoint couldn't be queried),
+        // signalling the caller to escalate to a full Refresh().
+        bool UpdateDeviceCache(DeviceChangedEvent deviceChangedEvent)
         {
-            if (GetDevice(deviceChangedEvent, out var device)) return;
+            // The endpoint couldn't be queried right now (transient during a connect/disconnect
+            // swap — the OS fires the lifecycle event before the device is fully registered).
+            // Signal inconclusive so the caller escalates to a full Refresh() rather than leaving
+            // this device missing from the cache until a restart.
+            if (GetDevice(deviceChangedEvent, out var device)) return false;
 
             // The lookup of the replaced device and the swap are a single atomic step under
             // _cacheLock, so we always dispose exactly the instance that was evicted and a
@@ -240,6 +255,7 @@ public class CachedAudioDeviceLister : IAudioDeviceLister
             }
 
             _context.Information("Updated device {deviceId} in cache", device.Id);
+            return true;
         }
 
         foreach (var deviceChangedEvent in deviceChangedEvents)
@@ -280,7 +296,14 @@ public class CachedAudioDeviceLister : IAudioDeviceLister
                     case EventType.Added:
                     case EventType.StateChanged:
                     case EventType.PropertyChanged:
-                        UpdateDeviceCache(deviceChangedEvent);
+                        if (!UpdateDeviceCache(deviceChangedEvent))
+                        {
+                            // The endpoint wasn't queryable right now (transient during a
+                            // connect/disconnect swap). Escalate to a full refresh so the cache
+                            // self-heals instead of diverging until a restart.
+                            inconclusive = true;
+                            break;
+                        }
                         _deviceListRefreshed.OnNext(Unit.Default);
                         break;
                     case EventType.DefaultChanged:
@@ -302,9 +325,38 @@ public class CachedAudioDeviceLister : IAudioDeviceLister
                 _context.Warning(e, "Couldn't process event: {event} for device {deviceId}", deviceChangedEvent.Action, deviceChangedEvent.DeviceId);
             }
         }
+
+        // An incremental update was inconclusive (an endpoint that the OS reported as
+        // added/changed wasn't queryable yet — typical mid-Bluetooth-swap). Rather than leave the
+        // cache stale until the next restart, reconcile it against a full re-enumeration.
+        if (inconclusive)
+        {
+            ForceRefresh();
+        }
     }
 
-    public void Refresh(CancellationToken cancellationToken = default)
+    /// <summary>
+    /// Force a full re-enumeration of the device list from the OS. Unlike the incremental
+    /// <see cref="ProcessDeviceUpdates"/> path (which can silently fail to apply a lifecycle
+    /// event when the endpoint isn't queryable yet, e.g. mid-Bluetooth-swap), a full refresh
+    /// always reconciles the cache against reality. Throttled so a burst of failed incremental
+    /// updates collapses into at most one refresh per <see cref="_forceRefreshWindow"/>.
+    /// </summary>
+    public void ForceRefresh()
+    {
+        var now = Environment.TickCount64;
+        lock (_forceRefreshLock)
+        {
+            if (now - _lastForceRefreshAt < _forceRefreshWindow)
+                return;
+            _lastForceRefreshAt = now;
+        }
+
+        _context.Information("Incremental update was inconclusive; triggering full refresh");
+        Refresh();
+    }
+
+    public virtual void Refresh(CancellationToken cancellationToken = default)
     {
         var logContext = _context.ForContext("TaskID", Task.CurrentId).ForContext("ThreadID", Environment.CurrentManagedThreadId);
         // Cancel the previous refresh operation, if any

--- a/SoundSwitch/Framework/Audio/Lister/CachedAudioDeviceLister.cs
+++ b/SoundSwitch/Framework/Audio/Lister/CachedAudioDeviceLister.cs
@@ -72,11 +72,19 @@ public class CachedAudioDeviceLister : IAudioDeviceLister
     private readonly ISubject<Unit> _deviceListRefreshed = new Subject<Unit>();
 
     // Throttle for ForceRefresh so a burst of inconclusive incremental updates (e.g. several
-    // devices swapping within a few hundred ms) collapses into a single full re-enumeration
-    // instead of a refresh storm.
+    // devices swapping within a few hundred ms) collapses into a single refresh cascade instead
+    // of a refresh storm. Retries within a cascade bypass this window (see ForceRefresh).
     private readonly object _forceRefreshLock = new object();
     private long _lastForceRefreshAt = -1;
     private const long _forceRefreshWindow = 2000; // ms
+    // Bounded retry: a single Refresh() snapshot can still miss an endpoint that only registers
+    // AFTER that snapshot was taken (mid Bluetooth-swap: the OS fires the lifecycle event, then the
+    // device appears in the enumerator a beat later). We retry a fixed number of times on a short,
+    // growing delay so the cache self-heals instead of diverging until a restart.
+    private const int _forceRefreshMaxRetries = 3;
+    private const int _forceRefreshRetryDelayMs = 300;
+    private int _forceRefreshRetries;
+    private volatile bool _disposed;
 
     /// <summary>
     /// Observable that emits when the device list has been successfully and fully refreshed.
@@ -347,13 +355,56 @@ public class CachedAudioDeviceLister : IAudioDeviceLister
         var now = Environment.TickCount64;
         lock (_forceRefreshLock)
         {
-            if (now - _lastForceRefreshAt < _forceRefreshWindow)
+            // The initial escalation is throttled so a burst of inconclusive incremental updates
+            // collapses into one refresh cascade. Scheduled retries re-enter here with
+            // _forceRefreshRetries > 0 and bypass the throttle so the cascade can complete rather
+            // than be starved by the window.
+            if (_forceRefreshRetries == 0 && now - _lastForceRefreshAt < _forceRefreshWindow)
                 return;
             _lastForceRefreshAt = now;
         }
 
-        _context.Information("Incremental update was inconclusive; triggering full refresh");
+        if (_disposed)
+        {
+            Interlocked.Exchange(ref _forceRefreshRetries, 0);
+            return;
+        }
+
+        _context.Information("Incremental update was inconclusive; triggering full refresh (attempt {Attempt})", _forceRefreshRetries + 1);
         Refresh();
+
+        // A single snapshot can still miss an endpoint that only registers AFTER this refresh ran
+        // (typical mid Bluetooth-swap). Retry a bounded number of times on a short, growing delay so
+        // the cache self-heals instead of staying stale until the next restart or OS event.
+        var attempt = Interlocked.Increment(ref _forceRefreshRetries);
+        if (attempt < _forceRefreshMaxRetries)
+        {
+            _ = Task.Delay(_forceRefreshRetryDelayMs * attempt)
+                .ContinueWith(_ => RetryForceRefresh(), TaskScheduler.Default);
+        }
+        else
+        {
+            Interlocked.Exchange(ref _forceRefreshRetries, 0);
+        }
+    }
+
+    private void RetryForceRefresh()
+    {
+        try
+        {
+            if (_disposed)
+            {
+                Interlocked.Exchange(ref _forceRefreshRetries, 0);
+                return;
+            }
+
+            ForceRefresh();
+        }
+        catch (Exception e)
+        {
+            _context.Warning(e, "ForceRefresh retry failed; stopping the cascade");
+            Interlocked.Exchange(ref _forceRefreshRetries, 0);
+        }
     }
 
     public virtual void Refresh(CancellationToken cancellationToken = default)
@@ -569,6 +620,8 @@ public class CachedAudioDeviceLister : IAudioDeviceLister
 
     public void Dispose()
     {
+        _disposed = true;
+
         // Swap both caches to Empty under the lock so no concurrent mutation can reintroduce a
         // device after the snapshot, then dispose the captured devices outside the lock.
         DeviceFullInfo[] oldDevices;

--- a/SoundSwitch/Model/IAudioDeviceLister.cs
+++ b/SoundSwitch/Model/IAudioDeviceLister.cs
@@ -58,4 +58,12 @@ public interface IAudioDeviceLister : IDisposable
     /// <param name="deviceChangedEvents"></param>
     /// <exception cref="ArgumentOutOfRangeException"></exception>
     void ProcessDeviceUpdates(IEnumerable<DeviceChangedEvent> deviceChangedEvents);
+
+    /// <summary>
+    /// Trigger a full device re-enumeration. Used as a fallback when an incremental
+    /// (event-driven) update cannot be applied — e.g. the OS reported a device lifecycle
+    /// change but the endpoint wasn't fully queryable yet, which would otherwise leave the
+    /// cache stale until the next restart.
+    /// </summary>
+    void ForceRefresh();
 }


### PR DESCRIPTION
Fixes #2404.

## Root cause
The cached device list is updated incrementally from OS device-notification events via `CachedAudioDeviceLister.ProcessDeviceUpdates`. When Windows reports a device lifecycle change (e.g. a Bluetooth earbud being connected/disconnected) it can fire the event **before** the endpoint is fully queryable, so `AudioSwitcher.GetAudioEndpoint(id)` transiently returns `null`. That `Added`/`StateChanged` event was silently dropped, leaving the cache stale — Device1 stayed "selected", Device2 stayed "Disconnected" — until the app was restarted. This is the regression users hit in v7.3.x.

## Fix
- Add `CachedAudioDeviceLister.ForceRefresh()` (throttled full re-enumeration) + `IAudioDeviceLister.ForceRefresh()`.
- `ProcessDeviceUpdates` now escalates to `ForceRefresh()` when an `Added`/`StateChanged`/`PropertyChanged` event's endpoint can't be resolved, so the cache self-heals against the real device state instead of diverging until restart.
- Removal (`Removed`) and default-device paths are unchanged.

## Tests
- `ProcessDeviceUpdates_InconclusiveEndpoint_EscalatesToForceRefresh` — an unresolvable endpoint triggers a full refresh.
- `ProcessDeviceUpdates_SwapScenario_ReflectsDeviceRemoval` — a Remove+Add swap evicts the old device and emits `DeviceListRefreshed`.

Note: the full solution cannot be compiled on Linux (CsWinRT projection in `SoundSwitch.Audio.Manager` requires Windows), so the real compile/test gate is the Windows CI `build / build` job.