### PR TITLE
fix(audio): resolve device by id via enumeration fallback (#2404)

### DIFF
--- a/SoundSwitch.Audio.Manager.Tests/AudioDeviceEnumeratorGetDeviceTests.cs
+++ b/SoundSwitch.Audio.Manager.Tests/AudioDeviceEnumeratorGetDeviceTests.cs
@@ -1,0 +1,60 @@
+using System;
+
+using FluentAssertions;
+
+using NUnit.Framework;
+
+using SoundSwitch.Audio.Manager.Interop.Enum;
+
+namespace SoundSwitch.Audio.Manager.Tests;
+
+/// <summary>
+/// Regression tests for issue #2404: resolving a device by id must survive the window where
+/// the OS fires a device lifecycle event before the endpoint is fully registered. The
+/// round-trip exercises the real COM path (direct lookup + enumeration fallback); the bogus
+/// id covers the fallback-then-null path. Real COM is expected here: these tests only run
+/// where the Windows audio stack exists.
+/// </summary>
+[TestFixture]
+public sealed class AudioDeviceEnumeratorGetDeviceTests
+{
+    private const string NonExistentDeviceId = "does-not-exist-id";
+
+    [Test]
+    [Platform("Win")]
+    public void GetDevice_ReturnsDevice_WhenResolvingAnEnumeratedEndpoint()
+    {
+        var switcher = SoundSwitch.Audio.Manager.AudioSwitcher.Instance;
+        var devices = switcher.GetAudioDevices(EDataFlow.eAll, EDeviceState.Active);
+
+        // The round-trip is only meaningful when the machine exposes at least one endpoint.
+        Assume.That(devices, Is.Not.Null.And.Not.Empty);
+
+        var expectedId = devices![0].Id;
+
+        try
+        {
+            using var resolved = switcher.GetDevice(expectedId);
+
+            resolved.Should().NotBeNull("a registered endpoint must be resolvable by id");
+            resolved!.Id.Should().Be(expectedId);
+        }
+        finally
+        {
+            foreach (var device in devices!) device.Dispose();
+        }
+    }
+
+    [Test]
+    [Platform("Win")]
+    public void GetDevice_ReturnsNull_WhenIdDoesNotExist()
+    {
+        var switcher = SoundSwitch.Audio.Manager.AudioSwitcher.Instance;
+
+        AudioDevice? resolved = null;
+        Action act = () => resolved = switcher.GetDevice(NonExistentDeviceId);
+
+        act.Should().NotThrow("an unknown id must resolve to null instead of propagating a COM failure");
+        resolved.Should().BeNull("the enumeration fallback must not fabricate a device");
+    }
+}

--- a/SoundSwitch.Audio.Manager/Interop/Client/AudioDeviceEnumerator.cs
+++ b/SoundSwitch.Audio.Manager/Interop/Client/AudioDeviceEnumerator.cs
@@ -102,19 +102,38 @@ namespace SoundSwitch.Audio.Manager.Interop.Client
                 if (device != null) Marshal.ReleaseComObject(device);
 
                 Logger.Information("IMMDeviceEnumerator.GetDevice({DeviceId}) failed with HR {HR}: falling back to endpoint enumeration", deviceId, hr);
-                foreach (var endpoint in GetEndpoints(EDataFlow.eAll, EDeviceState.All))
+                var endpoints = GetEndpoints(EDataFlow.eAll, EDeviceState.All);
+                AudioDevice? resolved = null;
+                try
                 {
-                    if (endpoint.Id == deviceId)
+                    foreach (var endpoint in endpoints)
                     {
-                        Logger.Information("Resolved device {DeviceId} via enumeration fallback", deviceId);
-                        return endpoint;
+                        if (endpoint.Id == deviceId)
+                        {
+                            resolved = endpoint;
+                            break;
+                        }
                     }
 
-                    endpoint.Dispose();
-                }
+                    if (resolved != null)
+                    {
+                        Logger.Information("Resolved device {DeviceId} via enumeration fallback", deviceId);
+                        return resolved;
+                    }
 
-                Logger.Warning("Device {DeviceId} not found: direct lookup failed with HR {HR} and enumeration fallback found no match", deviceId, hr);
-                return null;
+                    Logger.Warning("Device {DeviceId} not found: direct lookup failed with HR {HR} and enumeration fallback found no match", deviceId, hr);
+                    return null;
+                }
+                finally
+                {
+                    // Dispose every enumerated endpoint except the one we return, so a successful
+                    // match that isn't the final list item doesn't leak its COM reference until GC.
+                    foreach (var endpoint in endpoints)
+                    {
+                        if (!ReferenceEquals(endpoint, resolved))
+                            endpoint.Dispose();
+                    }
+                }
             }
             catch
             {

--- a/SoundSwitch.Audio.Manager/Interop/Client/AudioDeviceEnumerator.cs
+++ b/SoundSwitch.Audio.Manager/Interop/Client/AudioDeviceEnumerator.cs
@@ -3,6 +3,8 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
+using Serilog;
+
 using SoundSwitch.Audio.Manager.Interop.Com.Threading;
 using SoundSwitch.Audio.Manager.Interop.Enum;
 using SoundSwitch.Audio.Manager.Interop.Interface;
@@ -17,6 +19,8 @@ namespace SoundSwitch.Audio.Manager.Interop.Client
     /// </summary>
     internal sealed class AudioDeviceEnumerator : IDisposable
     {
+        private static readonly ILogger Logger = Log.ForContext<AudioDeviceEnumerator>();
+
         [ComImport, Guid(ComGuid.AUDIO_IMMDEVICE_ENUMERATOR_OBJECT_IID)]
         private class MMDeviceEnumeratorComObject
         {
@@ -80,19 +84,37 @@ namespace SoundSwitch.Audio.Manager.Interop.Client
         /// <summary>
         /// Get device with the given id
         /// </summary>
+        /// <remarks>
+        /// The direct <c>IMMDeviceEnumerator::GetDevice</c> lookup legitimately fails with E_NOTFOUND
+        /// when the OS fires a device lifecycle event before the endpoint is fully registered
+        /// (typical mid Bluetooth-swap). In that window the call falls back to a full enumeration
+        /// (issue #2404) instead of silently dropping the device from the cache.
+        /// </remarks>
         public AudioDevice? GetDevice(string deviceId)
         {
             ComThread.Assert();
             try
             {
                 var hr = _enumerator.GetDevice(deviceId, out var device);
-                if (hr != HRESULT.S_OK || device == null)
+                if (hr == HRESULT.S_OK && device != null)
+                    return new AudioDevice(device);
+
+                if (device != null) Marshal.ReleaseComObject(device);
+
+                Logger.Information("IMMDeviceEnumerator.GetDevice({DeviceId}) failed with HR {HR}: falling back to endpoint enumeration", deviceId, hr);
+                foreach (var endpoint in GetEndpoints(EDataFlow.eAll, EDeviceState.All))
                 {
-                    if (device != null) Marshal.ReleaseComObject(device);
-                    return null;
+                    if (endpoint.Id == deviceId)
+                    {
+                        Logger.Information("Resolved device {DeviceId} via enumeration fallback", deviceId);
+                        return endpoint;
+                    }
+
+                    endpoint.Dispose();
                 }
 
-                return new AudioDevice(device);
+                Logger.Warning("Device {DeviceId} not found: direct lookup failed with HR {HR} and enumeration fallback found no match", deviceId, hr);
+                return null;
             }
             catch
             {

--- a/SoundSwitch.Audio.Manager/Interop/Com/Threading/ComThread.cs
+++ b/SoundSwitch.Audio.Manager/Interop/Com/Threading/ComThread.cs
@@ -55,19 +55,12 @@ namespace SoundSwitch.Audio.Manager.Interop.Com.Threading
 
         private static Task<T> BeginInvoke<T>(Func<T> func)
         {
-            return Task<T>.Factory.StartNew(() =>
-            {
-                try
-                {
-                    return func();
-                }
-                catch (Exception e)
-                {
-                    Log.Warning(e, "Issue while running func in {class}", nameof(ComThread));
-                    return default;
-                }
-               
-            }, CancellationToken.None, TaskCreationOptions.None, Scheduler);
+            // Exceptions are deliberately NOT caught here: the faulted Task rethrows through
+            // Invoke<T>'s GetAwaiter().GetResult(), so the caller sees the real failure instead
+            // of a silent default(T) ("no device") result. Issue #2404: converting a transient
+            // COM failure into null made devices disappear from the cache until a full restart.
+            // The void BeginInvoke(Action) overload stays tolerant on purpose.
+            return Task<T>.Factory.StartNew(func, CancellationToken.None, TaskCreationOptions.None, Scheduler);
         }
     }
 }

--- a/SoundSwitch.Tests/RefreshDeviceTests.cs
+++ b/SoundSwitch.Tests/RefreshDeviceTests.cs
@@ -2,9 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Reactive;
 using System.Reflection;
-using System.Threading;
 using System.Threading.Tasks;
 
 using FluentAssertions;
@@ -18,7 +16,6 @@ using Serilog.Events;
 using SoundSwitch.Audio.Manager.Interop.Enum;
 using SoundSwitch.Common.Framework.Audio.Device;
 using SoundSwitch.Framework.Audio.Lister;
-using SoundSwitch.Model;
 
 namespace SoundSwitch.Tests;
 
@@ -241,131 +238,5 @@ public class RefreshDeviceTests
         removed.Disposed.Should().BeTrue("device absent from the published cache must be disposed");
         surviving.Disposed.Should().BeFalse("reused device is in the published cache, must NOT be disposed");
         fresh.Disposed.Should().BeFalse("fresh device is in the published cache, must NOT be disposed");
-    }
-
-    /// <summary>
-    /// Records how many times Refresh() was invoked, so the test can observe whether an
-    /// inconclusive incremental update escalates to a full refresh (the #2404 fix). The
-    /// real Refresh runs on Windows CI; here we just count invocations (no COM) and optionally
-    /// signal a completion source once the bounded retry cascade has drained.
-    /// </summary>
-    private sealed class CountingLister : CachedAudioDeviceLister
-    {
-        public int RefreshCount { get; private set; }
-
-        public TaskCompletionSource<int>? CascadeCompletion { get; set; }
-
-        public CountingLister(EDeviceState state) : base(state)
-        {
-        }
-
-        public override void Refresh(CancellationToken cancellationToken = default)
-        {
-            RefreshCount++;
-            // Do not touch COM; the real Refresh runs on Windows CI. The escalate logic only
-            // cares that Refresh was requested. Signal the test ONLY once the bounded retry
-            // cascade has fully drained (RefreshCount == MaxRetries), so the test doesn't wake
-            // early and assert the count before the background retries finish.
-            if (RefreshCount >= MaxRetries)
-            {
-                CascadeCompletion?.TrySetResult(RefreshCount);
-            }
-        }
-
-        // Expose the retry-cap so the test can wait for the cascade to complete deterministically
-        // without flaking on timing. The cascade does (maxRetries) refreshes, so after that many
-        // invocations it has fully drained.
-        public int MaxRetries => 3;
-    }
-
-    [Test]
-    public void ProcessDeviceUpdates_InconclusiveEndpoint_EscalatesToForceRefresh()
-    {
-        // Regression for #2404: when the OS reports a device lifecycle change but the endpoint
-        // isn't queryable yet (transient mid Bluetooth-swap), ProcessDeviceUpdates must NOT
-        // silently drop the change. It must escalate to a full Refresh() so the cache self-heals
-        // instead of diverging until a restart.
-        var lister = new CountingLister(EDeviceState.Active | EDeviceState.Unplugged);
-
-        // An Added event whose endpoint can't be resolved (GetAudioEndpoint returns null on the
-        // real AudioSwitcher; here we rely on the same inconclusive branch being hit because the
-        // backing AudioSwitcher has no such device).
-        var events = new[]
-        {
-            new DeviceChangedEvent(EventType.Added, "nonexistent-device-id")
-        };
-
-        lister.ProcessDeviceUpdates(events);
-
-        lister.RefreshCount.Should().BeGreaterThan(0,
-            "an inconclusive incremental update must trigger a full refresh (issue #2404)");
-    }
-
-    [Test]
-    public void ForceRefresh_RetriesUntilEndpointAppears()
-    {
-        // Regression for the CodeRabbit finding on #2404: a single Refresh() snapshot can still miss
-        // an endpoint that only registers AFTER that snapshot was taken (mid Bluetooth-swap). The
-        // fix must retry a BOUNDED number of times so a late-appearing endpoint is eventually
-        // picked up, and must not retry forever (no storm / no hang).
-        var lister = new CountingLister(EDeviceState.Active | EDeviceState.Unplugged);
-
-        // Wait for the cascade to fully drain (the retry loop stops after MaxRetries refreshes).
-        var drained = new TaskCompletionSource<int>();
-        lister.CascadeCompletion = drained;
-
-        // Trigger the cascade the same way ProcessDeviceUpdates does on an inconclusive update.
-        lister.GetType()
-            .GetMethod("ForceRefresh", BindingFlags.Public | BindingFlags.Instance)!
-            .Invoke(lister, null);
-
-        // The bounded retry (MaxRetries = 3) must complete within a few seconds; if it retried
-        // forever this would time out / hang the test.
-        drained.Task.Wait(TimeSpan.FromSeconds(5))
-            .Should().BeTrue("the bounded ForceRefresh retry cascade must drain without hanging");
-
-        lister.RefreshCount.Should().Be(lister.MaxRetries,
-            "ForceRefresh must retry a bounded number of times (not once, not forever) so a " +
-            "late-registering endpoint is eventually captured (issue #2404)");
-    }
-
-    [Test]
-    public void ProcessDeviceUpdates_SwapScenario_ReflectsDeviceRemoval()
-    {
-        // COM-free reproduction of the swap scenario: Device1 is removed and Device2 is added.
-        // After processing, Device1 must be gone from the cache and Device2 present, and the
-        // DeviceListRefreshed signal must have fired.
-        var lister = new CachedAudioDeviceLister(EDeviceState.Active | EDeviceState.Unplugged);
-
-        var playbackProperty = typeof(CachedAudioDeviceLister)
-            .GetProperty("PlaybackDevices", BindingFlags.NonPublic | BindingFlags.Instance);
-        var recordingProperty = typeof(CachedAudioDeviceLister)
-            .GetProperty("RecordingDevices", BindingFlags.NonPublic | BindingFlags.Instance);
-        playbackProperty.Should().NotBeNull();
-        recordingProperty.Should().NotBeNull();
-
-        // Seed only Device1 in the playback cache.
-        playbackProperty!.SetValue(lister, ImmutableDictionary.CreateRange(new Dictionary<string, DeviceFullInfo>
-        {
-            ["device1"] = new TrackedDevice("Buds A", "device1", EDataFlow.eRender, string.Empty, EDeviceState.Active, false)
-        }));
-        recordingProperty!.SetValue(lister, ImmutableDictionary.CreateRange(new Dictionary<string, DeviceFullInfo>()));
-
-        // The real AudioSwitcher won't resolve these ids on Linux, so Added(Device2) is
-        // inconclusive and escalates to Refresh() (which is a no-op here without COM). That still
-        // exercises the removal path: Removed(Device1) must evict it from the cache.
-        var refreshed = new List<Unit>();
-        using var sub = lister.DeviceListRefreshed.Subscribe(u => refreshed.Add(u));
-
-        lister.ProcessDeviceUpdates(new[]
-        {
-            new DeviceChangedEvent(EventType.Removed, "device1"),
-            new DeviceChangedEvent(EventType.Added, "device2")
-        });
-
-        var playback = (ImmutableDictionary<string, DeviceFullInfo>)playbackProperty.GetValue(lister)!;
-        playback.ContainsKey("device1").Should().BeFalse("removed device must be evicted from the cache");
-
-        refreshed.Should().NotBeEmpty("a removal must emit DeviceListRefreshed so the UI updates");
     }
 }

--- a/SoundSwitch/Framework/Audio/Lister/CachedAudioDeviceLister.cs
+++ b/SoundSwitch/Framework/Audio/Lister/CachedAudioDeviceLister.cs
@@ -71,21 +71,6 @@ public class CachedAudioDeviceLister : IAudioDeviceLister
 
     private readonly ISubject<Unit> _deviceListRefreshed = new Subject<Unit>();
 
-    // Throttle for ForceRefresh so a burst of inconclusive incremental updates (e.g. several
-    // devices swapping within a few hundred ms) collapses into a single refresh cascade instead
-    // of a refresh storm. Retries within a cascade bypass this window (see ForceRefresh).
-    private readonly object _forceRefreshLock = new object();
-    private long _lastForceRefreshAt = -1;
-    private const long _forceRefreshWindow = 2000; // ms
-    // Bounded retry: a single Refresh() snapshot can still miss an endpoint that only registers
-    // AFTER that snapshot was taken (mid Bluetooth-swap: the OS fires the lifecycle event, then the
-    // device appears in the enumerator a beat later). We retry a fixed number of times on a short,
-    // growing delay so the cache self-heals instead of diverging until a restart.
-    private const int _forceRefreshMaxRetries = 3;
-    private const int _forceRefreshRetryDelayMs = 300;
-    private int _forceRefreshRetries;
-    private volatile bool _disposed;
-
     /// <summary>
     /// Observable that emits when the device list has been successfully and fully refreshed.
     /// Does not emit when a refresh is cancelled or fails.
@@ -195,8 +180,6 @@ public class CachedAudioDeviceLister : IAudioDeviceLister
     /// <exception cref="ArgumentOutOfRangeException"></exception>
     public void ProcessDeviceUpdates(IEnumerable<DeviceChangedEvent> deviceChangedEvents)
     {
-        var inconclusive = false;
-
         bool GetDevice(DeviceChangedEvent deviceChangedEvent, out DeviceFullInfo device)
         {
             device = AudioSwitcher.Instance.GetAudioEndpoint(deviceChangedEvent.DeviceId);
@@ -209,15 +192,9 @@ public class CachedAudioDeviceLister : IAudioDeviceLister
             return false;
         }
 
-        // Returns false when the update was inconclusive (the endpoint couldn't be queried),
-        // signalling the caller to escalate to a full Refresh().
-        bool UpdateDeviceCache(DeviceChangedEvent deviceChangedEvent)
+        void UpdateDeviceCache(DeviceChangedEvent deviceChangedEvent)
         {
-            // The endpoint couldn't be queried right now (transient during a connect/disconnect
-            // swap — the OS fires the lifecycle event before the device is fully registered).
-            // Signal inconclusive so the caller escalates to a full Refresh() rather than leaving
-            // this device missing from the cache until a restart.
-            if (GetDevice(deviceChangedEvent, out var device)) return false;
+            if (GetDevice(deviceChangedEvent, out var device)) return;
 
             // The lookup of the replaced device and the swap are a single atomic step under
             // _cacheLock, so we always dispose exactly the instance that was evicted and a
@@ -263,7 +240,6 @@ public class CachedAudioDeviceLister : IAudioDeviceLister
             }
 
             _context.Information("Updated device {deviceId} in cache", device.Id);
-            return true;
         }
 
         foreach (var deviceChangedEvent in deviceChangedEvents)
@@ -304,14 +280,7 @@ public class CachedAudioDeviceLister : IAudioDeviceLister
                     case EventType.Added:
                     case EventType.StateChanged:
                     case EventType.PropertyChanged:
-                        if (!UpdateDeviceCache(deviceChangedEvent))
-                        {
-                            // The endpoint wasn't queryable right now (transient during a
-                            // connect/disconnect swap). Escalate to a full refresh so the cache
-                            // self-heals instead of diverging until a restart.
-                            inconclusive = true;
-                            break;
-                        }
+                        UpdateDeviceCache(deviceChangedEvent);
                         _deviceListRefreshed.OnNext(Unit.Default);
                         break;
                     case EventType.DefaultChanged:
@@ -333,81 +302,9 @@ public class CachedAudioDeviceLister : IAudioDeviceLister
                 _context.Warning(e, "Couldn't process event: {event} for device {deviceId}", deviceChangedEvent.Action, deviceChangedEvent.DeviceId);
             }
         }
-
-        // An incremental update was inconclusive (an endpoint that the OS reported as
-        // added/changed wasn't queryable yet — typical mid-Bluetooth-swap). Rather than leave the
-        // cache stale until the next restart, reconcile it against a full re-enumeration.
-        if (inconclusive)
-        {
-            ForceRefresh();
-        }
     }
 
-    /// <summary>
-    /// Force a full re-enumeration of the device list from the OS. Unlike the incremental
-    /// <see cref="ProcessDeviceUpdates"/> path (which can silently fail to apply a lifecycle
-    /// event when the endpoint isn't queryable yet, e.g. mid-Bluetooth-swap), a full refresh
-    /// always reconciles the cache against reality. Throttled so a burst of failed incremental
-    /// updates collapses into at most one refresh per <see cref="_forceRefreshWindow"/>.
-    /// </summary>
-    public void ForceRefresh()
-    {
-        var now = Environment.TickCount64;
-        lock (_forceRefreshLock)
-        {
-            // The initial escalation is throttled so a burst of inconclusive incremental updates
-            // collapses into one refresh cascade. Scheduled retries re-enter here with
-            // _forceRefreshRetries > 0 and bypass the throttle so the cascade can complete rather
-            // than be starved by the window.
-            if (_forceRefreshRetries == 0 && now - _lastForceRefreshAt < _forceRefreshWindow)
-                return;
-            _lastForceRefreshAt = now;
-        }
-
-        if (_disposed)
-        {
-            Interlocked.Exchange(ref _forceRefreshRetries, 0);
-            return;
-        }
-
-        _context.Information("Incremental update was inconclusive; triggering full refresh (attempt {Attempt})", _forceRefreshRetries + 1);
-        Refresh();
-
-        // A single snapshot can still miss an endpoint that only registers AFTER this refresh ran
-        // (typical mid Bluetooth-swap). Retry a bounded number of times on a short, growing delay so
-        // the cache self-heals instead of staying stale until the next restart or OS event.
-        var attempt = Interlocked.Increment(ref _forceRefreshRetries);
-        if (attempt < _forceRefreshMaxRetries)
-        {
-            _ = Task.Delay(_forceRefreshRetryDelayMs * attempt)
-                .ContinueWith(_ => RetryForceRefresh(), TaskScheduler.Default);
-        }
-        else
-        {
-            Interlocked.Exchange(ref _forceRefreshRetries, 0);
-        }
-    }
-
-    private void RetryForceRefresh()
-    {
-        try
-        {
-            if (_disposed)
-            {
-                Interlocked.Exchange(ref _forceRefreshRetries, 0);
-                return;
-            }
-
-            ForceRefresh();
-        }
-        catch (Exception e)
-        {
-            _context.Warning(e, "ForceRefresh retry failed; stopping the cascade");
-            Interlocked.Exchange(ref _forceRefreshRetries, 0);
-        }
-    }
-
-    public virtual void Refresh(CancellationToken cancellationToken = default)
+    public void Refresh(CancellationToken cancellationToken = default)
     {
         var logContext = _context.ForContext("TaskID", Task.CurrentId).ForContext("ThreadID", Environment.CurrentManagedThreadId);
         // Cancel the previous refresh operation, if any
@@ -620,8 +517,6 @@ public class CachedAudioDeviceLister : IAudioDeviceLister
 
     public void Dispose()
     {
-        _disposed = true;
-
         // Swap both caches to Empty under the lock so no concurrent mutation can reintroduce a
         // device after the snapshot, then dispose the captured devices outside the lock.
         DeviceFullInfo[] oldDevices;

--- a/SoundSwitch/Model/IAudioDeviceLister.cs
+++ b/SoundSwitch/Model/IAudioDeviceLister.cs
@@ -58,12 +58,4 @@ public interface IAudioDeviceLister : IDisposable
     /// <param name="deviceChangedEvents"></param>
     /// <exception cref="ArgumentOutOfRangeException"></exception>
     void ProcessDeviceUpdates(IEnumerable<DeviceChangedEvent> deviceChangedEvents);
-
-    /// <summary>
-    /// Trigger a full device re-enumeration. Used as a fallback when an incremental
-    /// (event-driven) update cannot be applied — e.g. the OS reported a device lifecycle
-    /// change but the endpoint wasn't fully queryable yet, which would otherwise leave the
-    /// cache stale until the next restart.
-    /// </summary>
-    void ForceRefresh();
 }


### PR DESCRIPTION
Fixes #2404.

## Root cause

The by-id device resolver `AudioDeviceEnumerator.GetDevice(id)` calls native `IMMDeviceEnumerator::GetDevice(id)` and returns null when the OS fires a device lifecycle event *before* the endpoint is fully registered — the typical mid Bluetooth-swap window. This is normal Windows behavior: `GetDevice` legitimately returns E_NOTFOUND there. NAudio's equivalent makes the identical native call and only "works" because its callers fall back on failure. Our code just returned null, so the device was silently dropped from the cache until a full app restart.

The band-aid PR #2405 (0cc81fb8) papered over this with a `ForceRefresh()` retry cascade; it has been **reverted** on this branch (60dba39c) and is not reintroduced.

## Fix (approach A)

- **`AudioDeviceEnumerator.GetDevice(id)`** keeps its `ComThread.Assert()` and the try/catch that returns null on genuine errors. When the direct `_enumerator.GetDevice(deviceId, out device)` returns non-`S_OK`, it now falls back to enumeration: `GetEndpoints(EDataFlow.eAll, EDeviceState.All)`, returning the `AudioDevice` whose `Id` matches; null if still not found. Non-matching endpoints are disposed; the fallback is logged at Information (used + result) and Warning when it finds no match.
- **`ComThread.BeginInvoke<T>`** no longer swallows exceptions inside the invoked func into `default(T)` — that conversion turned transient COM failures into a silent "no device". The faulted Task now rethrows through `Invoke<T>`'s `GetAwaiter().GetResult()`, so callers see the real failure. The void `BeginInvoke(Action)` overload stays tolerant as before. `AudioSwitcher.GetDevice` still honors its null contract because `AudioDeviceEnumerator.GetDevice` catches genuine errors itself.

## Regression tests

New `AudioDeviceEnumeratorGetDeviceTests` in `SoundSwitch.Audio.Manager.Tests` (NUnit + FluentAssertions, `[Platform("Win")]`, real COM — runs on the Windows CI job `SoundSwitch.Audio.Manager.Tests`):

- Round-trip: enumerate real endpoints, pick one id, assert `GetDevice(id)` returns a non-null `AudioDevice` with the same `Id` (direct COM path, guarded against regressions).
- A non-existent id ("does-not-exist-id") returns null without throwing (fallback-then-null path).

## Validation

Cannot build on Linux (`cswinrt.exe` prebuild in `SoundSwitch.Audio.Manager` is Windows-only); namespaces/usings/signatures were audited manually. Compilation and the audio test suite are validated by the Windows GitHub Actions CI on this push.