### PR TITLE
fix(banner): mute microphone banner follows notification position setting

### DIFF
--- a/SoundSwitch/Framework/Banner/MicrophoneMute/MicrophoneMuteBannerManager.cs
+++ b/SoundSwitch/Framework/Banner/MicrophoneMute/MicrophoneMuteBannerManager.cs
@@ -32,7 +32,28 @@ public class MicrophoneMuteBannerManager
 {
     private static System.Threading.SynchronizationContext _syncContext;
     private readonly Dictionary<string, BannerForm> _activeBanners = new();
+    private readonly Dictionary<string, string> _activeMicNames = new();
     private const int SPACING = 10;
+
+    public MicrophoneMuteBannerManager()
+    {
+        AppModel.Instance.BannerSettingsChanged += OnBannerSettingsChanged;
+    }
+
+    private void OnBannerSettingsChanged(object? sender, BannerDataChangedEvent e)
+    {
+        _syncContext.Send(_ =>
+        {
+            foreach (var micId in _activeBanners.Keys)
+            {
+                if (_activeMicNames.TryGetValue(micId, out var name))
+                {
+                    ShowMuteBanner(micId, name);
+                }
+            }
+            RearrangeBanners();
+        }, null);
+    }
 
     /// <summary>
     /// Updates or creates a banner when a microphone's mute state changes
@@ -89,6 +110,8 @@ public class MicrophoneMuteBannerManager
         {
             // Update existing banner
             existingBanner.SetData(data);
+            // Keep mic name current in case it was updated
+            _activeMicNames[microphoneId] = microphoneName;
         }
         else
         {
@@ -97,6 +120,7 @@ public class MicrophoneMuteBannerManager
             newBanner.SetData(data);
             // Arrange existing banners vertically
             _activeBanners.Add(microphoneId, newBanner);
+            _activeMicNames[microphoneId] = microphoneName;
             RearrangeBanners();
         }
     }
@@ -129,6 +153,7 @@ public class MicrophoneMuteBannerManager
 
             // Remove from our tracking dictionary
             _activeBanners.Remove(microphoneId);
+            _activeMicNames.Remove(microphoneId);
 
             // Banner will auto-dispose after TTL expires
             existingBanner.Disposed += (s, e) => RearrangeBanners();
@@ -153,6 +178,7 @@ public class MicrophoneMuteBannerManager
     {
         if (!_activeBanners.TryGetValue(microphoneId, out var existingBanner)) return;
         _activeBanners.Remove(microphoneId);
+        _activeMicNames.Remove(microphoneId);
         existingBanner.Dispose();
         RearrangeBanners();
     }


### PR DESCRIPTION
## Summary
- The persistent microphone-mute banner was created once with a snapshot of `BannerPositionImpl` and never refreshed when the user changed the notification position setting, so it stayed stuck in the top-left corner regardless of the configured position.
- Fix: `MicrophoneMuteBannerManager` now subscribes to `BannerSettingsChanged` and re-issues `SetData` for every active mute banner, which re-reads the position fresh. Track mic names alongside `BannerForm`s so the handler can re-issue per mic.
- Closes #2412

## Test
- Linux: cannot build the full solution (CsWinRT prebuild). Code change is a single file, namespace-audited (uses `SoundSwitch.Model` which is already imported).
- Windows CI `build / build` is the compile gate.

## Manual verification
- Set notification position to something other than top-left, mute a microphone with the hotkey — the persistent mute banner should appear at the configured position, not top-left.
- Change the position setting while a mute banner is visible — the banner should move to the new position.

Fixes #2412
https://github.com/Belphemur/SoundSwitch/issues/2412