### PR TITLE
fix(audio): treat S_FALSE as success for IAudioEndpointVolume calls (#2409)

### DIFF
--- a/SoundSwitch.Audio.Manager/AudioEndpointVolumeClient.cs
+++ b/SoundSwitch.Audio.Manager/AudioEndpointVolumeClient.cs
@@ -40,14 +40,14 @@ namespace SoundSwitch.Audio.Manager
             get => ComThread.Invoke(() =>
             {
                 var hr = _volume.GetMasterVolumeLevelScalar(out var level);
-                if (hr != HRESULT.S_OK) throw AudioDeviceException.FromHResult(hr, "IAudioEndpointVolume.GetMasterVolumeLevelScalar");
+                if (hr.Failed()) throw AudioDeviceException.FromHResult(hr, "IAudioEndpointVolume.GetMasterVolumeLevelScalar");
                 return level;
             });
             set => ComThread.Invoke(() =>
             {
                 var eventContext = Guid.Empty;
                 var hr = _volume.SetMasterVolumeLevelScalar(value, ref eventContext);
-                if (hr != HRESULT.S_OK) throw AudioDeviceException.FromHResult(hr, "IAudioEndpointVolume.SetMasterVolumeLevelScalar");
+                if (hr.Failed()) throw AudioDeviceException.FromHResult(hr, "IAudioEndpointVolume.SetMasterVolumeLevelScalar");
             });
         }
 
@@ -56,28 +56,28 @@ namespace SoundSwitch.Audio.Manager
             get => ComThread.Invoke(() =>
             {
                 var hr = _volume.GetMute(out var mute);
-                if (hr != HRESULT.S_OK) throw AudioDeviceException.FromHResult(hr, "IAudioEndpointVolume.GetMute");
+                if (hr.Failed()) throw AudioDeviceException.FromHResult(hr, "IAudioEndpointVolume.GetMute");
                 return mute;
             });
             set => ComThread.Invoke(() =>
             {
                 var eventContext = Guid.Empty;
                 var hr = _volume.SetMute(value, ref eventContext);
-                if (hr != HRESULT.S_OK) throw AudioDeviceException.FromHResult(hr, "IAudioEndpointVolume.SetMute");
+                if (hr.Failed()) throw AudioDeviceException.FromHResult(hr, "IAudioEndpointVolume.SetMute");
             });
         }
 
         public int ChannelCount => ComThread.Invoke(() =>
         {
             var hr = _volume.GetChannelCount(out var count);
-            if (hr != HRESULT.S_OK) throw AudioDeviceException.FromHResult(hr, "IAudioEndpointVolume.GetChannelCount");
+            if (hr.Failed()) throw AudioDeviceException.FromHResult(hr, "IAudioEndpointVolume.GetChannelCount");
             return (int)count;
         });
 
         public float GetChannelVolumeLevelScalar(int channel) => ComThread.Invoke(() =>
         {
             var hr = _volume.GetChannelVolumeLevelScalar((uint)channel, out var level);
-            if (hr != HRESULT.S_OK) throw AudioDeviceException.FromHResult(hr, "IAudioEndpointVolume.GetChannelVolumeLevelScalar");
+            if (hr.Failed()) throw AudioDeviceException.FromHResult(hr, "IAudioEndpointVolume.GetChannelVolumeLevelScalar");
             return level;
         });
 
@@ -85,7 +85,7 @@ namespace SoundSwitch.Audio.Manager
         {
             var eventContext = Guid.Empty;
             var hr = _volume.SetChannelVolumeLevelScalar((uint)channel, level, ref eventContext);
-            if (hr != HRESULT.S_OK) throw AudioDeviceException.FromHResult(hr, "IAudioEndpointVolume.SetChannelVolumeLevelScalar");
+            if (hr.Failed()) throw AudioDeviceException.FromHResult(hr, "IAudioEndpointVolume.SetChannelVolumeLevelScalar");
         });
 
         /// <summary>
@@ -110,7 +110,7 @@ namespace SoundSwitch.Audio.Manager
                         {
                             var callback = new EndpointVolumeCallback(this);
                             var hr = _volume.RegisterControlChangeNotify(callback);
-                            if (hr != HRESULT.S_OK) throw AudioDeviceException.FromHResult(hr, "IAudioEndpointVolume.RegisterControlChangeNotify");
+                            if (hr.Failed()) throw AudioDeviceException.FromHResult(hr, "IAudioEndpointVolume.RegisterControlChangeNotify");
                             _callback = callback;
                         }
 

--- a/SoundSwitch.Audio.Manager/AudioSwitcher.cs
+++ b/SoundSwitch.Audio.Manager/AudioSwitcher.cs
@@ -216,17 +216,27 @@ namespace SoundSwitch.Audio.Manager
                 if (endpointVolume == null)
                     return device;
 
-                if (endpointVolume.ChannelCount == 2)
+                // This "keep volume" copy is a best-effort nicety: a COM failure here must not
+                // abort the ongoing device switch, so every exception is logged and swallowed.
+                try
                 {
-                    endpointVolume.SetChannelVolumeLevelScalar(0, audioInfo.Value.Volume);
-                    endpointVolume.SetChannelVolumeLevelScalar(1, audioInfo.Value.Volume);
+                    if (endpointVolume.ChannelCount == 2)
+                    {
+                        endpointVolume.SetChannelVolumeLevelScalar(0, audioInfo.Value.Volume);
+                        endpointVolume.SetChannelVolumeLevelScalar(1, audioInfo.Value.Volume);
+                    }
+                    else
+                    {
+                        endpointVolume.MasterVolumeLevelScalar = audioInfo.Value.Volume;
+                    }
+
+                    endpointVolume.Mute = audioInfo.Value.IsMuted;
                 }
-                else
+                catch (Exception e)
                 {
-                    endpointVolume.MasterVolumeLevelScalar = audioInfo.Value.Volume;
+                    Log.Warning(e, "Failed to apply kept volume/mute to {Device}; continuing device switch", device.FriendlyName);
                 }
 
-                endpointVolume.Mute = audioInfo.Value.IsMuted;
                 return device;
             });
         }

--- a/SoundSwitch.Audio.Manager/Interop/Enum/HRESULT.cs
+++ b/SoundSwitch.Audio.Manager/Interop/Enum/HRESULT.cs
@@ -11,4 +11,14 @@
         ERROR_NOT_FOUND = 0x80070490,
         PROCESS_NO_AUDIO = 0x80070057
     }
+
+    public static class HRESULTExtensions
+    {
+        /// <summary>
+        /// COM success is "severity bit clear": only a negative (as int32) HRESULT is a failure.
+        /// S_FALSE (0x1) is a success code returned e.g. by IAudioEndpointVolume setters when the
+        /// endpoint is already in the requested state.
+        /// </summary>
+        public static bool Failed(this HRESULT hr) => (int)hr < 0;
+    }
 }


### PR DESCRIPTION
## Summary

Device switching could abort with `AudioDeviceException: IAudioEndpointVolume.SetMute failed (HRESULT 0x00000001)` whenever the "keep volume" feature re-applied the previous device's mute state. `HRESULT 0x00000001` is `S_FALSE` — a **success** code Windows returns when the endpoint is *already* in the requested state — but the strict `hr != HRESULT.S_OK` check misclassified it as a hard failure.

Since that mute write happens *before* the actual `SwitchTo` calls in `SetActiveDevice` (and `ComThread` deliberately rethrows transient COM failures), the exception aborted the whole device switch.

## Changes

1. **`HRESULT.Failed()` helper** (`SoundSwitch.Audio.Manager/Interop/Enum/HRESULT.cs`): COM success is "severity bit clear" — a call only failed when `(int)hr < 0`. Added as an extension method on the enum.
2. **`AudioEndpointVolumeClient.cs`**: all 8 `if (hr != HRESULT.S_OK)` checks now use `hr.Failed()`, so `S_FALSE` counts as success while genuine failures (e.g. `0x8007xxxx`) still throw `AudioDeviceException` with the same messages.
3. **`AudioSwitcher.SetVolumeFromDefaultDevice`**: the apply-volume/mute block (the optional "keep volume" copy) is now wrapped in try/catch — any failure is logged via Serilog with the device name and swallowed, so it can never abort the device switch. Early-outs (inactive device / null `endpointVolume`) are unchanged.

## Verification

- `git diff --stat` shows only the three files above; no unrelated edits.
- All 8 throwing checks in `AudioEndpointVolumeClient` use `Failed()`; error message strings untouched.
- The full solution cannot compile on Linux (CsWinRT `cswinrt.exe` requires Windows); the manager project build was attempted and failed only at that environment gate. Windows CI is the authoritative compile gate.

Fixes #2409

## Sentry issues

- [SOUNDSWITCH-4AJ](https://soundswitch.sentry.io/issues/SOUNDSWITCH-4AJ/) — uncaught `AudioDeviceException` on 7.3.2
- [SOUNDSWITCH-30Y](https://soundswitch.sentry.io/issues/SOUNDSWITCH-30Y/)
- [SOUNDSWITCH-226](https://soundswitch.sentry.io/issues/SOUNDSWITCH-226/)
