### PR TITLE
chore(website): align VuePress stack + arch-aware installer download

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,7 +23,8 @@
             "matchPackageNames": [
                 "vuepress",
                 "@vuepress/bundler-vite",
-                "vuepress-theme-hope"
+                "vuepress-theme-hope",
+                "@vuepress/plugin-llms"
             ],
             "groupName": "vuepress"
         },

--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,15 @@
             "automerge": false
         },
         {
+            "description": "VuePress core + bundler + theme must move together (peer deps)",
+            "matchPackageNames": [
+                "vuepress",
+                "@vuepress/bundler-vite",
+                "vuepress-theme-hope"
+            ],
+            "groupName": "vuepress"
+        },
+        {
             "matchPackageNames": [
                 "conventional-changelog-conventionalcommits"
             ],

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -8,14 +8,14 @@
       "name": "soundswitch-docs",
       "version": "1.0.0",
       "dependencies": {
-        "@vuepress/bundler-vite": "2.0.0-rc.30",
+        "@vuepress/bundler-vite": "2.0.0-rc.31",
         "sass-embedded": "^1.100.0",
         "vue": "^3.5.40",
-        "vuepress": "2.0.0-rc.30",
-        "vuepress-theme-hope": "2.0.0-rc.107"
+        "vuepress": "2.0.0-rc.31",
+        "vuepress-theme-hope": "2.0.0-rc.109"
       },
       "devDependencies": {
-        "@vuepress/plugin-llms": "^2.0.0-rc.132",
+        "@vuepress/plugin-llms": "^2.0.0-rc.134",
         "@vuepress/plugin-slimsearch": "^2.0.0-rc.130",
         "wrangler": "^4.114.0"
       }
@@ -1473,577 +1473,6 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@mdit/helper": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/@mdit/helper/-/helper-0.23.2.tgz",
-      "integrity": "sha512-w4oja7kZYnkSiodfn4Neg1gmlIkvQtmCBJTLvLFOaET7xt8KomDNPQeumpGobQ9dWkXFqBKHlxjTYgroPH+CvA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/markdown-it": "^14.1.2"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "markdown-it": "^14.1.0"
-      },
-      "peerDependenciesMeta": {
-        "markdown-it": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mdit/plugin-alert": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/@mdit/plugin-alert/-/plugin-alert-0.23.2.tgz",
-      "integrity": "sha512-pXIil0FLy9ilhvT6d324A4X+mt5i/zG8ml0VIpZwiUYh2k1Wi6VnZhFHfsnONTRu6dPL2EwQBIhQgQ+269f7LA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/markdown-it": "^14.1.2"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "markdown-it": "^14.1.0"
-      },
-      "peerDependenciesMeta": {
-        "markdown-it": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mdit/plugin-align": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@mdit/plugin-align/-/plugin-align-0.24.2.tgz",
-      "integrity": "sha512-vx0I0LPirTMefIPjUHlRfM/hW7+OKZQSBgiPsxr5pIjPHiXs0ZV+0Tg7zDrnqZNI4QhaWjePRiSF7JkLg9gS/w==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdit/plugin-container": "0.23.2",
-        "@types/markdown-it": "^14.1.2"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "markdown-it": "^14.1.0"
-      },
-      "peerDependenciesMeta": {
-        "markdown-it": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mdit/plugin-attrs": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/@mdit/plugin-attrs/-/plugin-attrs-0.25.2.tgz",
-      "integrity": "sha512-/R1BzkCWY8OvjDek9y/0/hpxZKWlwef0Gq/jtee9+ZbX0J9ffXfJl+Isgh3Ecur01R6Bv+1XNJtaBGNgUm/w6Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdit/helper": "0.23.2",
-        "@types/markdown-it": "^14.1.2"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "markdown-it": "^14.1.0"
-      },
-      "peerDependenciesMeta": {
-        "markdown-it": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mdit/plugin-container": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/@mdit/plugin-container/-/plugin-container-0.23.2.tgz",
-      "integrity": "sha512-rXlFg37YuQDNcVKCaPtaJ2oCbfxTIguzf0Uklt65PK6J3kqB82+IE0+p87GIObWxdm1ajfbMUSLfvfrHoiqq4Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/markdown-it": "^14.1.2"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "markdown-it": "^14.1.0"
-      },
-      "peerDependenciesMeta": {
-        "markdown-it": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mdit/plugin-demo": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/@mdit/plugin-demo/-/plugin-demo-0.23.2.tgz",
-      "integrity": "sha512-GBsdFI1HF3ZsYf7oXtLinv2pgXkEw2Cj4+Au/aCAsdXZ+T/X7KPQQNA9MwKrWS8fQpVipys/SSK4R+IsbmVWiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/markdown-it": "^14.1.2"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "markdown-it": "^14.1.0"
-      },
-      "peerDependenciesMeta": {
-        "markdown-it": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mdit/plugin-figure": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/@mdit/plugin-figure/-/plugin-figure-0.23.2.tgz",
-      "integrity": "sha512-PK4G29p29cZJiA2uQ0gv6faW65ilTxPH+MssyAj/WBobIrhVDhcAg+tVN/in3/FhQ31bzKoUtCPBjzYWmj73tA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/markdown-it": "^14.1.2"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "markdown-it": "^14.1.0"
-      },
-      "peerDependenciesMeta": {
-        "markdown-it": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mdit/plugin-footnote": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/@mdit/plugin-footnote/-/plugin-footnote-0.23.2.tgz",
-      "integrity": "sha512-zE2jAx1KX1ZLuF0v4t2VwgrsfSYHRr23n5viRcxyF2tnbBKLJA38Pmk7jrKfKK9akZVD32zRzZWGrRF39TPXqw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/markdown-it": "^14.1.2"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "markdown-it": "^14.1.0"
-      }
-    },
-    "node_modules/@mdit/plugin-icon": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@mdit/plugin-icon/-/plugin-icon-0.24.2.tgz",
-      "integrity": "sha512-20VVIIEH9RItrIaNfTruIbrWL/qDoeEdcDxzFHFULJFjdDpdDOUdfTiC5/u6T7FmbngMLfe1M7PoVW1apet1Gw==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdit/helper": "0.23.2",
-        "@types/markdown-it": "^14.1.2"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "markdown-it": "^14.1.0"
-      },
-      "peerDependenciesMeta": {
-        "markdown-it": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mdit/plugin-img-lazyload": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/@mdit/plugin-img-lazyload/-/plugin-img-lazyload-0.23.2.tgz",
-      "integrity": "sha512-ChmBzqd9ovp6sUplb388on8NphfW0JBMmaDLf4lXd0IvMX3+dYlPAtPKxUJr3QwmEK5rAnfRFeJG5cvC+CsHSg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/markdown-it": "^14.1.2"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "markdown-it": "^14.1.0"
-      },
-      "peerDependenciesMeta": {
-        "markdown-it": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mdit/plugin-img-mark": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/@mdit/plugin-img-mark/-/plugin-img-mark-0.23.2.tgz",
-      "integrity": "sha512-1yvG+kcec8s8hXaCRnbagNJogh5yE6ioS588NcMedBjA2bZ0Q/4xexXF1phU3e3T740ACPqwN+amwj+Cf/GlIA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/markdown-it": "^14.1.2"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "markdown-it": "^14.1.0"
-      },
-      "peerDependenciesMeta": {
-        "markdown-it": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mdit/plugin-img-size": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/@mdit/plugin-img-size/-/plugin-img-size-0.23.2.tgz",
-      "integrity": "sha512-WsMBjy32leLRwTVvZj/88+QqvoKU5ZM1znx7kLnaUJUYjw6fqd82RTC3P3wmQa0/dxKk3m17oFQPlDshzXhEiA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/markdown-it": "^14.1.2"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "markdown-it": "^14.1.0"
-      },
-      "peerDependenciesMeta": {
-        "markdown-it": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mdit/plugin-include": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/@mdit/plugin-include/-/plugin-include-0.23.2.tgz",
-      "integrity": "sha512-wU+b1AITt3iCb70d9GpY8/BsEkf18XPeO3vdcU6pmAOrFo1GyWAf21KTE0+g/Zh7n3DdyqdjpPCjEJbW73xzzg==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdit/helper": "0.23.2",
-        "@types/markdown-it": "^14.1.2",
-        "upath": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "markdown-it": "^14.1.0"
-      },
-      "peerDependenciesMeta": {
-        "markdown-it": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mdit/plugin-include/node_modules/upath": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/upath/-/upath-2.0.1.tgz",
-      "integrity": "sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4",
-        "yarn": "*"
-      }
-    },
-    "node_modules/@mdit/plugin-inline-rule": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/@mdit/plugin-inline-rule/-/plugin-inline-rule-0.23.2.tgz",
-      "integrity": "sha512-+w8ORGQ08zgY61Vz/9xHKwpMitCV7pdI80MOq03tlZQRUANUQRaM3mnA6/B51bzubJvnB8NPQdRAJ2Mwt6ZILg==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdit/helper": "0.23.2",
-        "@types/markdown-it": "^14.1.2"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "markdown-it": "^14.1.0"
-      },
-      "peerDependenciesMeta": {
-        "markdown-it": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mdit/plugin-katex-slim": {
-      "version": "0.26.2",
-      "resolved": "https://registry.npmjs.org/@mdit/plugin-katex-slim/-/plugin-katex-slim-0.26.2.tgz",
-      "integrity": "sha512-QDkYQ8x2QpK9QTORofjlzvOBbXIMhGpCtdQbkYQUNyzDwNAOsfyVmqvXTXVSlxbO/qfGvThTcFJCZa3Ma/zw4w==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdit/helper": "0.23.2",
-        "@mdit/plugin-tex": "0.24.2",
-        "@types/markdown-it": "^14.1.2"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "katex": "^0.16.25",
-        "markdown-it": "^14.1.0"
-      },
-      "peerDependenciesMeta": {
-        "katex": {
-          "optional": true
-        },
-        "markdown-it": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mdit/plugin-layout": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@mdit/plugin-layout/-/plugin-layout-0.2.2.tgz",
-      "integrity": "sha512-lPeJULVt1s9rEA2aU5pKRRsqGpJVmmcLE08GKeuPb7xgJuJvsPnDHNqA4eVSHUR9WARMolygfTBT1yAQd715HA==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdit/helper": "0.23.2",
-        "@types/markdown-it": "^14.1.2"
-      },
-      "peerDependencies": {
-        "markdown-it": "^14.1.0"
-      },
-      "peerDependenciesMeta": {
-        "markdown-it": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mdit/plugin-mark": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/@mdit/plugin-mark/-/plugin-mark-0.23.2.tgz",
-      "integrity": "sha512-j/icOo3K55IkO2TbK26PpumNFzJ1+iSNGc4r29E1iamO8pA6iouVLdzawTAwQ4uQPrQW//JovgoUjWycnoBGKQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdit/plugin-inline-rule": "0.23.2",
-        "@types/markdown-it": "^14.1.2"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "markdown-it": "^14.1.0"
-      },
-      "peerDependenciesMeta": {
-        "markdown-it": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mdit/plugin-mathjax-slim": {
-      "version": "0.26.2",
-      "resolved": "https://registry.npmjs.org/@mdit/plugin-mathjax-slim/-/plugin-mathjax-slim-0.26.2.tgz",
-      "integrity": "sha512-e/ap85PAPcl7DTOvz1nFqzBc7YL16jD1tbdB/ChzfxjdEN8SN9pMokRQOAlmegaoA/mPWcoKCPj/JGilgyOAiA==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdit/plugin-tex": "0.24.2",
-        "@types/markdown-it": "^14.1.2"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "@mathjax/mathjax-newcm-font": "^4.1.0",
-        "@mathjax/src": "^4.0.0",
-        "markdown-it": "^14.1.0"
-      },
-      "peerDependenciesMeta": {
-        "@mathjax/mathjax-newcm-font": {
-          "optional": true
-        },
-        "@mathjax/src": {
-          "optional": true
-        },
-        "markdown-it": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mdit/plugin-plantuml": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@mdit/plugin-plantuml/-/plugin-plantuml-0.24.2.tgz",
-      "integrity": "sha512-UKv2X2p/BHN3uHP//SF6l2Rdp91Nk/6RlaPrmvHz/RSMRI4YzuNL+IAg/kJAQmT4tWyInsR4Bwcw8R0qGHCk0A==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdit/plugin-uml": "0.24.2",
-        "@types/markdown-it": "^14.1.2"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "markdown-it": "^14.1.0"
-      },
-      "peerDependenciesMeta": {
-        "markdown-it": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mdit/plugin-spoiler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/@mdit/plugin-spoiler/-/plugin-spoiler-0.23.2.tgz",
-      "integrity": "sha512-rCUGTp7WqxK40tYQYseR0RuLOS001fMOn55bgj1Evrf2oI6RydEeOtlbeh48bZK9na/swmUtwV3yYC4wZi6kNQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdit/plugin-inline-rule": "0.23.2",
-        "@types/markdown-it": "^14.1.2"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "markdown-it": "^14.1.0"
-      },
-      "peerDependenciesMeta": {
-        "markdown-it": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mdit/plugin-stylize": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/@mdit/plugin-stylize/-/plugin-stylize-0.23.2.tgz",
-      "integrity": "sha512-q62eRLz/41AoodZIwx5NHoSuHyX1CuFaVjG13j6kbuo5gWmLF3JcyIY9BG+BRgSM+00LvB9DCZWAf/ZdN+vOVg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/markdown-it": "^14.1.2"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "markdown-it": "^14.1.0"
-      },
-      "peerDependenciesMeta": {
-        "markdown-it": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mdit/plugin-sub": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@mdit/plugin-sub/-/plugin-sub-0.24.2.tgz",
-      "integrity": "sha512-E4wNJ5mDIoJbjvGj9D/GTlhWhUmR94UQjEtPCEQf/oy9nZMhetA0qFjCCFnGpJQHpHcBEkxWc5hEVdMiWhQBFA==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdit/plugin-inline-rule": "0.23.2",
-        "@types/markdown-it": "^14.1.2"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "markdown-it": "^14.1.0"
-      },
-      "peerDependenciesMeta": {
-        "markdown-it": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mdit/plugin-sup": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@mdit/plugin-sup/-/plugin-sup-0.24.2.tgz",
-      "integrity": "sha512-tMi63tSz6we8cjfdjLmhbTr/B+wX96PtsBwTKKKWn6UWmJzv9Kljq2AOHvV8phwpXz+Jz3yPP/qyrXqvZajdzg==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdit/plugin-inline-rule": "0.23.2",
-        "@types/markdown-it": "^14.1.2"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "markdown-it": "^14.1.0"
-      },
-      "peerDependenciesMeta": {
-        "markdown-it": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mdit/plugin-tab": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@mdit/plugin-tab/-/plugin-tab-0.24.2.tgz",
-      "integrity": "sha512-9rN23SP4beO0shBOuSGLGR+Ia7fminVSH6xl5Rb6rh6rRYQ6R3NR2KkIfLZvoMCRiN2uDwhXT/R9LyXHOdRMUQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdit/helper": "0.23.2",
-        "@types/markdown-it": "^14.1.2"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "markdown-it": "^14.1.0"
-      },
-      "peerDependenciesMeta": {
-        "markdown-it": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mdit/plugin-tasklist": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/@mdit/plugin-tasklist/-/plugin-tasklist-0.23.2.tgz",
-      "integrity": "sha512-9vpH3ZG2JmB3SqYfXmRXk9mI5Q6U+KO30quNH1PN5lp5gQtW4kceWhfAPeQtSMemNV4KuCyns+6PRX8zD9Sajw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/markdown-it": "^14.1.2"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "markdown-it": "^14.1.0"
-      },
-      "peerDependenciesMeta": {
-        "markdown-it": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mdit/plugin-tex": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@mdit/plugin-tex/-/plugin-tex-0.24.2.tgz",
-      "integrity": "sha512-nVKIJHQJHvgDByKMpCgFT6gdeEZUyzZby24BjCjxP2N10bkgK8IEwZIBu7G5n5WBw2D0kmFD4Top+YA2mjeiQQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/markdown-it": "^14.1.2"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "markdown-it": "^14.1.0"
-      },
-      "peerDependenciesMeta": {
-        "markdown-it": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mdit/plugin-uml": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@mdit/plugin-uml/-/plugin-uml-0.24.2.tgz",
-      "integrity": "sha512-GZB2x2hCb5qLCZFx5NaqugoVNF164vOYi5PWHk8vTqIsIMLVXt5b6ODFSngrjH6t3k3c7GDDcnr8QwOUSkjNQQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdit/helper": "0.23.2",
-        "@types/markdown-it": "^14.1.2"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "markdown-it": "^14.1.0"
-      },
-      "peerDependenciesMeta": {
-        "markdown-it": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
@@ -2685,15 +2114,15 @@
       "license": "MIT"
     },
     "node_modules/@shikijs/core": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.3.1.tgz",
-      "integrity": "sha512-ANMDxuaPsNMdDC1m4vfvhlDmJweMwkE5XitTwrq2rWHx5jM+dlm4MmHt2PP6t0uejfR77SuhrhJ0zEijIF/uhA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.4.3.tgz",
+      "integrity": "sha512-QCR4q2ZO/ILJEuwiBMel4wdcTDb1JGwfjKTxPDF6x8ixOaluPrVqIn06C99AcRPhmYlBR56d/Fb+GN58GzExpg==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/primitive": "4.3.1",
-        "@shikijs/types": "4.3.1",
+        "@shikijs/primitive": "4.4.3",
+        "@shikijs/types": "4.4.3",
         "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.4",
+        "@types/hast": "^3.0.5",
         "hast-util-to-html": "^9.0.5"
       },
       "engines": {
@@ -2701,12 +2130,12 @@
       }
     },
     "node_modules/@shikijs/engine-javascript": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.3.1.tgz",
-      "integrity": "sha512-JBItcnPuYq7jVJdZo/vMj94r+szT7XEjHFX+mvFDGSEIbVAXAGyHAHzhbWzpGOwYidCZrErJLLgn2PVeiokHnQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.4.3.tgz",
+      "integrity": "sha512-FbOjFJp9VLdo1Wevs10BBtVxiTWwNLqZh5Gkhjgda/ioL15YOgeSl9n+6XMa3qRlPQzfhFNe641SrynFHYG0nQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "4.3.1",
+        "@shikijs/types": "4.4.3",
         "@shikijs/vscode-textmate": "^10.0.2",
         "oniguruma-to-es": "^4.3.6"
       },
@@ -2715,12 +2144,12 @@
       }
     },
     "node_modules/@shikijs/engine-oniguruma": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.3.1.tgz",
-      "integrity": "sha512-OXyNMzg0pews+msMj4cHeqT4xiYKKvbnn6VbdAXxfoFl3SSx4fJTc8FadECuc5/H9p3BzhNAoAUXKwAu9rWYhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.4.3.tgz",
+      "integrity": "sha512-EcOQkxdxGQrc1Row/cC2c96/v1dbZqGnEVu1qTuT/MJmp6+cXCvQussowVmCv5Tqr3KuY3c7IbM6HTW3LJ1k9w==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "4.3.1",
+        "@shikijs/types": "4.4.3",
         "@shikijs/vscode-textmate": "^10.0.2"
       },
       "engines": {
@@ -2728,64 +2157,64 @@
       }
     },
     "node_modules/@shikijs/langs": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.3.1.tgz",
-      "integrity": "sha512-m0l9nsDqgBHvbZbk7A0/kXz/impK3uB/c6rAn6Gpg/uPtdZRQ+alsN/17MU5thb68XTj/4DxkZAotrM0GGSpDQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.4.3.tgz",
+      "integrity": "sha512-ePic0yfAJGOF83D5wBHK/00EjK65oahBYxFk5epgq33WRv7X9UuxLEV8PtR0szC0z8dl7INIpIodB99JRFlR+A==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "4.3.1"
+        "@shikijs/types": "4.4.3"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@shikijs/primitive": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.3.1.tgz",
-      "integrity": "sha512-CXQRQOYy1leqQ8ceTeJdmXv/bsUY++6QyLpXJ94LZAAYj5X2SKRdc5ipguv4NPyGVKItB2PPwUpRNe0Sjh5S1A==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.4.3.tgz",
+      "integrity": "sha512-m0wBeLDQDeIxRdUmrCPdQqfuUamDwRL5isCfYbguKD6NiaKpVbsv+3J81DyIKgNW5h4WAIIr8T4EkgQrBBxvaQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "4.3.1",
+        "@shikijs/types": "4.4.3",
         "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.4"
+        "@types/hast": "^3.0.5"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@shikijs/themes": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.3.1.tgz",
-      "integrity": "sha512-dgpoJ4WqNi2yTmizQHBJ5zcX6j2lE6icN/0yt4l1kkf16jrY/pwPLoTb1ETsWMz0OBLf9ZNvwmxft+cH+N9qSA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.4.3.tgz",
+      "integrity": "sha512-w8UHjeUnIR965KMWJHUPXOc2mNJUnK3vpVLYLvw5IYU2mnTTJ89E24OrJDBNiJDQ0qzb0tc4l7mrIXx5cFeIyw==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "4.3.1"
+        "@shikijs/types": "4.4.3"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@shikijs/transformers": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-4.3.1.tgz",
-      "integrity": "sha512-z6ir0bGDgWcF2FduktEfPgIsdOtIlDiLAjFBgBzE42Q9xHbkkIXZtORHzlLVB71iZP9elEcqKg6keajvOUwE2A==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-4.4.3.tgz",
+      "integrity": "sha512-oJSARV6NaWd+rnNJbtnpAdj3Zg0ZVyzsnMgb3vi3HA+35y8lBWUCpOnWsmyiXZIikY+x1BDqrQUgmxfzWh7Jvw==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/core": "4.3.1",
-        "@shikijs/types": "4.3.1"
+        "@shikijs/core": "4.4.3",
+        "@shikijs/types": "4.4.3"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@shikijs/types": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.3.1.tgz",
-      "integrity": "sha512-CHFxE0jztBIZRHH6gxXE7DXUCFXjReEGxZ/j0rfSLGKZuwp2xBYycEP14875DSa9KLL/6700oxIq6oO6ef9K2g==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.4.3.tgz",
+      "integrity": "sha512-UEJxmRR++MAGR6hugn0vgVS2W/6lWAts84FFSrnlH9sP0LNol7E5+NQ792pH8liWUhyMyjhTgSUH3k7iD7tc5g==",
       "license": "MIT",
       "dependencies": {
         "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.4"
+        "@types/hast": "^3.0.5"
       },
       "engines": {
         "node": ">=20"
@@ -2889,9 +2318,9 @@
       "license": "MIT"
     },
     "node_modules/@types/markdown-it": {
-      "version": "14.1.2",
-      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
-      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-NoQ2yGlLWj4wpxMs+TYmRKk3thDrQ97agr7sFqfLsAlvoS8SNQuTrlObhFqG9iugdTtgOE9jpJ6FNM4ZGsa5xQ==",
       "license": "MIT",
       "dependencies": {
         "@types/linkify-it": "^5",
@@ -3157,103 +2586,103 @@
       "license": "MIT"
     },
     "node_modules/@vuepress/bundler-vite": {
-      "version": "2.0.0-rc.30",
-      "resolved": "https://registry.npmjs.org/@vuepress/bundler-vite/-/bundler-vite-2.0.0-rc.30.tgz",
-      "integrity": "sha512-Glfi6JQIbSTpQDuYR3e4VDF6iMgdZixQLHtry4tidYSeSudeZgL1yzxIxO4B5hRoflP+Xre7Fy3r0ilGZSitXg==",
+      "version": "2.0.0-rc.31",
+      "resolved": "https://registry.npmjs.org/@vuepress/bundler-vite/-/bundler-vite-2.0.0-rc.31.tgz",
+      "integrity": "sha512-4ptpbmDvAf9KvME7xY4OhYT4M/fAyk4qnP97jl5+kdRkOcv/XsRW2WKhP2lC8ckr9hMwVoRdBRE2/qgrtX+iDQ==",
       "license": "MIT",
       "dependencies": {
-        "@vitejs/plugin-vue": "^6.0.6",
-        "@vuepress/bundlerutils": "2.0.0-rc.30",
-        "@vuepress/client": "2.0.0-rc.30",
-        "@vuepress/core": "2.0.0-rc.30",
-        "@vuepress/shared": "2.0.0-rc.30",
-        "@vuepress/utils": "2.0.0-rc.30",
-        "autoprefixer": "^10.5.0",
+        "@vitejs/plugin-vue": "^6.0.8",
+        "@vuepress/bundlerutils": "2.0.0-rc.31",
+        "@vuepress/client": "2.0.0-rc.31",
+        "@vuepress/core": "2.0.0-rc.31",
+        "@vuepress/shared": "2.0.0-rc.31",
+        "@vuepress/utils": "2.0.0-rc.31",
+        "autoprefixer": "^10.5.4",
         "connect-history-api-fallback": "^2.0.0",
-        "postcss": "^8.5.14",
+        "postcss": "^8.5.22",
         "postcss-load-config": "^6.0.1",
-        "rolldown": "^1.0.0",
-        "vite": "^8.0.11",
-        "vue": "^3.5.34",
-        "vue-router": "^5.0.6"
+        "rolldown": "^1.2.0",
+        "vite": "^8.1.5",
+        "vue": "^3.5.40",
+        "vue-router": "^5.2.0"
       }
     },
     "node_modules/@vuepress/bundlerutils": {
-      "version": "2.0.0-rc.30",
-      "resolved": "https://registry.npmjs.org/@vuepress/bundlerutils/-/bundlerutils-2.0.0-rc.30.tgz",
-      "integrity": "sha512-pDB1mc4d6PluzDbr4jDgHBMbcTjl1U+RyMMDy/6JaV934T5iaJLOrHe/FrDXq39qM5rvQTMkTh6KesJ6qHxrLA==",
+      "version": "2.0.0-rc.31",
+      "resolved": "https://registry.npmjs.org/@vuepress/bundlerutils/-/bundlerutils-2.0.0-rc.31.tgz",
+      "integrity": "sha512-CSk4gR0fvJ419ocipH3cbk/xt0IFK92XwqzFX3N7BzPVFlWE74iaBfT3VUFQHQN2vYPwMMou4wlEdnK4PS4cvQ==",
       "license": "MIT",
       "dependencies": {
-        "@vuepress/client": "2.0.0-rc.30",
-        "@vuepress/core": "2.0.0-rc.30",
-        "@vuepress/shared": "2.0.0-rc.30",
-        "@vuepress/utils": "2.0.0-rc.30",
-        "vue": "^3.5.34",
-        "vue-router": "^5.0.6"
+        "@vuepress/client": "2.0.0-rc.31",
+        "@vuepress/core": "2.0.0-rc.31",
+        "@vuepress/markdown": "2.0.0-rc.31",
+        "@vuepress/shared": "2.0.0-rc.31",
+        "@vuepress/utils": "2.0.0-rc.31",
+        "vue": "^3.5.40",
+        "vue-router": "^5.2.0"
       }
     },
     "node_modules/@vuepress/cli": {
-      "version": "2.0.0-rc.30",
-      "resolved": "https://registry.npmjs.org/@vuepress/cli/-/cli-2.0.0-rc.30.tgz",
-      "integrity": "sha512-AE77SLQyaebUqqLp6SAjno9jMjgjARqZlE3db4Vwrnd2g3W2LDLOdxs6MCbA5OiZmoasr2XtKGNbf0mW3EVSRg==",
+      "version": "2.0.0-rc.31",
+      "resolved": "https://registry.npmjs.org/@vuepress/cli/-/cli-2.0.0-rc.31.tgz",
+      "integrity": "sha512-X75edJjhacYCzrYSOhXvlakh+/1fm2eCGJcrcZqKGfeZXcKhDrF154E7meLqfEkiHDb3zPCg+C2wAs1m6ujoxQ==",
       "license": "MIT",
       "dependencies": {
-        "@vuepress/core": "2.0.0-rc.30",
-        "@vuepress/shared": "2.0.0-rc.30",
-        "@vuepress/utils": "2.0.0-rc.30",
+        "@vuepress/core": "2.0.0-rc.31",
+        "@vuepress/shared": "2.0.0-rc.31",
+        "@vuepress/utils": "2.0.0-rc.31",
         "cac": "^7.0.0",
         "chokidar": "^5.0.0",
         "envinfo": "^7.21.0",
-        "esbuild": "^0.28.0"
+        "rolldown": "^1.2.0"
       },
       "bin": {
         "vuepress-cli": "bin/vuepress.js"
       }
     },
     "node_modules/@vuepress/client": {
-      "version": "2.0.0-rc.30",
-      "resolved": "https://registry.npmjs.org/@vuepress/client/-/client-2.0.0-rc.30.tgz",
-      "integrity": "sha512-bIAY32Z3Rx6ONBriY+8K2K5wjKxQXzA1jMao4cVTOgMfapHyzhyfNCp1FTkWw6iHoccM9xIDniuyeT8W6JDWPg==",
+      "version": "2.0.0-rc.31",
+      "resolved": "https://registry.npmjs.org/@vuepress/client/-/client-2.0.0-rc.31.tgz",
+      "integrity": "sha512-F1mVj2NCblUwweGjfsmfLiC7GrO0YN5rnej14nMSGfHP3ch1FHpZeACiiRk1L0MolpBd7OYskx5rYyh7vY0tCg==",
       "license": "MIT",
       "dependencies": {
-        "@vue/devtools-api": "^8.1.1",
-        "@vue/devtools-kit": "^8.1.1",
-        "@vuepress/shared": "2.0.0-rc.30",
-        "vue": "^3.5.34",
-        "vue-router": "^5.0.6"
+        "@vue/devtools-api": "^8.1.5",
+        "@vue/devtools-kit": "^8.1.5",
+        "@vuepress/shared": "2.0.0-rc.31",
+        "vue": "^3.5.40",
+        "vue-router": "^5.2.0"
       }
     },
     "node_modules/@vuepress/core": {
-      "version": "2.0.0-rc.30",
-      "resolved": "https://registry.npmjs.org/@vuepress/core/-/core-2.0.0-rc.30.tgz",
-      "integrity": "sha512-Sxe+S0xC0Yn7eh4P4TlnzolYqDBo62ZnfbY3qaLc5nlKW4sgJY+pJDBqSOHBL5Z5I4q0V43+9WULNtHXeDHVMg==",
+      "version": "2.0.0-rc.31",
+      "resolved": "https://registry.npmjs.org/@vuepress/core/-/core-2.0.0-rc.31.tgz",
+      "integrity": "sha512-b01o8GkukVSZwQYn0DZirEr5ghiAiX2m8yNUeptOJ6nJgLyPGO02zmGlmERCxR9qsfHnTsc5UcbjJpmOr/cFiQ==",
       "license": "MIT",
       "dependencies": {
-        "@vuepress/client": "2.0.0-rc.30",
-        "@vuepress/markdown": "2.0.0-rc.30",
-        "@vuepress/shared": "2.0.0-rc.30",
-        "@vuepress/utils": "2.0.0-rc.30",
-        "vue": "^3.5.34"
+        "@vuepress/client": "2.0.0-rc.31",
+        "@vuepress/markdown": "2.0.0-rc.31",
+        "@vuepress/shared": "2.0.0-rc.31",
+        "@vuepress/utils": "2.0.0-rc.31",
+        "vue": "^3.5.40"
       }
     },
     "node_modules/@vuepress/helper": {
-      "version": "2.0.0-rc.131",
-      "resolved": "https://registry.npmjs.org/@vuepress/helper/-/helper-2.0.0-rc.131.tgz",
-      "integrity": "sha512-VlzJre0tJhlyoHpiRzclM9KntYzdip9rUWf8zaqfwlOV8A280fexTfWdxZwDkekgh9E3l6jJTqRJZpVDdXVFYg==",
-      "dev": true,
+      "version": "2.0.0-rc.134",
+      "resolved": "https://registry.npmjs.org/@vuepress/helper/-/helper-2.0.0-rc.134.tgz",
+      "integrity": "sha512-l4KjjLrdzkWIXDAzlFu7yTY6dMmBSr/NvcS1ezpOvDPBPMVxE2KfLVfmizsfrwfRYMbcz4JePdvoShG7niDvLw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "^3.5.39",
-        "@vueuse/core": "^14.3.0",
+        "@vue/shared": "^3.5.42",
+        "@vueuse/core": "^14.4.0",
         "cheerio": "^1.2.0",
         "fflate": "^0.8.3",
         "gray-matter": "^4.0.3",
-        "vue": "^3.5.39"
+        "vue": "^3.5.42"
       },
       "peerDependencies": {
-        "@vuepress/bundler-vite": "2.0.0-rc.30",
-        "@vuepress/bundler-webpack": "2.0.0-rc.30",
-        "vuepress": "2.0.0-rc.30"
+        "@vuepress/bundler-vite": "2.0.0-rc.31",
+        "@vuepress/bundler-webpack": "2.0.0-rc.31",
+        "vuepress": "2.0.0-rc.31"
       },
       "peerDependenciesMeta": {
         "@vuepress/bundler-vite": {
@@ -3264,10 +2693,26 @@
         }
       }
     },
+    "node_modules/@vuepress/highlighter-helper": {
+      "version": "2.0.0-rc.134",
+      "resolved": "https://registry.npmjs.org/@vuepress/highlighter-helper/-/highlighter-helper-2.0.0-rc.134.tgz",
+      "integrity": "sha512-SPo5YMk1qbKA+gqIZZCfd3msrqvW8vWK3flfC2hqkc0a7NTglL33QL7VwoH4hk9le1KNcbOn9Mr2ImUEBxgx7Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@vuepress/helper": "2.0.0-rc.134",
+        "@vueuse/core": "^14.4.0",
+        "vuepress": "2.0.0-rc.31"
+      },
+      "peerDependenciesMeta": {
+        "@vueuse/core": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vuepress/markdown": {
-      "version": "2.0.0-rc.30",
-      "resolved": "https://registry.npmjs.org/@vuepress/markdown/-/markdown-2.0.0-rc.30.tgz",
-      "integrity": "sha512-4wloGD4xBVm09yi48rPg9LOBXHh/aHGMxpks1GuF79yifS78n8cHSZilWaDryM5nimcUrPtK21XUAXFjyZHjBA==",
+      "version": "2.0.0-rc.31",
+      "resolved": "https://registry.npmjs.org/@vuepress/markdown/-/markdown-2.0.0-rc.31.tgz",
+      "integrity": "sha512-W4UdVwYob3sZ794BFd53dolhXVOma0JzN15k6CwmmhOy/3wWuIZ8pV3YQsxxyAQJ8ZxQWGZ4Wf5u/w7G/1/IkQ==",
       "license": "MIT",
       "dependencies": {
         "@mdit-vue/plugin-component": "^3.0.2",
@@ -3280,164 +2725,83 @@
         "@mdit-vue/types": "^3.0.2",
         "@types/markdown-it": "^14.1.2",
         "@types/markdown-it-emoji": "^3.0.1",
-        "@vuepress/shared": "2.0.0-rc.30",
-        "@vuepress/utils": "2.0.0-rc.30",
-        "markdown-it": "^14.1.1",
-        "markdown-it-anchor": "^9.2.0",
-        "markdown-it-emoji": "^3.0.0",
-        "mdurl": "^2.0.0"
+        "@vuepress/shared": "2.0.0-rc.31",
+        "@vuepress/utils": "2.0.0-rc.31",
+        "markdown-it": "^14.3.0",
+        "markdown-it-anchor": "^9.2.1",
+        "markdown-it-emoji": "^3.1.0",
+        "mdurl": "^2.1.0"
       }
     },
     "node_modules/@vuepress/plugin-active-header-links": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-active-header-links/-/plugin-active-header-links-2.0.0-rc.130.tgz",
-      "integrity": "sha512-Qs3yiDI5hp/Xz1JoXE9iJtkuuIYpsVDs9zz2DlKxTE6iSjlChuLWoCezly4fW0HRm/epa5jnnNHXSUjvkk9DOQ==",
+      "version": "2.0.0-rc.134",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-active-header-links/-/plugin-active-header-links-2.0.0-rc.134.tgz",
+      "integrity": "sha512-KvgCeJ0EdahpUhxze6yafaZmLJQJPanQbjU66fNoMDgMXmWf4U39+3YSIWhCt4J9pmBTjUbwvYjTliCX9+HjWg==",
       "license": "MIT",
       "dependencies": {
-        "@vueuse/core": "^14.3.0",
-        "vue": "^3.5.34"
+        "@vueuse/core": "^14.4.0",
+        "vue": "^3.5.42"
       },
       "peerDependencies": {
-        "vuepress": "2.0.0-rc.30"
+        "vuepress": "2.0.0-rc.31"
       }
     },
     "node_modules/@vuepress/plugin-back-to-top": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-back-to-top/-/plugin-back-to-top-2.0.0-rc.130.tgz",
-      "integrity": "sha512-0h7ghTvjMjLNJenYbe7Xr0/0TlqZj3fuoub4sy7VhXFhupeqzcnqoYpKtICgBxoxH89Cde7BY2JKuXsO9BHm9w==",
+      "version": "2.0.0-rc.134",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-back-to-top/-/plugin-back-to-top-2.0.0-rc.134.tgz",
+      "integrity": "sha512-WXG5okUBryh/BTsvTsdrY6uIq87iwz8KPbaxyP70Gd7v+Otyo8ro1zwbgHIlMlObBlwtEJF2HjuVja1i5ucGAw==",
       "license": "MIT",
       "dependencies": {
-        "@vuepress/helper": "2.0.0-rc.130",
-        "@vueuse/core": "^14.3.0",
-        "vue": "^3.5.34"
+        "@vuepress/helper": "2.0.0-rc.134",
+        "@vueuse/core": "^14.4.0",
+        "vue": "^3.5.42"
       },
       "peerDependencies": {
-        "vuepress": "2.0.0-rc.30"
-      }
-    },
-    "node_modules/@vuepress/plugin-back-to-top/node_modules/@vuepress/helper": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/helper/-/helper-2.0.0-rc.130.tgz",
-      "integrity": "sha512-x6UG/9XJvBREeTocRWji8SRqa14S+Xa8cw9b7Jc/Yh3eRwN/hrexM7ZkFixSjyslvYUaxLkOtEUZW/EK8ArMFw==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/shared": "^3.5.34",
-        "@vueuse/core": "^14.3.0",
-        "cheerio": "^1.2.0",
-        "fflate": "^0.8.2",
-        "gray-matter": "^4.0.3",
-        "vue": "^3.5.34"
-      },
-      "peerDependencies": {
-        "@vuepress/bundler-vite": "2.0.0-rc.30",
-        "@vuepress/bundler-webpack": "2.0.0-rc.30",
-        "vuepress": "2.0.0-rc.30"
-      },
-      "peerDependenciesMeta": {
-        "@vuepress/bundler-vite": {
-          "optional": true
-        },
-        "@vuepress/bundler-webpack": {
-          "optional": true
-        }
+        "vuepress": "2.0.0-rc.31"
       }
     },
     "node_modules/@vuepress/plugin-blog": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-blog/-/plugin-blog-2.0.0-rc.130.tgz",
-      "integrity": "sha512-ukCenqqjq03o/4mp4aGPmFeC3DkeooB2igQPTauyBfJ/5QuADVDPFWhncqadlPtVRIxEr3EzxeqiNKleY+oAKQ==",
+      "version": "2.0.0-rc.134",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-blog/-/plugin-blog-2.0.0-rc.134.tgz",
+      "integrity": "sha512-VqciJsVffE2tIPG16N+wXflZr5LYkvJtZMIRXkZnAqSlciwuL3h0+pfQhpdmTaqwdExyi00czT81sOk1oYVrrg==",
       "license": "MIT",
       "dependencies": {
-        "@vuepress/helper": "2.0.0-rc.130",
-        "vue": "^3.5.34"
+        "@vuepress/helper": "2.0.0-rc.134",
+        "vue": "^3.5.42"
       },
       "peerDependencies": {
-        "vuepress": "2.0.0-rc.30"
-      }
-    },
-    "node_modules/@vuepress/plugin-blog/node_modules/@vuepress/helper": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/helper/-/helper-2.0.0-rc.130.tgz",
-      "integrity": "sha512-x6UG/9XJvBREeTocRWji8SRqa14S+Xa8cw9b7Jc/Yh3eRwN/hrexM7ZkFixSjyslvYUaxLkOtEUZW/EK8ArMFw==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/shared": "^3.5.34",
-        "@vueuse/core": "^14.3.0",
-        "cheerio": "^1.2.0",
-        "fflate": "^0.8.2",
-        "gray-matter": "^4.0.3",
-        "vue": "^3.5.34"
-      },
-      "peerDependencies": {
-        "@vuepress/bundler-vite": "2.0.0-rc.30",
-        "@vuepress/bundler-webpack": "2.0.0-rc.30",
-        "vuepress": "2.0.0-rc.30"
-      },
-      "peerDependenciesMeta": {
-        "@vuepress/bundler-vite": {
-          "optional": true
-        },
-        "@vuepress/bundler-webpack": {
-          "optional": true
-        }
+        "vuepress": "2.0.0-rc.31"
       }
     },
     "node_modules/@vuepress/plugin-catalog": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-catalog/-/plugin-catalog-2.0.0-rc.130.tgz",
-      "integrity": "sha512-SJvDFfgT0H+1hYAcIn9EzQ1L42YlIB6yhmEekGA04IAyWbsdO2lopK6v3++uEt5sH3bXQl8DxlaFMIxmemsa0A==",
+      "version": "2.0.0-rc.134",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-catalog/-/plugin-catalog-2.0.0-rc.134.tgz",
+      "integrity": "sha512-XpRT8mRXBFLnh2/uJPjDR5gxZgKT3GtJ8n2cd/vGt0zl4iQklvA67Lq3ufzHtMcw7vUz5TXjkHPQ1Pz1EUePow==",
       "license": "MIT",
       "dependencies": {
-        "@vuepress/helper": "2.0.0-rc.130",
-        "vue": "^3.5.34"
+        "@vuepress/helper": "2.0.0-rc.134",
+        "vue": "^3.5.42"
       },
       "peerDependencies": {
-        "vuepress": "2.0.0-rc.30"
-      }
-    },
-    "node_modules/@vuepress/plugin-catalog/node_modules/@vuepress/helper": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/helper/-/helper-2.0.0-rc.130.tgz",
-      "integrity": "sha512-x6UG/9XJvBREeTocRWji8SRqa14S+Xa8cw9b7Jc/Yh3eRwN/hrexM7ZkFixSjyslvYUaxLkOtEUZW/EK8ArMFw==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/shared": "^3.5.34",
-        "@vueuse/core": "^14.3.0",
-        "cheerio": "^1.2.0",
-        "fflate": "^0.8.2",
-        "gray-matter": "^4.0.3",
-        "vue": "^3.5.34"
-      },
-      "peerDependencies": {
-        "@vuepress/bundler-vite": "2.0.0-rc.30",
-        "@vuepress/bundler-webpack": "2.0.0-rc.30",
-        "vuepress": "2.0.0-rc.30"
-      },
-      "peerDependenciesMeta": {
-        "@vuepress/bundler-vite": {
-          "optional": true
-        },
-        "@vuepress/bundler-webpack": {
-          "optional": true
-        }
+        "vuepress": "2.0.0-rc.31"
       }
     },
     "node_modules/@vuepress/plugin-comment": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-comment/-/plugin-comment-2.0.0-rc.130.tgz",
-      "integrity": "sha512-JEMPgcZ8BHAn9EFgY9jOyUsKnTpp4RK1UJzamrhdp33YKxllZOeMPKCAG1D2un7hygydcVKP4x8o0wlG6xqOCA==",
+      "version": "2.0.0-rc.134",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-comment/-/plugin-comment-2.0.0-rc.134.tgz",
+      "integrity": "sha512-GOM69XuInZSYl4PusOcy703kPF01fABtbR2ylPJhS/qdqMOdfryxVZmfvTci0KJAfk5UrRvsg0elCSRrHybVBg==",
       "license": "MIT",
       "dependencies": {
-        "@vuepress/helper": "2.0.0-rc.130",
-        "@vueuse/core": "^14.3.0",
+        "@vuepress/helper": "2.0.0-rc.134",
+        "@vueuse/core": "^14.4.0",
         "giscus": "^1.6.0",
-        "vue": "^3.5.34"
+        "vue": "^3.5.42"
       },
       "peerDependencies": {
         "@waline/client": "^3.13.0",
         "artalk": "^2.9.1",
         "twikoo": "^1.7.2",
-        "vuepress": "2.0.0-rc.30"
+        "vuepress": "2.0.0-rc.31"
       },
       "peerDependenciesMeta": {
         "@waline/client": {
@@ -3451,274 +2815,149 @@
         }
       }
     },
-    "node_modules/@vuepress/plugin-comment/node_modules/@vuepress/helper": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/helper/-/helper-2.0.0-rc.130.tgz",
-      "integrity": "sha512-x6UG/9XJvBREeTocRWji8SRqa14S+Xa8cw9b7Jc/Yh3eRwN/hrexM7ZkFixSjyslvYUaxLkOtEUZW/EK8ArMFw==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/shared": "^3.5.34",
-        "@vueuse/core": "^14.3.0",
-        "cheerio": "^1.2.0",
-        "fflate": "^0.8.2",
-        "gray-matter": "^4.0.3",
-        "vue": "^3.5.34"
-      },
-      "peerDependencies": {
-        "@vuepress/bundler-vite": "2.0.0-rc.30",
-        "@vuepress/bundler-webpack": "2.0.0-rc.30",
-        "vuepress": "2.0.0-rc.30"
-      },
-      "peerDependenciesMeta": {
-        "@vuepress/bundler-vite": {
-          "optional": true
-        },
-        "@vuepress/bundler-webpack": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@vuepress/plugin-copy-code": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-copy-code/-/plugin-copy-code-2.0.0-rc.130.tgz",
-      "integrity": "sha512-LlYzqvZ3//0+YSHKbG8arxrMUQyom+fneXdbEjB1UB7GqNE1UvPRWvn+bP9/e/uFNdHvFTGrBe9XhWmy++SpSQ==",
+      "version": "2.0.0-rc.134",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-copy-code/-/plugin-copy-code-2.0.0-rc.134.tgz",
+      "integrity": "sha512-ye0xrWQVomYVdPpvMRkWMJNH5/JPzwqVL6+zPYGSg/BRU9MGbWAJFRO2uS6jXYc2jQ4vQ+U1i6p4j4QyFb9v8Q==",
       "license": "MIT",
       "dependencies": {
-        "@vuepress/helper": "2.0.0-rc.130",
-        "@vueuse/core": "^14.3.0",
-        "vue": "^3.5.34"
+        "@vuepress/helper": "2.0.0-rc.134",
+        "@vueuse/core": "^14.4.0",
+        "vue": "^3.5.42"
       },
       "peerDependencies": {
-        "vuepress": "2.0.0-rc.30"
-      }
-    },
-    "node_modules/@vuepress/plugin-copy-code/node_modules/@vuepress/helper": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/helper/-/helper-2.0.0-rc.130.tgz",
-      "integrity": "sha512-x6UG/9XJvBREeTocRWji8SRqa14S+Xa8cw9b7Jc/Yh3eRwN/hrexM7ZkFixSjyslvYUaxLkOtEUZW/EK8ArMFw==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/shared": "^3.5.34",
-        "@vueuse/core": "^14.3.0",
-        "cheerio": "^1.2.0",
-        "fflate": "^0.8.2",
-        "gray-matter": "^4.0.3",
-        "vue": "^3.5.34"
-      },
-      "peerDependencies": {
-        "@vuepress/bundler-vite": "2.0.0-rc.30",
-        "@vuepress/bundler-webpack": "2.0.0-rc.30",
-        "vuepress": "2.0.0-rc.30"
-      },
-      "peerDependenciesMeta": {
-        "@vuepress/bundler-vite": {
-          "optional": true
-        },
-        "@vuepress/bundler-webpack": {
-          "optional": true
-        }
+        "vuepress": "2.0.0-rc.31"
       }
     },
     "node_modules/@vuepress/plugin-copyright": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-copyright/-/plugin-copyright-2.0.0-rc.130.tgz",
-      "integrity": "sha512-Sgq8voS4qTg5Dmfq8LQL5EUyyzcnyY+OqFJegNjMMf6o7Aa3JXiXaPcTPKBe+NRTU21d4CwLO8OaojN7KjvI3A==",
+      "version": "2.0.0-rc.134",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-copyright/-/plugin-copyright-2.0.0-rc.134.tgz",
+      "integrity": "sha512-mzegZDlLwzw1WAAnt2zcG0fX+x9yJcmbyw69pTrIDmJRSI14Ae3ZIKEqtQBkQ/TVcbKhB0zlyt0mYxyCvW9RkQ==",
       "license": "MIT",
       "dependencies": {
-        "@vuepress/helper": "2.0.0-rc.130",
-        "@vueuse/core": "^14.3.0",
-        "vue": "^3.5.34"
+        "@vuepress/helper": "2.0.0-rc.134",
+        "@vueuse/core": "^14.4.0",
+        "vue": "^3.5.42"
       },
       "peerDependencies": {
-        "vuepress": "2.0.0-rc.30"
-      }
-    },
-    "node_modules/@vuepress/plugin-copyright/node_modules/@vuepress/helper": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/helper/-/helper-2.0.0-rc.130.tgz",
-      "integrity": "sha512-x6UG/9XJvBREeTocRWji8SRqa14S+Xa8cw9b7Jc/Yh3eRwN/hrexM7ZkFixSjyslvYUaxLkOtEUZW/EK8ArMFw==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/shared": "^3.5.34",
-        "@vueuse/core": "^14.3.0",
-        "cheerio": "^1.2.0",
-        "fflate": "^0.8.2",
-        "gray-matter": "^4.0.3",
-        "vue": "^3.5.34"
-      },
-      "peerDependencies": {
-        "@vuepress/bundler-vite": "2.0.0-rc.30",
-        "@vuepress/bundler-webpack": "2.0.0-rc.30",
-        "vuepress": "2.0.0-rc.30"
-      },
-      "peerDependenciesMeta": {
-        "@vuepress/bundler-vite": {
-          "optional": true
-        },
-        "@vuepress/bundler-webpack": {
-          "optional": true
-        }
+        "vuepress": "2.0.0-rc.31"
       }
     },
     "node_modules/@vuepress/plugin-git": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-git/-/plugin-git-2.0.0-rc.130.tgz",
-      "integrity": "sha512-0gSSiCR6Bv0b5ZB2IsO3EqlJxrblYIP0+ltadx2IkdFPsObvgaMKyu+VjRQ5NSuXTlcdJGGOatuRWckdfYtkZw==",
+      "version": "2.0.0-rc.134",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-git/-/plugin-git-2.0.0-rc.134.tgz",
+      "integrity": "sha512-W3Hkgd++pdwgF4U7CtPs02f7qON89W8XifvkJe8blpVZigq1mUw3/Nz5Abjua8MMCs4pvH9yuZ/b/OIitCazfw==",
       "license": "MIT",
       "dependencies": {
-        "@vuepress/helper": "2.0.0-rc.130",
-        "@vueuse/core": "^14.3.0",
+        "@vuepress/helper": "2.0.0-rc.134",
+        "@vueuse/core": "^14.4.0",
         "rehype-parse": "^9.0.1",
         "rehype-sanitize": "^6.0.0",
         "rehype-stringify": "^10.0.1",
         "unified": "^11.0.5",
-        "vue": "^3.5.34"
+        "vue": "^3.5.42"
       },
       "peerDependencies": {
-        "vuepress": "2.0.0-rc.30"
+        "vuepress": "2.0.0-rc.31"
       }
     },
-    "node_modules/@vuepress/plugin-git/node_modules/@vuepress/helper": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/helper/-/helper-2.0.0-rc.130.tgz",
-      "integrity": "sha512-x6UG/9XJvBREeTocRWji8SRqa14S+Xa8cw9b7Jc/Yh3eRwN/hrexM7ZkFixSjyslvYUaxLkOtEUZW/EK8ArMFw==",
+    "node_modules/@vuepress/plugin-icon": {
+      "version": "2.0.0-rc.134",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-icon/-/plugin-icon-2.0.0-rc.134.tgz",
+      "integrity": "sha512-X8KNezl9J0tEu7rGxRZoaP+WzTpMJkIGkfI3OqDv+gH33draWNJVN1/q2DrU2SM29usETW9zpxIc6KrFhJxNYg==",
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "^3.5.34",
-        "@vueuse/core": "^14.3.0",
-        "cheerio": "^1.2.0",
-        "fflate": "^0.8.2",
-        "gray-matter": "^4.0.3",
-        "vue": "^3.5.34"
+        "@mdit/plugin-icon": "^1.1.0",
+        "@vuepress/helper": "2.0.0-rc.134",
+        "@vueuse/core": "^14.4.0",
+        "vue": "^3.5.42"
       },
       "peerDependencies": {
-        "@vuepress/bundler-vite": "2.0.0-rc.30",
-        "@vuepress/bundler-webpack": "2.0.0-rc.30",
-        "vuepress": "2.0.0-rc.30"
+        "vuepress": "2.0.0-rc.31"
+      }
+    },
+    "node_modules/@vuepress/plugin-icon/node_modules/@mdit/helper": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mdit/helper/-/helper-1.1.1.tgz",
+      "integrity": "sha512-Rrl14ZjFerzfAqCt0zxAWbPgRpsumgm9iBLrCVE05WS8dM6v/LnF1ppPFVnRz1F7fAaxn0kTFOlYwzcY+kRsHQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "markdown-it": "^15.0.1"
       },
       "peerDependenciesMeta": {
-        "@vuepress/bundler-vite": {
-          "optional": true
-        },
-        "@vuepress/bundler-webpack": {
+        "markdown-it": {
           "optional": true
         }
       }
     },
-    "node_modules/@vuepress/plugin-icon": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-icon/-/plugin-icon-2.0.0-rc.130.tgz",
-      "integrity": "sha512-F4OXB32uEPvXrEGWai2QWZAIMAsz/XsCoVSVJYF+rBYUMKQJXaKfckBhH3Oc+q9JRKNhXjf+5209A5D3UoMKeg==",
+    "node_modules/@vuepress/plugin-icon/node_modules/@mdit/plugin-icon": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mdit/plugin-icon/-/plugin-icon-1.1.1.tgz",
+      "integrity": "sha512-tcVGsp9544Vt49OYYc52bznmjQwE8giVujwgfn5OgZ95oZpLtVaHRoHdCvmsHfwzBZi2WnEa3v40MNpors279A==",
       "license": "MIT",
       "dependencies": {
-        "@mdit/plugin-icon": "^0.24.2",
-        "@vuepress/helper": "2.0.0-rc.130",
-        "@vueuse/core": "^14.3.0",
-        "vue": "^3.5.34"
+        "@mdit/helper": "1.1.1"
+      },
+      "engines": {
+        "node": ">=22"
       },
       "peerDependencies": {
-        "vuepress": "2.0.0-rc.30"
-      }
-    },
-    "node_modules/@vuepress/plugin-icon/node_modules/@vuepress/helper": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/helper/-/helper-2.0.0-rc.130.tgz",
-      "integrity": "sha512-x6UG/9XJvBREeTocRWji8SRqa14S+Xa8cw9b7Jc/Yh3eRwN/hrexM7ZkFixSjyslvYUaxLkOtEUZW/EK8ArMFw==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/shared": "^3.5.34",
-        "@vueuse/core": "^14.3.0",
-        "cheerio": "^1.2.0",
-        "fflate": "^0.8.2",
-        "gray-matter": "^4.0.3",
-        "vue": "^3.5.34"
-      },
-      "peerDependencies": {
-        "@vuepress/bundler-vite": "2.0.0-rc.30",
-        "@vuepress/bundler-webpack": "2.0.0-rc.30",
-        "vuepress": "2.0.0-rc.30"
+        "markdown-it": "^15.0.1"
       },
       "peerDependenciesMeta": {
-        "@vuepress/bundler-vite": {
-          "optional": true
-        },
-        "@vuepress/bundler-webpack": {
+        "markdown-it": {
           "optional": true
         }
       }
     },
     "node_modules/@vuepress/plugin-links-check": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-links-check/-/plugin-links-check-2.0.0-rc.130.tgz",
-      "integrity": "sha512-eBvUBKq2xaG1eDronovmUNtJlTc29Ve/psMYAX9XfJojz/JoBbIEKLqYLBoYBti09IQ0YY2i6NNaaE13MnCsLA==",
+      "version": "2.0.0-rc.134",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-links-check/-/plugin-links-check-2.0.0-rc.134.tgz",
+      "integrity": "sha512-TdDwAvzbwzcV+/FoaOyJItddykL32KSniIbGWlBShSBxs7vFhrNfK6AVptIJbuk3WGYdPj12915diD+8/dMXeA==",
       "license": "MIT",
       "dependencies": {
-        "@vuepress/helper": "2.0.0-rc.130"
+        "@vuepress/helper": "2.0.0-rc.134"
       },
       "peerDependencies": {
-        "vuepress": "2.0.0-rc.30"
-      }
-    },
-    "node_modules/@vuepress/plugin-links-check/node_modules/@vuepress/helper": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/helper/-/helper-2.0.0-rc.130.tgz",
-      "integrity": "sha512-x6UG/9XJvBREeTocRWji8SRqa14S+Xa8cw9b7Jc/Yh3eRwN/hrexM7ZkFixSjyslvYUaxLkOtEUZW/EK8ArMFw==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/shared": "^3.5.34",
-        "@vueuse/core": "^14.3.0",
-        "cheerio": "^1.2.0",
-        "fflate": "^0.8.2",
-        "gray-matter": "^4.0.3",
-        "vue": "^3.5.34"
-      },
-      "peerDependencies": {
-        "@vuepress/bundler-vite": "2.0.0-rc.30",
-        "@vuepress/bundler-webpack": "2.0.0-rc.30",
-        "vuepress": "2.0.0-rc.30"
-      },
-      "peerDependenciesMeta": {
-        "@vuepress/bundler-vite": {
-          "optional": true
-        },
-        "@vuepress/bundler-webpack": {
-          "optional": true
-        }
+        "vuepress": "2.0.0-rc.31"
       }
     },
     "node_modules/@vuepress/plugin-llms": {
-      "version": "2.0.0-rc.132",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-llms/-/plugin-llms-2.0.0-rc.132.tgz",
-      "integrity": "sha512-2QffIkjfQGA7E3C2fJ47aebnrGXbhYPbSEBZYSm3ULGDNGrZi4s3lZFCVVNSFBZA0/j5c6BCIUWU4YfRMFOTLA==",
+      "version": "2.0.0-rc.134",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-llms/-/plugin-llms-2.0.0-rc.134.tgz",
+      "integrity": "sha512-xAUlxQWazXu5h8Stnfc5/DNXlMf0VrsCx6llLatuX7HSBd+W4mOm5MqH4R3vtaczK6KTTV452W2hlv2afMsFCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.4",
-        "@vuepress/helper": "2.0.0-rc.131",
+        "@vuepress/helper": "2.0.0-rc.134",
         "byte-size": "^9.0.1",
         "gray-matter": "^4.0.3",
         "mdast-util-from-markdown": "^2.0.3",
         "millify": "^6.1.0",
         "remark": "^15.0.1",
-        "tokenx": "^1.3.0",
+        "tokenx": "^2.1.0",
         "unist-util-remove": "^4.0.0",
         "unist-util-visit": "^5.1.0"
       },
       "peerDependencies": {
-        "vuepress": "2.0.0-rc.30"
+        "vuepress": "2.0.0-rc.31"
       }
     },
     "node_modules/@vuepress/plugin-markdown-chart": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-markdown-chart/-/plugin-markdown-chart-2.0.0-rc.130.tgz",
-      "integrity": "sha512-NpKtIN7dH25HfilhG7fI6f25iizmqfqwFoQuoQ1Hh7Bcvi4G+Fzf0655cXV8aIsGxJMP7EjlqWL6Lg2/UjOGvg==",
+      "version": "2.0.0-rc.134",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-markdown-chart/-/plugin-markdown-chart-2.0.0-rc.134.tgz",
+      "integrity": "sha512-9L55+YAD0iCw3fA6afRMymYGegoFsUOGXiR12OCL96pshPDgjmuJOzFvElFcC/Fr38ad2be0KiO4GmQhZ8nhjA==",
       "license": "MIT",
       "dependencies": {
-        "@mdit/plugin-container": "^0.23.2",
-        "@mdit/plugin-plantuml": "^0.24.2",
-        "@vuepress/helper": "2.0.0-rc.130",
-        "@vueuse/core": "^14.3.0",
-        "vue": "^3.5.34"
+        "@mdit/plugin-container": "^2.0.0",
+        "@mdit/plugin-plantuml": "^2.0.0",
+        "@vuepress/helper": "2.0.0-rc.134",
+        "@vueuse/core": "^14.4.0",
+        "vue": "^3.5.42"
       },
       "peerDependencies": {
         "chart.js": "^4.5.1",
@@ -3728,7 +2967,7 @@
         "markmap-toolbar": "^0.18.12",
         "markmap-view": "^0.18.12",
         "mermaid": "^11.14.0",
-        "vuepress": "2.0.0-rc.30"
+        "vuepress": "2.0.0-rc.31"
       },
       "peerDependenciesMeta": {
         "chart.js": {
@@ -3754,74 +2993,170 @@
         }
       }
     },
-    "node_modules/@vuepress/plugin-markdown-chart/node_modules/@vuepress/helper": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/helper/-/helper-2.0.0-rc.130.tgz",
-      "integrity": "sha512-x6UG/9XJvBREeTocRWji8SRqa14S+Xa8cw9b7Jc/Yh3eRwN/hrexM7ZkFixSjyslvYUaxLkOtEUZW/EK8ArMFw==",
+    "node_modules/@vuepress/plugin-markdown-chart/node_modules/@mdit/helper": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mdit/helper/-/helper-1.1.1.tgz",
+      "integrity": "sha512-Rrl14ZjFerzfAqCt0zxAWbPgRpsumgm9iBLrCVE05WS8dM6v/LnF1ppPFVnRz1F7fAaxn0kTFOlYwzcY+kRsHQ==",
       "license": "MIT",
-      "dependencies": {
-        "@vue/shared": "^3.5.34",
-        "@vueuse/core": "^14.3.0",
-        "cheerio": "^1.2.0",
-        "fflate": "^0.8.2",
-        "gray-matter": "^4.0.3",
-        "vue": "^3.5.34"
+      "engines": {
+        "node": ">=22"
       },
       "peerDependencies": {
-        "@vuepress/bundler-vite": "2.0.0-rc.30",
-        "@vuepress/bundler-webpack": "2.0.0-rc.30",
-        "vuepress": "2.0.0-rc.30"
+        "markdown-it": "^15.0.1"
       },
       "peerDependenciesMeta": {
-        "@vuepress/bundler-vite": {
+        "markdown-it": {
           "optional": true
-        },
-        "@vuepress/bundler-webpack": {
+        }
+      }
+    },
+    "node_modules/@vuepress/plugin-markdown-chart/node_modules/@mdit/plugin-container": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@mdit/plugin-container/-/plugin-container-2.0.1.tgz",
+      "integrity": "sha512-Heb0mQRy7AI46Szw1X/rqk2W7QJfVzJp08e2RRr41uN5eMuDFHXjpG/Fb3ywaTI7aw/MD4Q57Mug3hBKf5oZDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@mdit/helper": "1.1.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "markdown-it": "^15.0.1"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vuepress/plugin-markdown-chart/node_modules/@mdit/plugin-plantuml": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@mdit/plugin-plantuml/-/plugin-plantuml-2.0.1.tgz",
+      "integrity": "sha512-OvmGO2ICbvYKcwqYG4ei/hTQ+hDEQtQTxQRg+0THklOfWT7gXh4aC8c8oZpEAuGQFqoKmVQyerOsXVO6TXBqWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@mdit/helper": "1.1.1",
+        "@mdit/plugin-uml": "2.0.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "markdown-it": "^15.0.1"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vuepress/plugin-markdown-chart/node_modules/@mdit/plugin-uml": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@mdit/plugin-uml/-/plugin-uml-2.0.1.tgz",
+      "integrity": "sha512-I358hHOU0OjiJizuAjBSqsfKDgzduFd2eTfaTgoPwO/vhIDk1DxWvj5SbgeFCzNpkAd1acrxEWmn3u2QYY9TEw==",
+      "license": "MIT",
+      "dependencies": {
+        "@mdit/helper": "1.1.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "markdown-it": "^15.0.1"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it": {
           "optional": true
         }
       }
     },
     "node_modules/@vuepress/plugin-markdown-ext": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-markdown-ext/-/plugin-markdown-ext-2.0.0-rc.130.tgz",
-      "integrity": "sha512-5ib79ykId92+sBBT+nGyqz3wfJzO/xbc+t+XYAN2gQZGAw7XCjgq7FGa8lm06ABAcnu9mz0EfGN5B1ul3I74ww==",
+      "version": "2.0.0-rc.134",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-markdown-ext/-/plugin-markdown-ext-2.0.0-rc.134.tgz",
+      "integrity": "sha512-L37LQopCgnxcXqXQ+IqrmqJUGs9krmePWjm9PtatJS05cMGkgwSz/9z8tw3MwC/YMF0IIf27Tr4gUAt8fUMrBA==",
       "license": "MIT",
       "dependencies": {
-        "@mdit/plugin-container": "^0.23.2",
-        "@mdit/plugin-footnote": "^0.23.2",
-        "@mdit/plugin-tasklist": "^0.23.2",
-        "@types/markdown-it": "^14.1.2",
-        "@vuepress/helper": "2.0.0-rc.130",
-        "js-yaml": "^4.1.1",
-        "markdown-it-cjk-friendly": "^2.0.2"
+        "@mdit/plugin-container": "^2.0.0",
+        "@mdit/plugin-footnote": "^1.1.0",
+        "@mdit/plugin-tasklist": "^1.1.0",
+        "@types/markdown-it": "^14.2.0",
+        "@vuepress/helper": "2.0.0-rc.134",
+        "js-yaml": "^5.4.1",
+        "markdown-it-cjk-friendly": "^3.0.0"
       },
       "peerDependencies": {
-        "vuepress": "2.0.0-rc.30"
+        "vuepress": "2.0.0-rc.31"
       }
     },
-    "node_modules/@vuepress/plugin-markdown-ext/node_modules/@vuepress/helper": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/helper/-/helper-2.0.0-rc.130.tgz",
-      "integrity": "sha512-x6UG/9XJvBREeTocRWji8SRqa14S+Xa8cw9b7Jc/Yh3eRwN/hrexM7ZkFixSjyslvYUaxLkOtEUZW/EK8ArMFw==",
+    "node_modules/@vuepress/plugin-markdown-ext/node_modules/@mdit/helper": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mdit/helper/-/helper-1.1.1.tgz",
+      "integrity": "sha512-Rrl14ZjFerzfAqCt0zxAWbPgRpsumgm9iBLrCVE05WS8dM6v/LnF1ppPFVnRz1F7fAaxn0kTFOlYwzcY+kRsHQ==",
       "license": "MIT",
-      "dependencies": {
-        "@vue/shared": "^3.5.34",
-        "@vueuse/core": "^14.3.0",
-        "cheerio": "^1.2.0",
-        "fflate": "^0.8.2",
-        "gray-matter": "^4.0.3",
-        "vue": "^3.5.34"
+      "engines": {
+        "node": ">=22"
       },
       "peerDependencies": {
-        "@vuepress/bundler-vite": "2.0.0-rc.30",
-        "@vuepress/bundler-webpack": "2.0.0-rc.30",
-        "vuepress": "2.0.0-rc.30"
+        "markdown-it": "^15.0.1"
       },
       "peerDependenciesMeta": {
-        "@vuepress/bundler-vite": {
+        "markdown-it": {
           "optional": true
-        },
-        "@vuepress/bundler-webpack": {
+        }
+      }
+    },
+    "node_modules/@vuepress/plugin-markdown-ext/node_modules/@mdit/plugin-container": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@mdit/plugin-container/-/plugin-container-2.0.1.tgz",
+      "integrity": "sha512-Heb0mQRy7AI46Szw1X/rqk2W7QJfVzJp08e2RRr41uN5eMuDFHXjpG/Fb3ywaTI7aw/MD4Q57Mug3hBKf5oZDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@mdit/helper": "1.1.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "markdown-it": "^15.0.1"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vuepress/plugin-markdown-ext/node_modules/@mdit/plugin-footnote": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mdit/plugin-footnote/-/plugin-footnote-1.1.1.tgz",
+      "integrity": "sha512-0VV4rhegFSX8mp4/nG1rO3fgoDLofjnXIsAwRDK6Ajs9aj3NqSBB8HyYPnT7Ti0yPNn7XHHtqgrgJzYsbcDfyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@mdit/helper": "1.1.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "markdown-it": "^15.0.1"
+      }
+    },
+    "node_modules/@vuepress/plugin-markdown-ext/node_modules/@mdit/plugin-tasklist": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mdit/plugin-tasklist/-/plugin-tasklist-1.1.1.tgz",
+      "integrity": "sha512-vFQhn5voi2BZJq76YQ6EQ6WbgoxCyFyZBJqaLQaSpLG+yJEU7QANlGgfkWHLVJw/rSG0mQxbXsFaKkZuUPeRuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@mdit/helper": "1.1.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "markdown-it": "^15.0.1"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it": {
           "optional": true
         }
       }
@@ -3832,10 +3167,23 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
+    "node_modules/@vuepress/plugin-markdown-ext/node_modules/entities": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.1.0.tgz",
+      "integrity": "sha512-kxL7msIffSuh9aaFAMD7rxAIuTRMAHMeBtgHW2yUdWw732ZNh4MehkF2gdjvtdmikkaIP9bFDDJOPlsvm7avrA==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/@vuepress/plugin-markdown-ext/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.4.1.tgz",
+      "integrity": "sha512-28R/k+NAjeuf7+CKlTxWZVExJGwVVLwY06DgEnOMz2gEpfNkDcD7QvyiVPT0xy0XXhU8vHsd4Ot42OOPdJG7dQ==",
       "funding": [
         {
           "type": "github",
@@ -3851,153 +3199,336 @@
         "argparse": "^2.0.1"
       },
       "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "js-yaml": "bin/js-yaml.mjs"
       }
+    },
+    "node_modules/@vuepress/plugin-markdown-ext/node_modules/linkify-it": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-6.1.0.tgz",
+      "integrity": "sha512-wJ/TwpSDTLepCrQoYWYIExIKg5Zchex2Nn5yk2mFnB+6PtdkHtyLx742md9csRjjOnGkKIS/RrbY7l8D6gT9Vw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "uc.micro": "^3.0.0"
+      }
+    },
+    "node_modules/@vuepress/plugin-markdown-ext/node_modules/markdown-it": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-15.0.2.tgz",
+      "integrity": "sha512-q4IGxMv56jCqT4OCRCADBoDP3LO4MhmTXjFbphHPXs4g3j9Xg5RDnxqN8IF/3vIWEU+VCnUq+7JUg/cfy2E6Qw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "argparse": "^3.0.0",
+        "entities": "^8.0.0",
+        "linkify-it": "^6.0.0",
+        "mdurl": "^2.1.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^3.0.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/@vuepress/plugin-markdown-ext/node_modules/markdown-it/node_modules/argparse": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-3.0.2.tgz",
+      "integrity": "sha512-mFdDM6WqWKraGLsVb+C9CahPnzTXOefAOLq3jYcca2YZ8bEWpr++Tzj+zSaKW9+X9L5uSxcm1AZ3Y6aZJ09OhQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "PSF-2.0",
+      "peer": true
+    },
+    "node_modules/@vuepress/plugin-markdown-ext/node_modules/uc.micro": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-3.0.0.tgz",
+      "integrity": "sha512-U3PppEkleoTnIfi8BozMx3yju3qc/L6SwqWo2Sw+54PX+PX0q9I+r1Um5HCmqD7n9VDX5/v3vQH/AjA6deDdtw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@vuepress/plugin-markdown-hint": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-markdown-hint/-/plugin-markdown-hint-2.0.0-rc.130.tgz",
-      "integrity": "sha512-eGOnmUcBCCErdiWDJp8YgtOQtU1YsrRYuy1r3inA0euCaQbBWGotIwatS9s3NK2/eCABtwy5im4r/6ExKq7YpA==",
+      "version": "2.0.0-rc.134",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-markdown-hint/-/plugin-markdown-hint-2.0.0-rc.134.tgz",
+      "integrity": "sha512-O2d/n/6e4cFBMIxXZaxKH7GBr37fVAmgjzikOVaLpy7n5P5ketKvB460Gkq5lodKtOcnpu5/RtHG6if6NJhTWQ==",
       "license": "MIT",
       "dependencies": {
-        "@mdit/plugin-alert": "^0.23.2",
-        "@mdit/plugin-container": "^0.23.2",
-        "@types/markdown-it": "^14.1.2",
-        "@vuepress/helper": "2.0.0-rc.130",
-        "@vueuse/core": "^14.3.0"
+        "@mdit/plugin-alert": "^2.0.0",
+        "@mdit/plugin-container": "^2.0.0",
+        "@types/markdown-it": "^14.2.0",
+        "@vuepress/helper": "2.0.0-rc.134",
+        "@vueuse/core": "^14.4.0"
       },
       "peerDependencies": {
-        "vuepress": "2.0.0-rc.30"
+        "vuepress": "2.0.0-rc.31"
       }
     },
-    "node_modules/@vuepress/plugin-markdown-hint/node_modules/@vuepress/helper": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/helper/-/helper-2.0.0-rc.130.tgz",
-      "integrity": "sha512-x6UG/9XJvBREeTocRWji8SRqa14S+Xa8cw9b7Jc/Yh3eRwN/hrexM7ZkFixSjyslvYUaxLkOtEUZW/EK8ArMFw==",
+    "node_modules/@vuepress/plugin-markdown-hint/node_modules/@mdit/helper": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mdit/helper/-/helper-1.1.1.tgz",
+      "integrity": "sha512-Rrl14ZjFerzfAqCt0zxAWbPgRpsumgm9iBLrCVE05WS8dM6v/LnF1ppPFVnRz1F7fAaxn0kTFOlYwzcY+kRsHQ==",
       "license": "MIT",
-      "dependencies": {
-        "@vue/shared": "^3.5.34",
-        "@vueuse/core": "^14.3.0",
-        "cheerio": "^1.2.0",
-        "fflate": "^0.8.2",
-        "gray-matter": "^4.0.3",
-        "vue": "^3.5.34"
+      "engines": {
+        "node": ">=22"
       },
       "peerDependencies": {
-        "@vuepress/bundler-vite": "2.0.0-rc.30",
-        "@vuepress/bundler-webpack": "2.0.0-rc.30",
-        "vuepress": "2.0.0-rc.30"
+        "markdown-it": "^15.0.1"
       },
       "peerDependenciesMeta": {
-        "@vuepress/bundler-vite": {
+        "markdown-it": {
           "optional": true
-        },
-        "@vuepress/bundler-webpack": {
+        }
+      }
+    },
+    "node_modules/@vuepress/plugin-markdown-hint/node_modules/@mdit/plugin-alert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@mdit/plugin-alert/-/plugin-alert-2.0.1.tgz",
+      "integrity": "sha512-aWAjNZWQlXfCYUmTJvE+uWV0XZSz7SFcrI8N9Iq78XDZ3E/lEZo2apf9V5Nlbtc8cbda16fM9kx11GYwZlCSzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@mdit/helper": "1.1.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "markdown-it": "^15.0.1"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vuepress/plugin-markdown-hint/node_modules/@mdit/plugin-container": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@mdit/plugin-container/-/plugin-container-2.0.1.tgz",
+      "integrity": "sha512-Heb0mQRy7AI46Szw1X/rqk2W7QJfVzJp08e2RRr41uN5eMuDFHXjpG/Fb3ywaTI7aw/MD4Q57Mug3hBKf5oZDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@mdit/helper": "1.1.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "markdown-it": "^15.0.1"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it": {
           "optional": true
         }
       }
     },
     "node_modules/@vuepress/plugin-markdown-image": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-markdown-image/-/plugin-markdown-image-2.0.0-rc.130.tgz",
-      "integrity": "sha512-mtYpm7ulAsO1V+klYo+Lp6WLdZloifKIg9mlyJ9sbv+JUa9aCLTsmj9ve6vOGjVOKbtXyF63q8kkQVfcE0GLtw==",
+      "version": "2.0.0-rc.134",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-markdown-image/-/plugin-markdown-image-2.0.0-rc.134.tgz",
+      "integrity": "sha512-r8vX2jPPciQ2rsCpAaGcM5Nm3w5SXT4yhDNcfkDotk9PYRkf8m3U8zPK8MHltZOln/H/+ui5b1BSmNQAjj+akA==",
       "license": "MIT",
       "dependencies": {
-        "@mdit/plugin-figure": "^0.23.2",
-        "@mdit/plugin-img-lazyload": "^0.23.2",
-        "@mdit/plugin-img-mark": "^0.23.2",
-        "@mdit/plugin-img-size": "^0.23.2",
-        "@types/markdown-it": "^14.1.2",
-        "@vuepress/helper": "2.0.0-rc.130"
+        "@mdit/plugin-figure": "^1.2.0",
+        "@mdit/plugin-img-lazyload": "^1.1.0",
+        "@mdit/plugin-img-mark": "^1.1.0",
+        "@mdit/plugin-img-size": "^1.1.0",
+        "@types/markdown-it": "^14.2.0",
+        "@vuepress/helper": "2.0.0-rc.134"
       },
       "peerDependencies": {
-        "vuepress": "2.0.0-rc.30"
+        "vuepress": "2.0.0-rc.31"
       }
     },
-    "node_modules/@vuepress/plugin-markdown-image/node_modules/@vuepress/helper": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/helper/-/helper-2.0.0-rc.130.tgz",
-      "integrity": "sha512-x6UG/9XJvBREeTocRWji8SRqa14S+Xa8cw9b7Jc/Yh3eRwN/hrexM7ZkFixSjyslvYUaxLkOtEUZW/EK8ArMFw==",
+    "node_modules/@vuepress/plugin-markdown-image/node_modules/@mdit/helper": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mdit/helper/-/helper-1.1.1.tgz",
+      "integrity": "sha512-Rrl14ZjFerzfAqCt0zxAWbPgRpsumgm9iBLrCVE05WS8dM6v/LnF1ppPFVnRz1F7fAaxn0kTFOlYwzcY+kRsHQ==",
       "license": "MIT",
-      "dependencies": {
-        "@vue/shared": "^3.5.34",
-        "@vueuse/core": "^14.3.0",
-        "cheerio": "^1.2.0",
-        "fflate": "^0.8.2",
-        "gray-matter": "^4.0.3",
-        "vue": "^3.5.34"
+      "engines": {
+        "node": ">=22"
       },
       "peerDependencies": {
-        "@vuepress/bundler-vite": "2.0.0-rc.30",
-        "@vuepress/bundler-webpack": "2.0.0-rc.30",
-        "vuepress": "2.0.0-rc.30"
+        "markdown-it": "^15.0.1"
       },
       "peerDependenciesMeta": {
-        "@vuepress/bundler-vite": {
+        "markdown-it": {
           "optional": true
-        },
-        "@vuepress/bundler-webpack": {
+        }
+      }
+    },
+    "node_modules/@vuepress/plugin-markdown-image/node_modules/@mdit/plugin-figure": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@mdit/plugin-figure/-/plugin-figure-1.2.1.tgz",
+      "integrity": "sha512-a+MlxebF5oD5yI8lS+5wwRVfWFOsDVZaIJoQm7f+QSsMzH6glnH7E9E0DuYqhTJM7AnvyfofXkWuW+I0YbhfSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@mdit/helper": "1.1.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "markdown-it": "^15.0.1"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vuepress/plugin-markdown-image/node_modules/@mdit/plugin-img-lazyload": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mdit/plugin-img-lazyload/-/plugin-img-lazyload-1.1.1.tgz",
+      "integrity": "sha512-aZr/MkM0LLhGMJKjWI6/o0BdHRONzk6j5dOHK/BhyELcIjybKrwUH6QfEzsSFVnuwu3hXloQqOnTi0RLnF5ofQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@mdit/helper": "1.1.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "markdown-it": "^15.0.1"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vuepress/plugin-markdown-image/node_modules/@mdit/plugin-img-mark": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mdit/plugin-img-mark/-/plugin-img-mark-1.1.1.tgz",
+      "integrity": "sha512-rh/1lHADSt4HHNF4q6z9qT77us1ZSId0hmmXvwunl7MBNjxNTobiW25g9DbWRgfsi8JDQT2zeR5pViLimAKXWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@mdit/helper": "1.1.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "markdown-it": "^15.0.1"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vuepress/plugin-markdown-image/node_modules/@mdit/plugin-img-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mdit/plugin-img-size/-/plugin-img-size-1.1.1.tgz",
+      "integrity": "sha512-zl4Y+PCyahym3s0CyxTFa6X83yPWwALBh6SLtrx7rgaSZsKgsM3OqNlCLpOkVyUuYFgxoSkIoro0R01YGe7NXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@mdit/helper": "1.1.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "markdown-it": "^15.0.1"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it": {
           "optional": true
         }
       }
     },
     "node_modules/@vuepress/plugin-markdown-include": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-markdown-include/-/plugin-markdown-include-2.0.0-rc.130.tgz",
-      "integrity": "sha512-SdFpwBI3sLCPxx5Ddw4mD2GxL/pwWOuLJucHj0SOzIF8jY49ErkgE71KSxYvhBGiS/0dQUmt+CDg4SKldgmmwA==",
+      "version": "2.0.0-rc.134",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-markdown-include/-/plugin-markdown-include-2.0.0-rc.134.tgz",
+      "integrity": "sha512-dlOjVEuySQKWeAptrFVhGjkyANiAlW5nDdTKezLf+63uo123vUGHNgbEEm5MT07YWYLqqzAacJ77Eb2hDjvTdg==",
       "license": "MIT",
       "dependencies": {
-        "@mdit/plugin-include": "^0.23.2",
-        "@types/markdown-it": "^14.1.2",
-        "@vuepress/helper": "2.0.0-rc.130"
+        "@mdit/plugin-include": "^1.1.0",
+        "@types/markdown-it": "^14.2.0",
+        "@vuepress/helper": "2.0.0-rc.134"
       },
       "peerDependencies": {
-        "vuepress": "2.0.0-rc.30"
+        "vuepress": "2.0.0-rc.31"
       }
     },
-    "node_modules/@vuepress/plugin-markdown-include/node_modules/@vuepress/helper": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/helper/-/helper-2.0.0-rc.130.tgz",
-      "integrity": "sha512-x6UG/9XJvBREeTocRWji8SRqa14S+Xa8cw9b7Jc/Yh3eRwN/hrexM7ZkFixSjyslvYUaxLkOtEUZW/EK8ArMFw==",
+    "node_modules/@vuepress/plugin-markdown-include/node_modules/@mdit/helper": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mdit/helper/-/helper-1.1.1.tgz",
+      "integrity": "sha512-Rrl14ZjFerzfAqCt0zxAWbPgRpsumgm9iBLrCVE05WS8dM6v/LnF1ppPFVnRz1F7fAaxn0kTFOlYwzcY+kRsHQ==",
       "license": "MIT",
-      "dependencies": {
-        "@vue/shared": "^3.5.34",
-        "@vueuse/core": "^14.3.0",
-        "cheerio": "^1.2.0",
-        "fflate": "^0.8.2",
-        "gray-matter": "^4.0.3",
-        "vue": "^3.5.34"
+      "engines": {
+        "node": ">=22"
       },
       "peerDependencies": {
-        "@vuepress/bundler-vite": "2.0.0-rc.30",
-        "@vuepress/bundler-webpack": "2.0.0-rc.30",
-        "vuepress": "2.0.0-rc.30"
+        "markdown-it": "^15.0.1"
       },
       "peerDependenciesMeta": {
-        "@vuepress/bundler-vite": {
+        "markdown-it": {
           "optional": true
-        },
-        "@vuepress/bundler-webpack": {
+        }
+      }
+    },
+    "node_modules/@vuepress/plugin-markdown-include/node_modules/@mdit/plugin-include": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mdit/plugin-include/-/plugin-include-1.1.1.tgz",
+      "integrity": "sha512-DqJ9ztFvsaBbomamVqbVghvfkDlLGYd07VfaCKjjSeVf/zqsHzrqDW8eYluo5uT1d49J72N4Z0RpP6pRVN+NLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@mdit/helper": "1.1.1",
+        "upath": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "markdown-it": "^15.0.1"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it": {
           "optional": true
         }
       }
     },
     "node_modules/@vuepress/plugin-markdown-math": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-markdown-math/-/plugin-markdown-math-2.0.0-rc.130.tgz",
-      "integrity": "sha512-iyDvh+bMonqcaukxtHYeekdk4d57BhFqQ3zuiPz3rZRI+nmuUqdG9mC+nzN9K4NzxU2yi0z2cgPGO1cecdxIxA==",
+      "version": "2.0.0-rc.134",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-markdown-math/-/plugin-markdown-math-2.0.0-rc.134.tgz",
+      "integrity": "sha512-qpo/GpKhHPlPzlPHKHvd3w+583/7B1uaH+Z2db4DUoKGFa+WpN5rSJS+9znEczT/GeEie+QjlP/SIsbJGUU3ow==",
       "license": "MIT",
       "dependencies": {
-        "@mdit/plugin-katex-slim": "^0.26.2",
-        "@mdit/plugin-mathjax-slim": "^0.26.2",
-        "@types/markdown-it": "^14.1.2",
-        "@vuepress/helper": "2.0.0-rc.130",
-        "vue": "^3.5.34"
+        "@mdit/plugin-katex-slim": "^1.1.0",
+        "@mdit/plugin-mathjax-slim": "^1.2.0",
+        "@types/markdown-it": "^14.2.0",
+        "@vuepress/helper": "2.0.0-rc.134",
+        "vue": "^3.5.42"
       },
       "peerDependencies": {
         "@mathjax/src": "^4.1.1",
-        "katex": "^0.16.38",
-        "vuepress": "2.0.0-rc.30"
+        "katex": "^0.16.38 || ^0.18.0",
+        "vuepress": "2.0.0-rc.31"
       },
       "peerDependenciesMeta": {
         "@mathjax/src": {
@@ -4008,432 +3539,545 @@
         }
       }
     },
-    "node_modules/@vuepress/plugin-markdown-math/node_modules/@vuepress/helper": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/helper/-/helper-2.0.0-rc.130.tgz",
-      "integrity": "sha512-x6UG/9XJvBREeTocRWji8SRqa14S+Xa8cw9b7Jc/Yh3eRwN/hrexM7ZkFixSjyslvYUaxLkOtEUZW/EK8ArMFw==",
+    "node_modules/@vuepress/plugin-markdown-math/node_modules/@mdit/helper": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mdit/helper/-/helper-1.1.1.tgz",
+      "integrity": "sha512-Rrl14ZjFerzfAqCt0zxAWbPgRpsumgm9iBLrCVE05WS8dM6v/LnF1ppPFVnRz1F7fAaxn0kTFOlYwzcY+kRsHQ==",
       "license": "MIT",
-      "dependencies": {
-        "@vue/shared": "^3.5.34",
-        "@vueuse/core": "^14.3.0",
-        "cheerio": "^1.2.0",
-        "fflate": "^0.8.2",
-        "gray-matter": "^4.0.3",
-        "vue": "^3.5.34"
+      "engines": {
+        "node": ">=22"
       },
       "peerDependencies": {
-        "@vuepress/bundler-vite": "2.0.0-rc.30",
-        "@vuepress/bundler-webpack": "2.0.0-rc.30",
-        "vuepress": "2.0.0-rc.30"
+        "markdown-it": "^15.0.1"
       },
       "peerDependenciesMeta": {
-        "@vuepress/bundler-vite": {
+        "markdown-it": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vuepress/plugin-markdown-math/node_modules/@mdit/plugin-katex-slim": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mdit/plugin-katex-slim/-/plugin-katex-slim-1.1.1.tgz",
+      "integrity": "sha512-infYH1nOHs+5R987rvrdLqUUCXuyq/d/McI0I3KCwslbY3SLTAkXVlolw8t2UbqbrVpzYHZUP5layTFRp6eiqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@mdit/helper": "1.1.1",
+        "@mdit/plugin-tex": "1.1.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "katex": "^0.16.25 || ^0.17.0 || ^0.18.0",
+        "markdown-it": "^15.0.0"
+      },
+      "peerDependenciesMeta": {
+        "katex": {
           "optional": true
         },
-        "@vuepress/bundler-webpack": {
+        "markdown-it": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vuepress/plugin-markdown-math/node_modules/@mdit/plugin-mathjax-slim": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@mdit/plugin-mathjax-slim/-/plugin-mathjax-slim-1.2.1.tgz",
+      "integrity": "sha512-vTo3fS1EoN+hodNwcMrpuHXy4xB26Bwf7mOYyjjOsH8oB8i3Csdv3wha7NMxvH3joR5w0KXXtoKmtK5Qf+Ki5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@mdit/plugin-tex": "1.1.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "@mathjax/mathjax-newcm-font": "^4.1.3",
+        "@mathjax/src": "^4.1.3",
+        "markdown-it": "^15.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@mathjax/mathjax-newcm-font": {
+          "optional": true
+        },
+        "@mathjax/src": {
+          "optional": true
+        },
+        "markdown-it": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vuepress/plugin-markdown-math/node_modules/@mdit/plugin-tex": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mdit/plugin-tex/-/plugin-tex-1.1.1.tgz",
+      "integrity": "sha512-it1Nk5hbqL20YdaurYD3LiXiudEG/r6gqMYLIJNSg5d2qafrvMtYjUVKQbaHptsOLtuh0LHTHRJGXuw81N8AUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@mdit/helper": "1.1.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "markdown-it": "^15.0.1"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it": {
           "optional": true
         }
       }
     },
     "node_modules/@vuepress/plugin-markdown-preview": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-markdown-preview/-/plugin-markdown-preview-2.0.0-rc.130.tgz",
-      "integrity": "sha512-oLF7mD6BXvvTO4UOfMvousTAR6RCR66GBeoM7q1tRHoWN7W7wP7A+XQhgA4POXpHbvmkTRLVo07bIyceBAj0mA==",
+      "version": "2.0.0-rc.134",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-markdown-preview/-/plugin-markdown-preview-2.0.0-rc.134.tgz",
+      "integrity": "sha512-LiyEEZDEAj93xsrtHTsuTNpQk7/VDE/mIoy5YamsW47GxzSj4/3EPlbtCPH+hi8HN7Ynb4bOO8lrEJroII06oQ==",
       "license": "MIT",
       "dependencies": {
-        "@mdit/helper": "^0.23.2",
-        "@mdit/plugin-demo": "^0.23.2",
-        "@types/markdown-it": "^14.1.2",
-        "@vuepress/helper": "2.0.0-rc.130",
-        "@vueuse/core": "^14.3.0",
-        "vue": "^3.5.34"
+        "@mdit/helper": "^1.1.0",
+        "@mdit/plugin-demo": "^2.0.0",
+        "@types/markdown-it": "^14.2.0",
+        "@vuepress/helper": "2.0.0-rc.134",
+        "@vueuse/core": "^14.4.0",
+        "vue": "^3.5.42"
       },
       "peerDependencies": {
-        "vuepress": "2.0.0-rc.30"
+        "vuepress": "2.0.0-rc.31"
       }
     },
-    "node_modules/@vuepress/plugin-markdown-preview/node_modules/@vuepress/helper": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/helper/-/helper-2.0.0-rc.130.tgz",
-      "integrity": "sha512-x6UG/9XJvBREeTocRWji8SRqa14S+Xa8cw9b7Jc/Yh3eRwN/hrexM7ZkFixSjyslvYUaxLkOtEUZW/EK8ArMFw==",
+    "node_modules/@vuepress/plugin-markdown-preview/node_modules/@mdit/helper": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mdit/helper/-/helper-1.1.1.tgz",
+      "integrity": "sha512-Rrl14ZjFerzfAqCt0zxAWbPgRpsumgm9iBLrCVE05WS8dM6v/LnF1ppPFVnRz1F7fAaxn0kTFOlYwzcY+kRsHQ==",
       "license": "MIT",
-      "dependencies": {
-        "@vue/shared": "^3.5.34",
-        "@vueuse/core": "^14.3.0",
-        "cheerio": "^1.2.0",
-        "fflate": "^0.8.2",
-        "gray-matter": "^4.0.3",
-        "vue": "^3.5.34"
+      "engines": {
+        "node": ">=22"
       },
       "peerDependencies": {
-        "@vuepress/bundler-vite": "2.0.0-rc.30",
-        "@vuepress/bundler-webpack": "2.0.0-rc.30",
-        "vuepress": "2.0.0-rc.30"
+        "markdown-it": "^15.0.1"
       },
       "peerDependenciesMeta": {
-        "@vuepress/bundler-vite": {
+        "markdown-it": {
           "optional": true
-        },
-        "@vuepress/bundler-webpack": {
+        }
+      }
+    },
+    "node_modules/@vuepress/plugin-markdown-preview/node_modules/@mdit/plugin-demo": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@mdit/plugin-demo/-/plugin-demo-2.0.1.tgz",
+      "integrity": "sha512-0Uhjoq7v2b0HirR+7yIo3gZaWs1ChieYYVmvhqR606sm5iZPipq1t1JQ7rmd8bWeaatUOSAFwKlJWKNAoziIig==",
+      "license": "MIT",
+      "dependencies": {
+        "@mdit/helper": "1.1.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "markdown-it": "^15.0.1"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it": {
           "optional": true
         }
       }
     },
     "node_modules/@vuepress/plugin-markdown-stylize": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-markdown-stylize/-/plugin-markdown-stylize-2.0.0-rc.130.tgz",
-      "integrity": "sha512-WZ/Ls51lvfZ2UlEY1N8v2MCZjCJ9/w3VA0fPhoTkd/yI9ZX3/jBjd0AkK6srSYetj/rKB+1wHQ2Gg+V2oDDuaw==",
+      "version": "2.0.0-rc.134",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-markdown-stylize/-/plugin-markdown-stylize-2.0.0-rc.134.tgz",
+      "integrity": "sha512-5Y5pEFszlukjbqe16UBKdjfLHilRS5upBuTttUSJFIfdktMbAAigWQL4A89yFlJvn9K7FFly5LGLfXrq21eglw==",
       "license": "MIT",
       "dependencies": {
-        "@mdit/plugin-align": "^0.24.2",
-        "@mdit/plugin-attrs": "^0.25.2",
-        "@mdit/plugin-layout": "^0.2.2",
-        "@mdit/plugin-mark": "^0.23.2",
-        "@mdit/plugin-spoiler": "^0.23.2",
-        "@mdit/plugin-stylize": "^0.23.2",
-        "@mdit/plugin-sub": "^0.24.2",
-        "@mdit/plugin-sup": "^0.24.2",
-        "@types/markdown-it": "^14.1.2",
-        "@vuepress/helper": "2.0.0-rc.130"
+        "@mdit/plugin-align": "^1.1.0",
+        "@mdit/plugin-attrs": "^1.3.0",
+        "@mdit/plugin-layout": "^1.1.0",
+        "@mdit/plugin-mark": "^2.1.0",
+        "@mdit/plugin-spoiler": "^2.1.0",
+        "@mdit/plugin-stylize": "^2.0.0",
+        "@mdit/plugin-sub": "^1.1.0",
+        "@mdit/plugin-sup": "^1.1.0",
+        "@types/markdown-it": "^14.2.0",
+        "@vuepress/helper": "2.0.0-rc.134"
       },
       "peerDependencies": {
-        "vuepress": "2.0.0-rc.30"
+        "vuepress": "2.0.0-rc.31"
       }
     },
-    "node_modules/@vuepress/plugin-markdown-stylize/node_modules/@vuepress/helper": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/helper/-/helper-2.0.0-rc.130.tgz",
-      "integrity": "sha512-x6UG/9XJvBREeTocRWji8SRqa14S+Xa8cw9b7Jc/Yh3eRwN/hrexM7ZkFixSjyslvYUaxLkOtEUZW/EK8ArMFw==",
+    "node_modules/@vuepress/plugin-markdown-stylize/node_modules/@mdit/helper": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mdit/helper/-/helper-1.1.1.tgz",
+      "integrity": "sha512-Rrl14ZjFerzfAqCt0zxAWbPgRpsumgm9iBLrCVE05WS8dM6v/LnF1ppPFVnRz1F7fAaxn0kTFOlYwzcY+kRsHQ==",
       "license": "MIT",
-      "dependencies": {
-        "@vue/shared": "^3.5.34",
-        "@vueuse/core": "^14.3.0",
-        "cheerio": "^1.2.0",
-        "fflate": "^0.8.2",
-        "gray-matter": "^4.0.3",
-        "vue": "^3.5.34"
+      "engines": {
+        "node": ">=22"
       },
       "peerDependencies": {
-        "@vuepress/bundler-vite": "2.0.0-rc.30",
-        "@vuepress/bundler-webpack": "2.0.0-rc.30",
-        "vuepress": "2.0.0-rc.30"
+        "markdown-it": "^15.0.1"
       },
       "peerDependenciesMeta": {
-        "@vuepress/bundler-vite": {
+        "markdown-it": {
           "optional": true
-        },
-        "@vuepress/bundler-webpack": {
+        }
+      }
+    },
+    "node_modules/@vuepress/plugin-markdown-stylize/node_modules/@mdit/plugin-align": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mdit/plugin-align/-/plugin-align-1.1.1.tgz",
+      "integrity": "sha512-gyRlq3ehjJXsqi2gUkESslCHsl4BeZ1zTZe5f9xTbDwB8ZN28z9w2fIOS7fR1Fl3V6ykrS9zDC0pF9oy8Pi0FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@mdit/helper": "1.1.1",
+        "@mdit/plugin-container": "2.0.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "markdown-it": "^15.0.1"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vuepress/plugin-markdown-stylize/node_modules/@mdit/plugin-attrs": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@mdit/plugin-attrs/-/plugin-attrs-1.3.1.tgz",
+      "integrity": "sha512-PNW2PiQ1PIWHVYqJWVW+IKjMoYpTq6M9vWuyWnE9AZbkTh16KFDhfNgs0xUTtTQAIfI1jGN4IFQ46pvZowEEzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@mdit/helper": "1.1.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "markdown-it": "^15.0.1"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vuepress/plugin-markdown-stylize/node_modules/@mdit/plugin-container": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@mdit/plugin-container/-/plugin-container-2.0.1.tgz",
+      "integrity": "sha512-Heb0mQRy7AI46Szw1X/rqk2W7QJfVzJp08e2RRr41uN5eMuDFHXjpG/Fb3ywaTI7aw/MD4Q57Mug3hBKf5oZDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@mdit/helper": "1.1.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "markdown-it": "^15.0.1"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vuepress/plugin-markdown-stylize/node_modules/@mdit/plugin-inline-rule": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@mdit/plugin-inline-rule/-/plugin-inline-rule-2.2.1.tgz",
+      "integrity": "sha512-abU4gF31O9qhh0SGGfD/maoI8vPCt1oZ1VSho/TAs21eKeEUqQjXfgv2Y9dW7SY8zeZbHdxHze1bzvnOh1Rk2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@mdit/helper": "1.1.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "markdown-it": "^15.0.1"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vuepress/plugin-markdown-stylize/node_modules/@mdit/plugin-layout": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mdit/plugin-layout/-/plugin-layout-1.1.1.tgz",
+      "integrity": "sha512-IbXgeQlgWIMdu6YJeqjiHnDxkcPIqz72STrGuzOQQ59NAbSJQPyWSJymoPC4MMYgZous4KsT5x6S+gTr2lkkMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@mdit/helper": "1.1.1"
+      },
+      "peerDependencies": {
+        "markdown-it": "^15.0.1"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vuepress/plugin-markdown-stylize/node_modules/@mdit/plugin-mark": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@mdit/plugin-mark/-/plugin-mark-2.1.1.tgz",
+      "integrity": "sha512-GGc83glYiPWJYKxkS69btqDKb5MabiGo+WwgRWKaDimZjsNiZrvFyIF10zUXAEmYLBPMrY3a6TCBKaMCyp3l/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@mdit/helper": "1.1.1",
+        "@mdit/plugin-inline-rule": "2.2.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "markdown-it": "^15.0.1"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vuepress/plugin-markdown-stylize/node_modules/@mdit/plugin-spoiler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@mdit/plugin-spoiler/-/plugin-spoiler-2.1.1.tgz",
+      "integrity": "sha512-KT7VzkyPoMKqjv+aFQu6sDgRoY42+iYV7eUK5ehcOEuaS71CySkrz3G/Z5VoIk65PaKgPssZGnoKhybRdhsNfA==",
+      "license": "MIT",
+      "dependencies": {
+        "@mdit/helper": "1.1.1",
+        "@mdit/plugin-inline-rule": "2.2.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "markdown-it": "^15.0.1"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vuepress/plugin-markdown-stylize/node_modules/@mdit/plugin-stylize": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@mdit/plugin-stylize/-/plugin-stylize-2.0.1.tgz",
+      "integrity": "sha512-VXZGLkyz91B2/BRE5u0Mwl0o1l4YZ3h1EUMkL4q6zH/deH7IznnA7+TUidy30yjsTe7CyvUwSSDhfAsOpw6SBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@mdit/helper": "1.1.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "markdown-it": "^15.0.1"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vuepress/plugin-markdown-stylize/node_modules/@mdit/plugin-sub": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mdit/plugin-sub/-/plugin-sub-1.1.1.tgz",
+      "integrity": "sha512-7hqeZQPP2MJCT7YR3UsYdspBwZ0uPu7eLY9UCQssTvOD8V3lkp/Xi8vQ4xxz7pfhcLGJwsBG7pMRw07aBTkcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@mdit/helper": "1.1.1",
+        "@mdit/plugin-inline-rule": "2.2.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "markdown-it": "^15.0.1"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vuepress/plugin-markdown-stylize/node_modules/@mdit/plugin-sup": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mdit/plugin-sup/-/plugin-sup-1.1.1.tgz",
+      "integrity": "sha512-IW2CS9naSf0k/H9YZJ0z1O+F/Ls7vgMZOvW97TXeyJ3dyP6xt36RXqbsQSJBG42fZVmAjSHUbxDgbplDV8TSpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@mdit/helper": "1.1.1",
+        "@mdit/plugin-inline-rule": "2.2.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "markdown-it": "^15.0.1"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it": {
           "optional": true
         }
       }
     },
     "node_modules/@vuepress/plugin-markdown-tab": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-markdown-tab/-/plugin-markdown-tab-2.0.0-rc.130.tgz",
-      "integrity": "sha512-5GAMW+ejw/LeL1zAxZxqGt/o9jbNEtBLCuOWf2oCfQ/G8VuKYw0UcKS5mfJTEzAa98k9I61a7oAhcMc3z5sQ9g==",
+      "version": "2.0.0-rc.134",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-markdown-tab/-/plugin-markdown-tab-2.0.0-rc.134.tgz",
+      "integrity": "sha512-Je1uXpn+MpuFNELFPvnhmm3BfDCLSP1Ja/hLxZCQDSKcW69P3uqzn7cnXtqBnGY80RDw7x7AtAXGKoGsTmiqTw==",
       "license": "MIT",
       "dependencies": {
-        "@mdit/plugin-tab": "^0.24.2",
-        "@types/markdown-it": "^14.1.2",
-        "@vuepress/helper": "2.0.0-rc.130",
-        "@vueuse/core": "^14.3.0",
-        "vue": "^3.5.34"
+        "@mdit/plugin-tab": "^2.0.0",
+        "@types/markdown-it": "^14.2.0",
+        "@vuepress/helper": "2.0.0-rc.134",
+        "@vueuse/core": "^14.4.0",
+        "vue": "^3.5.42"
       },
       "peerDependencies": {
-        "vuepress": "2.0.0-rc.30"
+        "vuepress": "2.0.0-rc.31"
       }
     },
-    "node_modules/@vuepress/plugin-markdown-tab/node_modules/@vuepress/helper": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/helper/-/helper-2.0.0-rc.130.tgz",
-      "integrity": "sha512-x6UG/9XJvBREeTocRWji8SRqa14S+Xa8cw9b7Jc/Yh3eRwN/hrexM7ZkFixSjyslvYUaxLkOtEUZW/EK8ArMFw==",
+    "node_modules/@vuepress/plugin-markdown-tab/node_modules/@mdit/helper": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mdit/helper/-/helper-1.1.1.tgz",
+      "integrity": "sha512-Rrl14ZjFerzfAqCt0zxAWbPgRpsumgm9iBLrCVE05WS8dM6v/LnF1ppPFVnRz1F7fAaxn0kTFOlYwzcY+kRsHQ==",
       "license": "MIT",
-      "dependencies": {
-        "@vue/shared": "^3.5.34",
-        "@vueuse/core": "^14.3.0",
-        "cheerio": "^1.2.0",
-        "fflate": "^0.8.2",
-        "gray-matter": "^4.0.3",
-        "vue": "^3.5.34"
+      "engines": {
+        "node": ">=22"
       },
       "peerDependencies": {
-        "@vuepress/bundler-vite": "2.0.0-rc.30",
-        "@vuepress/bundler-webpack": "2.0.0-rc.30",
-        "vuepress": "2.0.0-rc.30"
+        "markdown-it": "^15.0.1"
       },
       "peerDependenciesMeta": {
-        "@vuepress/bundler-vite": {
+        "markdown-it": {
           "optional": true
-        },
-        "@vuepress/bundler-webpack": {
+        }
+      }
+    },
+    "node_modules/@vuepress/plugin-markdown-tab/node_modules/@mdit/plugin-tab": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@mdit/plugin-tab/-/plugin-tab-2.0.1.tgz",
+      "integrity": "sha512-hfl6yMlEAciZra0dnupPK2SzKlvBfQJLJUKfOtQ1rluYqhYuj+fadq6uu6mVUvT23p26sMSjxyMq3WJEpy/kPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@mdit/helper": "1.1.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "markdown-it": "^15.0.1"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it": {
           "optional": true
         }
       }
     },
     "node_modules/@vuepress/plugin-notice": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-notice/-/plugin-notice-2.0.0-rc.130.tgz",
-      "integrity": "sha512-rvsFxxf9TqhC7VQKVFZrlrAnaU97kgdoUWcqyfrfRcpl2MHtN6/cZXOow7eQzYqiFR0uYaMfnz8jzMlDvvl46g==",
+      "version": "2.0.0-rc.134",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-notice/-/plugin-notice-2.0.0-rc.134.tgz",
+      "integrity": "sha512-2n/gidK3JigDOJYq5aW886Cxp6ZfPRupHhn/CZsd5Tr6/xWsxpFH7u+5m0Znytahyh/Fcrp+Aqrq+GUrkbmnqQ==",
       "license": "MIT",
       "dependencies": {
-        "@vuepress/helper": "2.0.0-rc.130",
-        "@vueuse/core": "^14.3.0",
+        "@vuepress/helper": "2.0.0-rc.134",
+        "@vueuse/core": "^14.4.0",
         "chokidar": "^5.0.0",
-        "vue": "^3.5.34"
+        "vue": "^3.5.42"
       },
       "peerDependencies": {
-        "vuepress": "2.0.0-rc.30"
-      }
-    },
-    "node_modules/@vuepress/plugin-notice/node_modules/@vuepress/helper": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/helper/-/helper-2.0.0-rc.130.tgz",
-      "integrity": "sha512-x6UG/9XJvBREeTocRWji8SRqa14S+Xa8cw9b7Jc/Yh3eRwN/hrexM7ZkFixSjyslvYUaxLkOtEUZW/EK8ArMFw==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/shared": "^3.5.34",
-        "@vueuse/core": "^14.3.0",
-        "cheerio": "^1.2.0",
-        "fflate": "^0.8.2",
-        "gray-matter": "^4.0.3",
-        "vue": "^3.5.34"
-      },
-      "peerDependencies": {
-        "@vuepress/bundler-vite": "2.0.0-rc.30",
-        "@vuepress/bundler-webpack": "2.0.0-rc.30",
-        "vuepress": "2.0.0-rc.30"
-      },
-      "peerDependenciesMeta": {
-        "@vuepress/bundler-vite": {
-          "optional": true
-        },
-        "@vuepress/bundler-webpack": {
-          "optional": true
-        }
+        "vuepress": "2.0.0-rc.31"
       }
     },
     "node_modules/@vuepress/plugin-nprogress": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-nprogress/-/plugin-nprogress-2.0.0-rc.130.tgz",
-      "integrity": "sha512-mKSIbE11awTTrToRoeRcQa92T6FtRiFwwAGnBdg2szOYs9+gg206JsWiuQowerGb6YvR8An7e2Saww31LC2FjA==",
+      "version": "2.0.0-rc.134",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-nprogress/-/plugin-nprogress-2.0.0-rc.134.tgz",
+      "integrity": "sha512-jC0PExUcu33jeitgaXt5hiLZG5r0Qrdb3Vw4jA8H+QmMZ+R/y9RMyCj/roKwLyhbZwJChPl4+BAc4Wau4n9QzA==",
       "license": "MIT",
       "dependencies": {
-        "@vuepress/helper": "2.0.0-rc.130",
-        "vue": "^3.5.34"
+        "@vuepress/helper": "2.0.0-rc.134",
+        "vue": "^3.5.42"
       },
       "peerDependencies": {
-        "vuepress": "2.0.0-rc.30"
-      }
-    },
-    "node_modules/@vuepress/plugin-nprogress/node_modules/@vuepress/helper": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/helper/-/helper-2.0.0-rc.130.tgz",
-      "integrity": "sha512-x6UG/9XJvBREeTocRWji8SRqa14S+Xa8cw9b7Jc/Yh3eRwN/hrexM7ZkFixSjyslvYUaxLkOtEUZW/EK8ArMFw==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/shared": "^3.5.34",
-        "@vueuse/core": "^14.3.0",
-        "cheerio": "^1.2.0",
-        "fflate": "^0.8.2",
-        "gray-matter": "^4.0.3",
-        "vue": "^3.5.34"
-      },
-      "peerDependencies": {
-        "@vuepress/bundler-vite": "2.0.0-rc.30",
-        "@vuepress/bundler-webpack": "2.0.0-rc.30",
-        "vuepress": "2.0.0-rc.30"
-      },
-      "peerDependenciesMeta": {
-        "@vuepress/bundler-vite": {
-          "optional": true
-        },
-        "@vuepress/bundler-webpack": {
-          "optional": true
-        }
+        "vuepress": "2.0.0-rc.31"
       }
     },
     "node_modules/@vuepress/plugin-photo-swipe": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-photo-swipe/-/plugin-photo-swipe-2.0.0-rc.130.tgz",
-      "integrity": "sha512-Iu+mYMobiZgOXqFX1b6DvHZWVTHdsbfL/ewSXGhSQTpDv4sP3Szmbtico7e+Syz07f47TFH4MTGuoQ+Fc/cGuQ==",
+      "version": "2.0.0-rc.134",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-photo-swipe/-/plugin-photo-swipe-2.0.0-rc.134.tgz",
+      "integrity": "sha512-iTxYI+sornwcsVR8t0UgP1sWxvpZL/b6nxn63Z2g0UzXrIy3Y9oQZWd5h8bURFvODUvcQZSyHbAalpLKFgF3ag==",
       "license": "MIT",
       "dependencies": {
-        "@vuepress/helper": "2.0.0-rc.130",
-        "@vueuse/core": "^14.3.0",
+        "@vuepress/helper": "2.0.0-rc.134",
+        "@vueuse/core": "^14.4.0",
         "photoswipe": "^5.4.4",
-        "vue": "^3.5.34"
+        "vue": "^3.5.42"
       },
       "peerDependencies": {
-        "vuepress": "2.0.0-rc.30"
-      }
-    },
-    "node_modules/@vuepress/plugin-photo-swipe/node_modules/@vuepress/helper": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/helper/-/helper-2.0.0-rc.130.tgz",
-      "integrity": "sha512-x6UG/9XJvBREeTocRWji8SRqa14S+Xa8cw9b7Jc/Yh3eRwN/hrexM7ZkFixSjyslvYUaxLkOtEUZW/EK8ArMFw==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/shared": "^3.5.34",
-        "@vueuse/core": "^14.3.0",
-        "cheerio": "^1.2.0",
-        "fflate": "^0.8.2",
-        "gray-matter": "^4.0.3",
-        "vue": "^3.5.34"
-      },
-      "peerDependencies": {
-        "@vuepress/bundler-vite": "2.0.0-rc.30",
-        "@vuepress/bundler-webpack": "2.0.0-rc.30",
-        "vuepress": "2.0.0-rc.30"
-      },
-      "peerDependenciesMeta": {
-        "@vuepress/bundler-vite": {
-          "optional": true
-        },
-        "@vuepress/bundler-webpack": {
-          "optional": true
-        }
+        "vuepress": "2.0.0-rc.31"
       }
     },
     "node_modules/@vuepress/plugin-reading-time": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-reading-time/-/plugin-reading-time-2.0.0-rc.130.tgz",
-      "integrity": "sha512-yDf/UXu3/LrBh98WB7+Uvenrm0Od9pj4vQFjboWTChO+5y0rP/bayhFTxFlAMRhT7poWm4Yb+Xj6nrT0LugU/Q==",
+      "version": "2.0.0-rc.134",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-reading-time/-/plugin-reading-time-2.0.0-rc.134.tgz",
+      "integrity": "sha512-Ai9FYZB0lIv0xCo8ZeZX5iBql/1uGR7dRRR89yiyq652StqPnJ+vQvzR3Zw7XNWZxoEqMqeg/Sdl2gbAn78p4A==",
       "license": "MIT",
       "dependencies": {
-        "@vuepress/helper": "2.0.0-rc.130",
-        "vue": "^3.5.34"
+        "@vuepress/helper": "2.0.0-rc.134",
+        "vue": "^3.5.42"
       },
       "peerDependencies": {
-        "vuepress": "2.0.0-rc.30"
-      }
-    },
-    "node_modules/@vuepress/plugin-reading-time/node_modules/@vuepress/helper": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/helper/-/helper-2.0.0-rc.130.tgz",
-      "integrity": "sha512-x6UG/9XJvBREeTocRWji8SRqa14S+Xa8cw9b7Jc/Yh3eRwN/hrexM7ZkFixSjyslvYUaxLkOtEUZW/EK8ArMFw==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/shared": "^3.5.34",
-        "@vueuse/core": "^14.3.0",
-        "cheerio": "^1.2.0",
-        "fflate": "^0.8.2",
-        "gray-matter": "^4.0.3",
-        "vue": "^3.5.34"
-      },
-      "peerDependencies": {
-        "@vuepress/bundler-vite": "2.0.0-rc.30",
-        "@vuepress/bundler-webpack": "2.0.0-rc.30",
-        "vuepress": "2.0.0-rc.30"
-      },
-      "peerDependenciesMeta": {
-        "@vuepress/bundler-vite": {
-          "optional": true
-        },
-        "@vuepress/bundler-webpack": {
-          "optional": true
-        }
+        "vuepress": "2.0.0-rc.31"
       }
     },
     "node_modules/@vuepress/plugin-redirect": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-redirect/-/plugin-redirect-2.0.0-rc.130.tgz",
-      "integrity": "sha512-bqX81Pz6plOPQuEICZTDQY07BROT48Z+0DGzC7aQ+EVpss3yKbHwn8XHxF2gLs2nU+IRnPUP113mlWlxHJBheg==",
+      "version": "2.0.0-rc.134",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-redirect/-/plugin-redirect-2.0.0-rc.134.tgz",
+      "integrity": "sha512-hwhI8+g7Rq+THO3T1NPQVHzfZ1dniJrr5+0gNI46bkeXZYInHRVM14M1QvfRiDNNrWLAG9TxzRMCfjjpPcbyhw==",
       "license": "MIT",
       "dependencies": {
-        "@vuepress/helper": "2.0.0-rc.130",
-        "@vueuse/core": "^14.3.0",
-        "commander": "^14.0.3",
-        "vue": "^3.5.34"
+        "@vuepress/helper": "2.0.0-rc.134",
+        "@vueuse/core": "^14.4.0",
+        "commander": "^15.0.0",
+        "vue": "^3.5.42"
       },
       "bin": {
         "vp-redirect": "dist/cli/index.js"
       },
       "peerDependencies": {
-        "vuepress": "2.0.0-rc.30"
-      }
-    },
-    "node_modules/@vuepress/plugin-redirect/node_modules/@vuepress/helper": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/helper/-/helper-2.0.0-rc.130.tgz",
-      "integrity": "sha512-x6UG/9XJvBREeTocRWji8SRqa14S+Xa8cw9b7Jc/Yh3eRwN/hrexM7ZkFixSjyslvYUaxLkOtEUZW/EK8ArMFw==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/shared": "^3.5.34",
-        "@vueuse/core": "^14.3.0",
-        "cheerio": "^1.2.0",
-        "fflate": "^0.8.2",
-        "gray-matter": "^4.0.3",
-        "vue": "^3.5.34"
-      },
-      "peerDependencies": {
-        "@vuepress/bundler-vite": "2.0.0-rc.30",
-        "@vuepress/bundler-webpack": "2.0.0-rc.30",
-        "vuepress": "2.0.0-rc.30"
-      },
-      "peerDependenciesMeta": {
-        "@vuepress/bundler-vite": {
-          "optional": true
-        },
-        "@vuepress/bundler-webpack": {
-          "optional": true
-        }
+        "vuepress": "2.0.0-rc.31"
       }
     },
     "node_modules/@vuepress/plugin-rtl": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-rtl/-/plugin-rtl-2.0.0-rc.130.tgz",
-      "integrity": "sha512-5Pb2tpaa9vPwr5UVmcVwatBVkfnIA1LDeialk7IxUw5ppJ3c/onxrs2KvEzAQUSdtN2YCj4n2yK8a2ClhClL4g==",
+      "version": "2.0.0-rc.134",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-rtl/-/plugin-rtl-2.0.0-rc.134.tgz",
+      "integrity": "sha512-CtIS+xqt+ZvCLaO8rL+uHyWFOwFHo/WaLrNCaxl9nH1RAeLlaSMLXrz0jUiPw+mMaDvLRKm7PffwVd1d77YRnA==",
       "license": "MIT",
       "dependencies": {
-        "@vuepress/helper": "2.0.0-rc.130",
-        "@vueuse/core": "^14.3.0",
-        "vue": "^3.5.34"
+        "@vuepress/helper": "2.0.0-rc.134",
+        "@vueuse/core": "^14.4.0",
+        "vue": "^3.5.42"
       },
       "peerDependencies": {
-        "vuepress": "2.0.0-rc.30"
-      }
-    },
-    "node_modules/@vuepress/plugin-rtl/node_modules/@vuepress/helper": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/helper/-/helper-2.0.0-rc.130.tgz",
-      "integrity": "sha512-x6UG/9XJvBREeTocRWji8SRqa14S+Xa8cw9b7Jc/Yh3eRwN/hrexM7ZkFixSjyslvYUaxLkOtEUZW/EK8ArMFw==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/shared": "^3.5.34",
-        "@vueuse/core": "^14.3.0",
-        "cheerio": "^1.2.0",
-        "fflate": "^0.8.2",
-        "gray-matter": "^4.0.3",
-        "vue": "^3.5.34"
-      },
-      "peerDependencies": {
-        "@vuepress/bundler-vite": "2.0.0-rc.30",
-        "@vuepress/bundler-webpack": "2.0.0-rc.30",
-        "vuepress": "2.0.0-rc.30"
-      },
-      "peerDependenciesMeta": {
-        "@vuepress/bundler-vite": {
-          "optional": true
-        },
-        "@vuepress/bundler-webpack": {
-          "optional": true
-        }
+        "vuepress": "2.0.0-rc.31"
       }
     },
     "node_modules/@vuepress/plugin-sass-palette": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-sass-palette/-/plugin-sass-palette-2.0.0-rc.130.tgz",
-      "integrity": "sha512-30VTzIBLrzoJYoWdSz4K/1yC71e/OiGL6us0sJ71fDRVbTXXVQIQ0lyEMWJS5BrN6K22z4H6ujbYFQREjAWRwQ==",
+      "version": "2.0.0-rc.134",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-sass-palette/-/plugin-sass-palette-2.0.0-rc.134.tgz",
+      "integrity": "sha512-KibZWEfG54u6teAaqRntxB17uPI3uE2TgBn2VKrNqnSWOORa875FQXOV+2tTqc9ziI0nBymFu2i7qGV9nWGE1g==",
       "license": "MIT",
       "dependencies": {
-        "@vuepress/helper": "2.0.0-rc.130",
+        "@vuepress/helper": "2.0.0-rc.134",
         "chokidar": "^5.0.0"
       },
       "peerDependencies": {
         "sass": "^1.97.3",
         "sass-embedded": "^1.97.3",
-        "sass-loader": "^16.0.8",
-        "vuepress": "2.0.0-rc.30"
+        "sass-loader": "^17.0.1",
+        "vuepress": "2.0.0-rc.31"
       },
       "peerDependenciesMeta": {
         "sass": {
@@ -4447,88 +4091,34 @@
         }
       }
     },
-    "node_modules/@vuepress/plugin-sass-palette/node_modules/@vuepress/helper": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/helper/-/helper-2.0.0-rc.130.tgz",
-      "integrity": "sha512-x6UG/9XJvBREeTocRWji8SRqa14S+Xa8cw9b7Jc/Yh3eRwN/hrexM7ZkFixSjyslvYUaxLkOtEUZW/EK8ArMFw==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/shared": "^3.5.34",
-        "@vueuse/core": "^14.3.0",
-        "cheerio": "^1.2.0",
-        "fflate": "^0.8.2",
-        "gray-matter": "^4.0.3",
-        "vue": "^3.5.34"
-      },
-      "peerDependencies": {
-        "@vuepress/bundler-vite": "2.0.0-rc.30",
-        "@vuepress/bundler-webpack": "2.0.0-rc.30",
-        "vuepress": "2.0.0-rc.30"
-      },
-      "peerDependenciesMeta": {
-        "@vuepress/bundler-vite": {
-          "optional": true
-        },
-        "@vuepress/bundler-webpack": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@vuepress/plugin-seo": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-seo/-/plugin-seo-2.0.0-rc.130.tgz",
-      "integrity": "sha512-L+7B+kA4EsEaKixygFkhi9CwHW+SxQgcMYEBD4QICWht/fshEKZrxksbAaYM1c0o+hL3qgTFZVURp3Zc4kq2Ww==",
+      "version": "2.0.0-rc.134",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-seo/-/plugin-seo-2.0.0-rc.134.tgz",
+      "integrity": "sha512-DwUxaCmBW9NsYpZk5uvrBClA7t5TulNAZkfaNNSSYn+v0h0dTvd1yQPJzDiywcJ75pLcdgWu5zB7PzFrE3eSlQ==",
       "license": "MIT",
       "dependencies": {
-        "@vuepress/helper": "2.0.0-rc.130"
+        "@vuepress/helper": "2.0.0-rc.134"
       },
       "peerDependencies": {
-        "vuepress": "2.0.0-rc.30"
-      }
-    },
-    "node_modules/@vuepress/plugin-seo/node_modules/@vuepress/helper": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/helper/-/helper-2.0.0-rc.130.tgz",
-      "integrity": "sha512-x6UG/9XJvBREeTocRWji8SRqa14S+Xa8cw9b7Jc/Yh3eRwN/hrexM7ZkFixSjyslvYUaxLkOtEUZW/EK8ArMFw==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/shared": "^3.5.34",
-        "@vueuse/core": "^14.3.0",
-        "cheerio": "^1.2.0",
-        "fflate": "^0.8.2",
-        "gray-matter": "^4.0.3",
-        "vue": "^3.5.34"
-      },
-      "peerDependencies": {
-        "@vuepress/bundler-vite": "2.0.0-rc.30",
-        "@vuepress/bundler-webpack": "2.0.0-rc.30",
-        "vuepress": "2.0.0-rc.30"
-      },
-      "peerDependenciesMeta": {
-        "@vuepress/bundler-vite": {
-          "optional": true
-        },
-        "@vuepress/bundler-webpack": {
-          "optional": true
-        }
+        "vuepress": "2.0.0-rc.31"
       }
     },
     "node_modules/@vuepress/plugin-shiki": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-shiki/-/plugin-shiki-2.0.0-rc.130.tgz",
-      "integrity": "sha512-OkkRrXgr/Im6NFcYZhGzeV5yQRDqeE6GvzvwOvysMO2s0PRqb1D+Cd1Vj7Q+OYFg5Wb/IeiVSj2BH82LaXr29Q==",
+      "version": "2.0.0-rc.134",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-shiki/-/plugin-shiki-2.0.0-rc.134.tgz",
+      "integrity": "sha512-EpzUEkmDaFozSp3KOa9uk1sttDEubkxTYazv6rsv00wPwFlvg5Txj0JvRLDcJr8I3YywCNTDB5bRdC4tXVM0BA==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/transformers": "^4.0.2",
-        "@vuepress/helper": "2.0.0-rc.130",
-        "@vuepress/highlighter-helper": "2.0.0-rc.130",
-        "nanoid": "^5.1.11",
-        "shiki": "^4.0.2",
-        "synckit": "^0.11.12"
+        "@shikijs/transformers": "^4.4.3",
+        "@vuepress/helper": "2.0.0-rc.134",
+        "@vuepress/highlighter-helper": "2.0.0-rc.134",
+        "nanoid": "^6.0.1",
+        "shiki": "^4.4.3",
+        "synckit": "^0.11.13"
       },
       "peerDependencies": {
-        "@vuepress/shiki-twoslash": "2.0.0-rc.130",
-        "vuepress": "2.0.0-rc.30"
+        "@vuepress/shiki-twoslash": "2.0.0-rc.134",
+        "vuepress": "2.0.0-rc.31"
       },
       "peerDependenciesMeta": {
         "@vuepress/shiki-twoslash": {
@@ -4536,53 +4126,10 @@
         }
       }
     },
-    "node_modules/@vuepress/plugin-shiki/node_modules/@vuepress/helper": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/helper/-/helper-2.0.0-rc.130.tgz",
-      "integrity": "sha512-x6UG/9XJvBREeTocRWji8SRqa14S+Xa8cw9b7Jc/Yh3eRwN/hrexM7ZkFixSjyslvYUaxLkOtEUZW/EK8ArMFw==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/shared": "^3.5.34",
-        "@vueuse/core": "^14.3.0",
-        "cheerio": "^1.2.0",
-        "fflate": "^0.8.2",
-        "gray-matter": "^4.0.3",
-        "vue": "^3.5.34"
-      },
-      "peerDependencies": {
-        "@vuepress/bundler-vite": "2.0.0-rc.30",
-        "@vuepress/bundler-webpack": "2.0.0-rc.30",
-        "vuepress": "2.0.0-rc.30"
-      },
-      "peerDependenciesMeta": {
-        "@vuepress/bundler-vite": {
-          "optional": true
-        },
-        "@vuepress/bundler-webpack": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vuepress/plugin-shiki/node_modules/@vuepress/highlighter-helper": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/highlighter-helper/-/highlighter-helper-2.0.0-rc.130.tgz",
-      "integrity": "sha512-5tWF5I9gRFEcY8LIPUkPoe391LZeblMIrsJqhSSgJkoFUUe664DiEVpyBTpGGikd7q9+Wn9w8OWionBtR5POgg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@vuepress/helper": "2.0.0-rc.130",
-        "@vueuse/core": "^14.3.0",
-        "vuepress": "2.0.0-rc.30"
-      },
-      "peerDependenciesMeta": {
-        "@vueuse/core": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@vuepress/plugin-shiki/node_modules/nanoid": {
-      "version": "5.1.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
-      "integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-6.0.1.tgz",
+      "integrity": "sha512-3wVS3i51pE2pi1k5FFL/95BGfVS0kSsvDVuGXHOtxox/TywUmtgq+3qiTOTbs9J7KfHaXPiN171k/A6dBnaXFw==",
       "funding": [
         {
           "type": "github",
@@ -4594,146 +4141,91 @@
         "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^18 || >=20"
+        "node": "^22 || ^24 || >=26"
       }
     },
     "node_modules/@vuepress/plugin-sitemap": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-sitemap/-/plugin-sitemap-2.0.0-rc.130.tgz",
-      "integrity": "sha512-jeecCdcxap25+iguIOyNQtDBimh8rAwvyGCe8pdDzFVWWQFWiVthHWmjumftMDW02tIRPSmdwNeiPUJ8eZBCjg==",
+      "version": "2.0.0-rc.134",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-sitemap/-/plugin-sitemap-2.0.0-rc.134.tgz",
+      "integrity": "sha512-iFfrpIRzuv+oOXLvIh2qNzthC44ZF6A/t+hram3F1Aisz5X7K4tAbA+QTjaaQWSxav7H7qM2L1fkrPx0gnP1Fw==",
       "license": "MIT",
       "dependencies": {
-        "@vuepress/helper": "2.0.0-rc.130",
+        "@vuepress/helper": "2.0.0-rc.134",
         "sitemap": "^9.0.1"
       },
       "peerDependencies": {
-        "vuepress": "2.0.0-rc.30"
-      }
-    },
-    "node_modules/@vuepress/plugin-sitemap/node_modules/@vuepress/helper": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/helper/-/helper-2.0.0-rc.130.tgz",
-      "integrity": "sha512-x6UG/9XJvBREeTocRWji8SRqa14S+Xa8cw9b7Jc/Yh3eRwN/hrexM7ZkFixSjyslvYUaxLkOtEUZW/EK8ArMFw==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/shared": "^3.5.34",
-        "@vueuse/core": "^14.3.0",
-        "cheerio": "^1.2.0",
-        "fflate": "^0.8.2",
-        "gray-matter": "^4.0.3",
-        "vue": "^3.5.34"
-      },
-      "peerDependencies": {
-        "@vuepress/bundler-vite": "2.0.0-rc.30",
-        "@vuepress/bundler-webpack": "2.0.0-rc.30",
-        "vuepress": "2.0.0-rc.30"
-      },
-      "peerDependenciesMeta": {
-        "@vuepress/bundler-vite": {
-          "optional": true
-        },
-        "@vuepress/bundler-webpack": {
-          "optional": true
-        }
+        "vuepress": "2.0.0-rc.31"
       }
     },
     "node_modules/@vuepress/plugin-slimsearch": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-slimsearch/-/plugin-slimsearch-2.0.0-rc.130.tgz",
-      "integrity": "sha512-CzWioaawlBpkjM0S/Z7Z+8AMNnfalvlvuUZOssHDXMaVRMh4s2tDMh1ZNiS3+xVwbOpQvvoPUsbyTxXiEGbCZQ==",
+      "version": "2.0.0-rc.134",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-slimsearch/-/plugin-slimsearch-2.0.0-rc.134.tgz",
+      "integrity": "sha512-5n1r32FUtb7WG8/qXUQrUJwL6iUWKTRSBAexvJ76+rbO7dXFiCKdTJIl6eAgoCnW2tur/2i+WbauRVPfhkDxEQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@vuepress/helper": "2.0.0-rc.130",
-        "@vueuse/core": "^14.3.0",
+        "@vuepress/helper": "2.0.0-rc.134",
+        "@vueuse/core": "^14.4.0",
         "cheerio": "^1.2.0",
-        "slimsearch": "^2.3.0",
-        "vue": "^3.5.34"
+        "slimsearch": "^3.0.0",
+        "vue": "^3.5.42"
       },
       "peerDependencies": {
-        "vuepress": "2.0.0-rc.30"
-      }
-    },
-    "node_modules/@vuepress/plugin-slimsearch/node_modules/@vuepress/helper": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/helper/-/helper-2.0.0-rc.130.tgz",
-      "integrity": "sha512-x6UG/9XJvBREeTocRWji8SRqa14S+Xa8cw9b7Jc/Yh3eRwN/hrexM7ZkFixSjyslvYUaxLkOtEUZW/EK8ArMFw==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/shared": "^3.5.34",
-        "@vueuse/core": "^14.3.0",
-        "cheerio": "^1.2.0",
-        "fflate": "^0.8.2",
-        "gray-matter": "^4.0.3",
-        "vue": "^3.5.34"
-      },
-      "peerDependencies": {
-        "@vuepress/bundler-vite": "2.0.0-rc.30",
-        "@vuepress/bundler-webpack": "2.0.0-rc.30",
-        "vuepress": "2.0.0-rc.30"
-      },
-      "peerDependenciesMeta": {
-        "@vuepress/bundler-vite": {
-          "optional": true
-        },
-        "@vuepress/bundler-webpack": {
-          "optional": true
-        }
+        "vuepress": "2.0.0-rc.31"
       }
     },
     "node_modules/@vuepress/plugin-theme-data": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-theme-data/-/plugin-theme-data-2.0.0-rc.130.tgz",
-      "integrity": "sha512-UjVGs2RbSWKTyxxbbrVPDBJhIBqtlbYiXuG3gkRiyx4q5PJodhSRbFi/VW9BCspBZTZkiwqF6N2+o8iOWxSt/Q==",
+      "version": "2.0.0-rc.134",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-theme-data/-/plugin-theme-data-2.0.0-rc.134.tgz",
+      "integrity": "sha512-ji09x93XGAyZCc0BsgNUlqji7SPJ/x/trfSd7lp+EWUD0/tb9ScF2A7D8igZ6Y9JA1fIrRmJymmfITA5UlsOaQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/devtools-api": "^8.1.2",
-        "vue": "^3.5.34"
+        "@vue/devtools-api": "^8.2.1",
+        "vue": "^3.5.42"
       },
       "peerDependencies": {
-        "vuepress": "2.0.0-rc.30"
+        "vuepress": "2.0.0-rc.31"
       }
     },
     "node_modules/@vuepress/shared": {
-      "version": "2.0.0-rc.30",
-      "resolved": "https://registry.npmjs.org/@vuepress/shared/-/shared-2.0.0-rc.30.tgz",
-      "integrity": "sha512-tW2bUobo96UQjBtnq6VkFG8ytWTwFT/3jjSVp75kDUb6N6D5ogXZdQIMvX7q+9OW0ogNKjLkCyRM3xK5eJbojA==",
+      "version": "2.0.0-rc.31",
+      "resolved": "https://registry.npmjs.org/@vuepress/shared/-/shared-2.0.0-rc.31.tgz",
+      "integrity": "sha512-FCBYbDrRd8rbRdj7osw2liS+gGsx7eyYktEm0efJlZavPh5O9nqC6e1ryUc0Mjzo04ZCgS+8EY3B+NHa5W2t8A==",
       "license": "MIT",
       "dependencies": {
         "@mdit-vue/types": "^3.0.2"
       }
     },
     "node_modules/@vuepress/utils": {
-      "version": "2.0.0-rc.30",
-      "resolved": "https://registry.npmjs.org/@vuepress/utils/-/utils-2.0.0-rc.30.tgz",
-      "integrity": "sha512-pIqvCPDAm3puCeJqYtVmxTN35Q3ApKYe5O6xPYt0SExnmmZI6W7QmV1ZsYwanjjjWME2Kqd4OrFVxEw7V+V6ng==",
+      "version": "2.0.0-rc.31",
+      "resolved": "https://registry.npmjs.org/@vuepress/utils/-/utils-2.0.0-rc.31.tgz",
+      "integrity": "sha512-UeJYobsP2JuGjGNqh9Tk/iLhV9O0FQLj1ClFRxjG0gl/KUAASxofOODjOFFEsWv4FnkxNEUwejxO6cNqW1zOWg==",
       "license": "MIT",
       "dependencies": {
         "@types/debug": "^4.1.13",
         "@types/fs-extra": "^11.0.4",
         "@types/hash-sum": "^1.0.2",
         "@types/picomatch": "^4.0.3",
-        "@vuepress/shared": "2.0.0-rc.30",
+        "@vuepress/shared": "2.0.0-rc.31",
         "debug": "^4.4.3",
-        "fs-extra": "^11.3.5",
+        "fs-extra": "^11.3.6",
         "hash-sum": "^2.0.0",
-        "ora": "^9.4.0",
+        "ora": "^9.4.1",
         "picocolors": "^1.1.1",
-        "picomatch": "^4.0.4",
-        "tinyglobby": "^0.2.16",
-        "upath": "^3.0.7"
+        "picomatch": "^4.0.5",
+        "tinyglobby": "^0.2.17",
+        "upath": "^3.0.8"
       }
     },
     "node_modules/@vueuse/core": {
-      "version": "14.3.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-14.3.0.tgz",
-      "integrity": "sha512-aHfz47g0ZhMtTVHmIzMVpJy8ePhhOy68GY5bv110+5DVtZ+W7BsOx+m61UNQqfrWyPztIHIanWa3E2tib3NFIw==",
+      "version": "14.4.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-14.4.0.tgz",
+      "integrity": "sha512-X4WHz1HlCzCBoYXesUkifzzWBAcZgXG8Fi5iNPQg/epdzOB3gu8Fawj3hvuwYR1nGcXGnvxwYYcUC/71++svtQ==",
       "license": "MIT",
       "dependencies": {
         "@types/web-bluetooth": "^0.0.21",
-        "@vueuse/metadata": "14.3.0",
-        "@vueuse/shared": "14.3.0"
+        "@vueuse/metadata": "14.4.0",
+        "@vueuse/shared": "14.4.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
@@ -4743,18 +4235,18 @@
       }
     },
     "node_modules/@vueuse/metadata": {
-      "version": "14.3.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-14.3.0.tgz",
-      "integrity": "sha512-BwxmbAzwAVF50+MW57GXOUEV61nFBGnlBvrTqj49PqWJu3uw7hdu72ztXeZ33RdZtDY6kO+bfCAE1PCn88Tktw==",
+      "version": "14.4.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-14.4.0.tgz",
+      "integrity": "sha512-swx/255R6JyHZFJhx845iz5CRWDZdCfvkZOpACWc5+c5WHcG24mv8gUT1WIdFQaHt6dq79rvILd9QnCWiyVm9g==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@vueuse/shared": {
-      "version": "14.3.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-14.3.0.tgz",
-      "integrity": "sha512-bZpge9eSXwa4ToSiqJ7j6KRwhAsneMFoSz3LMWKQDkqimm3D/tbFlrklrs/IOqC8tEcYmXQZJ6N0UrjhBirVCg==",
+      "version": "14.4.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-14.4.0.tgz",
+      "integrity": "sha512-JRgY90Sz8DDtPMsaDflvPMp9xYk69JZAmbuDvAquUVXKr2gEjqtzGNTTthLfckH0BzBqvnu31gb4a8TGLRe79g==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
@@ -4776,9 +4268,9 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -4915,12 +4407,12 @@
       }
     },
     "node_modules/bcrypt-ts": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/bcrypt-ts/-/bcrypt-ts-8.0.1.tgz",
-      "integrity": "sha512-ILrO7U7YieyG+71KVIVVuPCmjN8N9DY3gYs4OiEoJvW8A5HOe4eerRhLD0Rgo2CAyANRKssFGXmLF74zJz094g==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-ts/-/bcrypt-ts-9.0.2.tgz",
+      "integrity": "sha512-esaMayGbxzD3bOpy7f00pa5wA15wqhP15RbDYGzh/xGbZRNr05G9HdNiqK4ywzrVdzO8rv+Z4l6m01/9pv1FRA==",
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/birpc": {
@@ -5263,12 +4755,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/confbox": {
@@ -5301,9 +4793,9 @@
       }
     },
     "node_modules/create-codepen": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/create-codepen/-/create-codepen-2.0.3.tgz",
-      "integrity": "sha512-HSy5IoCMdexZEIqFA6N1u2fkXzwdmUGFp6w+ELMW2AohHJuhsLQ+eZuX8TTPavloTvvRGMgDalq7mWNs4d7bgg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/create-codepen/-/create-codepen-2.0.4.tgz",
+      "integrity": "sha512-FqyukRiD6BS/T1Oq63RdMJg9ivLpcms4aA911mQwk221SVPOML/8PtPRwSTrAKMZuuGLDmvv7QM9mmmi1msfUw==",
       "license": "MIT",
       "engines": {
         "node": ">=22"
@@ -5538,6 +5030,7 @@
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
       "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -6540,9 +6033,9 @@
       }
     },
     "node_modules/markdown-it-cjk-friendly": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/markdown-it-cjk-friendly/-/markdown-it-cjk-friendly-2.0.2.tgz",
-      "integrity": "sha512-KXCl6sd129UqkAiRDb+NcAHrxC9xRa2WsGIsMMvtp2y1YlbeIaNYzArX2zfDoGhOjsyNMfJrGO7xGBss27YQSA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-cjk-friendly/-/markdown-it-cjk-friendly-3.0.0.tgz",
+      "integrity": "sha512-y4OkqwenFXmb1i3w7qfh9E60qNX6U4KzECke8N/7io9SARFSvbR/wde0q/l6/Az9doieLOIw7ZsbDSgl27DR4g==",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "^1.4.0"
@@ -6551,7 +6044,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@types/markdown-it": "*",
+        "@types/markdown-it": ">=14.2.0",
         "markdown-it": "*"
       },
       "peerDependenciesMeta": {
@@ -8378,19 +7871,19 @@
       }
     },
     "node_modules/shiki": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.3.1.tgz",
-      "integrity": "sha512-oR+qDVi2OjX1tmDpyv+3KviX01KzO6Af+0NNnKnsp9491UEGz2YpxTuJboS/6VhYpTdqzmuJBuiTlrAWWJAssw==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.4.3.tgz",
+      "integrity": "sha512-Mb/GvXPHBAXdgGIcnfU5L3ldpn1XcxrGkPHwqgRx17/I2XRfqlFKk2vGkHWINn1kdXvzJZeuO3is6I9KLPFm0g==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/core": "4.3.1",
-        "@shikijs/engine-javascript": "4.3.1",
-        "@shikijs/engine-oniguruma": "4.3.1",
-        "@shikijs/langs": "4.3.1",
-        "@shikijs/themes": "4.3.1",
-        "@shikijs/types": "4.3.1",
+        "@shikijs/core": "4.4.3",
+        "@shikijs/engine-javascript": "4.4.3",
+        "@shikijs/engine-oniguruma": "4.4.3",
+        "@shikijs/langs": "4.4.3",
+        "@shikijs/themes": "4.4.3",
+        "@shikijs/types": "4.4.3",
         "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.4"
+        "@types/hast": "^3.0.5"
       },
       "engines": {
         "node": ">=20"
@@ -8428,9 +7921,9 @@
       }
     },
     "node_modules/sitemap/node_modules/@types/node": {
-      "version": "24.13.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
-      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "version": "24.13.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.4.tgz",
+      "integrity": "sha512-YJ7EqCstVTzIr0fMr7qul/977en+pQHrfmuKIo6Zr9i75Be21dr3MovcfvGtyvi2HAUrRerWps5sMO9I7WaxDw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
@@ -8443,13 +7936,13 @@
       "license": "MIT"
     },
     "node_modules/slimsearch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/slimsearch/-/slimsearch-2.3.0.tgz",
-      "integrity": "sha512-e0L+ke+DGxptl2os/9DshoGVB+XkD2u1nSnRH4Jh0MNIfqkRUmLFLjvwVJiDT7grAYhpCEfHRv5nBNvcADZ4pw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slimsearch/-/slimsearch-3.0.0.tgz",
+      "integrity": "sha512-vckFE1PJyPEaj7YptS8AzUT2GzphtTsmWwd9MIGVudjbzagN1G0jNnm3fgkebNOSePM2OSld0mtoxiSczS3GoA==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18.18.0"
+        "node": ">=22"
       }
     },
     "node_modules/source-map-js": {
@@ -8611,11 +8104,14 @@
       }
     },
     "node_modules/tokenx": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/tokenx/-/tokenx-1.3.0.tgz",
-      "integrity": "sha512-NLdXTEZkKiO0gZuLtMoZKjCXTREXeZZt8nnnNeyoXtNZAfG/GKGSbQtLU5STspc0rMSwcA+UJfWZkbNU01iKmQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tokenx/-/tokenx-2.1.0.tgz",
+      "integrity": "sha512-iHhqfDuFFbMWHGfjEnVALgatV10KqcO5W5Fl99fYJmFjhE57JXPdnFrDlp6BTFIMmbbazsCg/lZYpJ2mPsPeQQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "bin": {
+        "tokenx": "bin/tokenx.mjs"
+      }
     },
     "node_modules/trim-lines": {
       "version": "3.0.1",
@@ -9435,18 +8931,18 @@
       }
     },
     "node_modules/vuepress": {
-      "version": "2.0.0-rc.30",
-      "resolved": "https://registry.npmjs.org/vuepress/-/vuepress-2.0.0-rc.30.tgz",
-      "integrity": "sha512-GHAIiUzDRvUJ4LW1K3Ha7VsDIuEOM0hlPSP6/8vTkspi23g4/JFGwy27+3IXDymIN7opxqrawjiO1ORTaF30DA==",
+      "version": "2.0.0-rc.31",
+      "resolved": "https://registry.npmjs.org/vuepress/-/vuepress-2.0.0-rc.31.tgz",
+      "integrity": "sha512-IcJ4E5iOL4aoERm5d+W4j6rJeH/gxDx+NGxvLYvEVPInmv2p90Mjj4VFjFoxqlWc7lIwwFNIVYpPI6dw0miH4Q==",
       "license": "MIT",
       "dependencies": {
-        "@vuepress/cli": "2.0.0-rc.30",
-        "@vuepress/client": "2.0.0-rc.30",
-        "@vuepress/core": "2.0.0-rc.30",
-        "@vuepress/markdown": "2.0.0-rc.30",
-        "@vuepress/shared": "2.0.0-rc.30",
-        "@vuepress/utils": "2.0.0-rc.30",
-        "vue": "^3.5.34"
+        "@vuepress/cli": "2.0.0-rc.31",
+        "@vuepress/client": "2.0.0-rc.31",
+        "@vuepress/core": "2.0.0-rc.31",
+        "@vuepress/markdown": "2.0.0-rc.31",
+        "@vuepress/shared": "2.0.0-rc.31",
+        "@vuepress/utils": "2.0.0-rc.31",
+        "vue": "^3.5.40"
       },
       "bin": {
         "vuepress": "bin/vuepress.js",
@@ -9457,9 +8953,9 @@
         "node": ">=22.18.0"
       },
       "peerDependencies": {
-        "@vuepress/bundler-vite": "2.0.0-rc.30",
-        "@vuepress/bundler-webpack": "2.0.0-rc.30",
-        "vue": "^3.5.34"
+        "@vuepress/bundler-vite": "2.0.0-rc.31",
+        "@vuepress/bundler-webpack": "2.0.0-rc.31",
+        "vue": "^3.5.40"
       },
       "peerDependenciesMeta": {
         "@vuepress/bundler-vite": {
@@ -9471,20 +8967,20 @@
       }
     },
     "node_modules/vuepress-plugin-components": {
-      "version": "2.0.0-rc.107",
-      "resolved": "https://registry.npmjs.org/vuepress-plugin-components/-/vuepress-plugin-components-2.0.0-rc.107.tgz",
-      "integrity": "sha512-nxoCqivo/UN4n6gOCod3ULY+qxx6s39Fu8dXg/UJ3VbfvJOxZ2732bKFBxSiTDpQqh+YgTUlzL9t94t1UuTpOg==",
+      "version": "2.0.0-rc.109",
+      "resolved": "https://registry.npmjs.org/vuepress-plugin-components/-/vuepress-plugin-components-2.0.0-rc.109.tgz",
+      "integrity": "sha512-fUOqwqqsDOgvzCd+FerD566zQ13L9SdRvfJYzMavFRY3y2QffZOAyaKcL8Xz6reA4oPIxoBf8QNSnFPuOxZsgA==",
       "license": "MIT",
       "dependencies": {
-        "@stackblitz/sdk": "^1.11.0",
-        "@vuepress/helper": "2.0.0-rc.130",
-        "@vuepress/plugin-sass-palette": "2.0.0-rc.130",
-        "@vueuse/core": "^14.3.0",
+        "@stackblitz/sdk": "^1.11.1",
+        "@vuepress/helper": "2.0.0-rc.134",
+        "@vuepress/plugin-sass-palette": "2.0.0-rc.134",
+        "@vueuse/core": "^14.4.0",
         "balloon-css": "^1.2.0",
-        "create-codepen": "^2.0.2",
+        "create-codepen": "^2.0.4",
         "qrcode": "^1.5.4",
-        "vue": "^3.5.34",
-        "vuepress-shared": "2.0.0-rc.107"
+        "vue": "^3.5.42",
+        "vuepress-shared": "2.0.0-rc.109"
       },
       "engines": {
         "node": ">=20.19.0",
@@ -9497,11 +8993,11 @@
         "dashjs": "4.7.4",
         "hls.js": "^1.4.12",
         "mpegts.js": "^1.7.3",
-        "sass": "^1.99.0",
-        "sass-embedded": "^1.99.0",
-        "sass-loader": "^16.0.8",
+        "sass": "^1.104.0",
+        "sass-embedded": "^1.104.0",
+        "sass-loader": "^17.0.1",
         "vidstack": "^1.12.9",
-        "vuepress": "2.0.0-rc.30"
+        "vuepress": "2.0.0-rc.31"
       },
       "peerDependenciesMeta": {
         "artplayer": {
@@ -9530,49 +9026,22 @@
         }
       }
     },
-    "node_modules/vuepress-plugin-components/node_modules/@vuepress/helper": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/helper/-/helper-2.0.0-rc.130.tgz",
-      "integrity": "sha512-x6UG/9XJvBREeTocRWji8SRqa14S+Xa8cw9b7Jc/Yh3eRwN/hrexM7ZkFixSjyslvYUaxLkOtEUZW/EK8ArMFw==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/shared": "^3.5.34",
-        "@vueuse/core": "^14.3.0",
-        "cheerio": "^1.2.0",
-        "fflate": "^0.8.2",
-        "gray-matter": "^4.0.3",
-        "vue": "^3.5.34"
-      },
-      "peerDependencies": {
-        "@vuepress/bundler-vite": "2.0.0-rc.30",
-        "@vuepress/bundler-webpack": "2.0.0-rc.30",
-        "vuepress": "2.0.0-rc.30"
-      },
-      "peerDependenciesMeta": {
-        "@vuepress/bundler-vite": {
-          "optional": true
-        },
-        "@vuepress/bundler-webpack": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/vuepress-plugin-md-enhance": {
-      "version": "2.0.0-rc.107",
-      "resolved": "https://registry.npmjs.org/vuepress-plugin-md-enhance/-/vuepress-plugin-md-enhance-2.0.0-rc.107.tgz",
-      "integrity": "sha512-LCrmYZh9ge1FWvBG1QkLhH6qDf/C1+OOXlGVaDv0seKNbXWanl8Oggf7Fu4WOQ3+yU22deN4xmWiPKnycdX9zQ==",
+      "version": "2.0.0-rc.109",
+      "resolved": "https://registry.npmjs.org/vuepress-plugin-md-enhance/-/vuepress-plugin-md-enhance-2.0.0-rc.109.tgz",
+      "integrity": "sha512-rszPlo6xbAEgvG8dEVfReqmPaEwVjj+X7IW5+7dFdmaURNq7BWr5jYDagOzHW1Hi32tzEovyzS3l/PDFnKlSug==",
       "license": "MIT",
       "dependencies": {
-        "@mdit/plugin-container": "^0.23.2",
-        "@mdit/plugin-demo": "^0.23.2",
-        "@types/markdown-it": "^14.1.2",
-        "@vuepress/helper": "2.0.0-rc.130",
-        "@vuepress/plugin-sass-palette": "2.0.0-rc.130",
-        "@vueuse/core": "^14.3.0",
+        "@mdit/plugin-container": "^2.0.0",
+        "@mdit/plugin-demo": "^2.0.0",
+        "@types/markdown-it": "^14.2.0",
+        "@vuepress/helper": "2.0.0-rc.134",
+        "@vuepress/plugin-sass-palette": "2.0.0-rc.134",
+        "@vueuse/core": "^14.4.0",
         "balloon-css": "^1.2.0",
-        "js-yaml": "^4.1.1",
-        "vue": "^3.5.34",
-        "vuepress-shared": "2.0.0-rc.107"
+        "js-yaml": "^5.4.1",
+        "vue": "^3.5.42",
+        "vuepress-shared": "2.0.0-rc.109"
       },
       "engines": {
         "node": ">= 20.19.0",
@@ -9584,11 +9053,11 @@
         "@vue/repl": "^4.1.1",
         "kotlin-playground": "^1.23.0",
         "sandpack-vue3": "^3.0.0",
-        "sass": "^1.99.0",
-        "sass-embedded": "^1.99.0",
-        "sass-loader": "^16.0.8",
-        "typescript": ">=5.0.0",
-        "vuepress": "2.0.0-rc.30"
+        "sass": "^1.104.0",
+        "sass-embedded": "^1.104.0",
+        "sass-loader": "^17.0.1",
+        "typescript": ">=5.0.0 && < 7.0.0",
+        "vuepress": "2.0.0-rc.31"
       },
       "peerDependenciesMeta": {
         "@vue/repl": {
@@ -9614,29 +9083,59 @@
         }
       }
     },
-    "node_modules/vuepress-plugin-md-enhance/node_modules/@vuepress/helper": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/helper/-/helper-2.0.0-rc.130.tgz",
-      "integrity": "sha512-x6UG/9XJvBREeTocRWji8SRqa14S+Xa8cw9b7Jc/Yh3eRwN/hrexM7ZkFixSjyslvYUaxLkOtEUZW/EK8ArMFw==",
+    "node_modules/vuepress-plugin-md-enhance/node_modules/@mdit/helper": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mdit/helper/-/helper-1.1.1.tgz",
+      "integrity": "sha512-Rrl14ZjFerzfAqCt0zxAWbPgRpsumgm9iBLrCVE05WS8dM6v/LnF1ppPFVnRz1F7fAaxn0kTFOlYwzcY+kRsHQ==",
       "license": "MIT",
-      "dependencies": {
-        "@vue/shared": "^3.5.34",
-        "@vueuse/core": "^14.3.0",
-        "cheerio": "^1.2.0",
-        "fflate": "^0.8.2",
-        "gray-matter": "^4.0.3",
-        "vue": "^3.5.34"
+      "engines": {
+        "node": ">=22"
       },
       "peerDependencies": {
-        "@vuepress/bundler-vite": "2.0.0-rc.30",
-        "@vuepress/bundler-webpack": "2.0.0-rc.30",
-        "vuepress": "2.0.0-rc.30"
+        "markdown-it": "^15.0.1"
       },
       "peerDependenciesMeta": {
-        "@vuepress/bundler-vite": {
+        "markdown-it": {
           "optional": true
-        },
-        "@vuepress/bundler-webpack": {
+        }
+      }
+    },
+    "node_modules/vuepress-plugin-md-enhance/node_modules/@mdit/plugin-container": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@mdit/plugin-container/-/plugin-container-2.0.1.tgz",
+      "integrity": "sha512-Heb0mQRy7AI46Szw1X/rqk2W7QJfVzJp08e2RRr41uN5eMuDFHXjpG/Fb3ywaTI7aw/MD4Q57Mug3hBKf5oZDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@mdit/helper": "1.1.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "markdown-it": "^15.0.1"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vuepress-plugin-md-enhance/node_modules/@mdit/plugin-demo": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@mdit/plugin-demo/-/plugin-demo-2.0.1.tgz",
+      "integrity": "sha512-0Uhjoq7v2b0HirR+7yIo3gZaWs1ChieYYVmvhqR606sm5iZPipq1t1JQ7rmd8bWeaatUOSAFwKlJWKNAoziIig==",
+      "license": "MIT",
+      "dependencies": {
+        "@mdit/helper": "1.1.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "markdown-it": "^15.0.1"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it": {
           "optional": true
         }
       }
@@ -9648,9 +9147,9 @@
       "license": "Python-2.0"
     },
     "node_modules/vuepress-plugin-md-enhance/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.4.1.tgz",
+      "integrity": "sha512-28R/k+NAjeuf7+CKlTxWZVExJGwVVLwY06DgEnOMz2gEpfNkDcD7QvyiVPT0xy0XXhU8vHsd4Ot42OOPdJG7dQ==",
       "funding": [
         {
           "type": "github",
@@ -9666,18 +9165,18 @@
         "argparse": "^2.0.1"
       },
       "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/vuepress-shared": {
-      "version": "2.0.0-rc.107",
-      "resolved": "https://registry.npmjs.org/vuepress-shared/-/vuepress-shared-2.0.0-rc.107.tgz",
-      "integrity": "sha512-Iw+LBRFinNVHLiHMwr9b8aKKpH2BviAossExrNEM1qfaRYTDgL6zR9wvPHFE7v3ygyeneKIyT1noxJfHsHBpZg==",
+      "version": "2.0.0-rc.109",
+      "resolved": "https://registry.npmjs.org/vuepress-shared/-/vuepress-shared-2.0.0-rc.109.tgz",
+      "integrity": "sha512-pk3TB2n25EivMjgGtMLruVqlc9LmOWKThUOeC/J8WzQxVVmkdPXUmo+Jg5VnzNNUjDHiBOupFaqSTqJnHQAA+w==",
       "license": "MIT",
       "dependencies": {
-        "@vuepress/helper": "2.0.0-rc.130",
-        "@vueuse/core": "^14.3.0",
-        "vue": "^3.5.34"
+        "@vuepress/helper": "2.0.0-rc.134",
+        "@vueuse/core": "^14.4.0",
+        "vue": "^3.5.42"
       },
       "engines": {
         "node": ">= 20.19.0",
@@ -9686,81 +9185,54 @@
         "yarn": ">=2"
       },
       "peerDependencies": {
-        "vuepress": "2.0.0-rc.30"
-      }
-    },
-    "node_modules/vuepress-shared/node_modules/@vuepress/helper": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/helper/-/helper-2.0.0-rc.130.tgz",
-      "integrity": "sha512-x6UG/9XJvBREeTocRWji8SRqa14S+Xa8cw9b7Jc/Yh3eRwN/hrexM7ZkFixSjyslvYUaxLkOtEUZW/EK8ArMFw==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/shared": "^3.5.34",
-        "@vueuse/core": "^14.3.0",
-        "cheerio": "^1.2.0",
-        "fflate": "^0.8.2",
-        "gray-matter": "^4.0.3",
-        "vue": "^3.5.34"
-      },
-      "peerDependencies": {
-        "@vuepress/bundler-vite": "2.0.0-rc.30",
-        "@vuepress/bundler-webpack": "2.0.0-rc.30",
-        "vuepress": "2.0.0-rc.30"
-      },
-      "peerDependenciesMeta": {
-        "@vuepress/bundler-vite": {
-          "optional": true
-        },
-        "@vuepress/bundler-webpack": {
-          "optional": true
-        }
+        "vuepress": "2.0.0-rc.31"
       }
     },
     "node_modules/vuepress-theme-hope": {
-      "version": "2.0.0-rc.107",
-      "resolved": "https://registry.npmjs.org/vuepress-theme-hope/-/vuepress-theme-hope-2.0.0-rc.107.tgz",
-      "integrity": "sha512-FKqsToGZHUDv31+in5Xh9FIUgZfcAkQoEjIeoPngEmkZ+i1PcdDArmteBcJFa8PiqNV+67ZqeZ07hYGaJh21ew==",
+      "version": "2.0.0-rc.109",
+      "resolved": "https://registry.npmjs.org/vuepress-theme-hope/-/vuepress-theme-hope-2.0.0-rc.109.tgz",
+      "integrity": "sha512-Jq3UTiVang2AWRPvbV6B97VBG9lQaBpn6zrzv6EL6b7FnG/98a9+uR0WW6Xu4lyz3A1AtV1omUac65fXDjnTtg==",
       "license": "MIT",
       "dependencies": {
-        "@vuepress/helper": "2.0.0-rc.130",
-        "@vuepress/plugin-active-header-links": "2.0.0-rc.130",
-        "@vuepress/plugin-back-to-top": "2.0.0-rc.130",
-        "@vuepress/plugin-blog": "2.0.0-rc.130",
-        "@vuepress/plugin-catalog": "2.0.0-rc.130",
-        "@vuepress/plugin-comment": "2.0.0-rc.130",
-        "@vuepress/plugin-copy-code": "2.0.0-rc.130",
-        "@vuepress/plugin-copyright": "2.0.0-rc.130",
-        "@vuepress/plugin-git": "2.0.0-rc.130",
-        "@vuepress/plugin-icon": "2.0.0-rc.130",
-        "@vuepress/plugin-links-check": "2.0.0-rc.130",
-        "@vuepress/plugin-markdown-chart": "2.0.0-rc.130",
-        "@vuepress/plugin-markdown-ext": "2.0.0-rc.130",
-        "@vuepress/plugin-markdown-hint": "2.0.0-rc.130",
-        "@vuepress/plugin-markdown-image": "2.0.0-rc.130",
-        "@vuepress/plugin-markdown-include": "2.0.0-rc.130",
-        "@vuepress/plugin-markdown-math": "2.0.0-rc.130",
-        "@vuepress/plugin-markdown-preview": "2.0.0-rc.130",
-        "@vuepress/plugin-markdown-stylize": "2.0.0-rc.130",
-        "@vuepress/plugin-markdown-tab": "2.0.0-rc.130",
-        "@vuepress/plugin-notice": "2.0.0-rc.130",
-        "@vuepress/plugin-nprogress": "2.0.0-rc.130",
-        "@vuepress/plugin-photo-swipe": "2.0.0-rc.130",
-        "@vuepress/plugin-reading-time": "2.0.0-rc.130",
-        "@vuepress/plugin-redirect": "2.0.0-rc.130",
-        "@vuepress/plugin-rtl": "2.0.0-rc.130",
-        "@vuepress/plugin-sass-palette": "2.0.0-rc.130",
-        "@vuepress/plugin-seo": "2.0.0-rc.130",
-        "@vuepress/plugin-shiki": "2.0.0-rc.130",
-        "@vuepress/plugin-sitemap": "2.0.0-rc.130",
-        "@vuepress/plugin-theme-data": "2.0.0-rc.130",
-        "@vueuse/core": "^14.3.0",
+        "@vuepress/helper": "2.0.0-rc.134",
+        "@vuepress/plugin-active-header-links": "2.0.0-rc.134",
+        "@vuepress/plugin-back-to-top": "2.0.0-rc.134",
+        "@vuepress/plugin-blog": "2.0.0-rc.134",
+        "@vuepress/plugin-catalog": "2.0.0-rc.134",
+        "@vuepress/plugin-comment": "2.0.0-rc.134",
+        "@vuepress/plugin-copy-code": "2.0.0-rc.134",
+        "@vuepress/plugin-copyright": "2.0.0-rc.134",
+        "@vuepress/plugin-git": "2.0.0-rc.134",
+        "@vuepress/plugin-icon": "2.0.0-rc.134",
+        "@vuepress/plugin-links-check": "2.0.0-rc.134",
+        "@vuepress/plugin-markdown-chart": "2.0.0-rc.134",
+        "@vuepress/plugin-markdown-ext": "2.0.0-rc.134",
+        "@vuepress/plugin-markdown-hint": "2.0.0-rc.134",
+        "@vuepress/plugin-markdown-image": "2.0.0-rc.134",
+        "@vuepress/plugin-markdown-include": "2.0.0-rc.134",
+        "@vuepress/plugin-markdown-math": "2.0.0-rc.134",
+        "@vuepress/plugin-markdown-preview": "2.0.0-rc.134",
+        "@vuepress/plugin-markdown-stylize": "2.0.0-rc.134",
+        "@vuepress/plugin-markdown-tab": "2.0.0-rc.134",
+        "@vuepress/plugin-notice": "2.0.0-rc.134",
+        "@vuepress/plugin-nprogress": "2.0.0-rc.134",
+        "@vuepress/plugin-photo-swipe": "2.0.0-rc.134",
+        "@vuepress/plugin-reading-time": "2.0.0-rc.134",
+        "@vuepress/plugin-redirect": "2.0.0-rc.134",
+        "@vuepress/plugin-rtl": "2.0.0-rc.134",
+        "@vuepress/plugin-sass-palette": "2.0.0-rc.134",
+        "@vuepress/plugin-seo": "2.0.0-rc.134",
+        "@vuepress/plugin-shiki": "2.0.0-rc.134",
+        "@vuepress/plugin-sitemap": "2.0.0-rc.134",
+        "@vuepress/plugin-theme-data": "2.0.0-rc.134",
+        "@vueuse/core": "^14.4.0",
         "balloon-css": "^1.2.0",
-        "bcrypt-ts": "^8.0.1",
+        "bcrypt-ts": "^9.0.2",
         "chokidar": "^5.0.0",
-        "vue": "^3.5.34",
-        "vuepress-plugin-components": "2.0.0-rc.107",
-        "vuepress-plugin-md-enhance": "2.0.0-rc.107",
-        "vuepress-shared": "2.0.0-rc.107"
+        "vue": "^3.5.42",
+        "vuepress-plugin-components": "2.0.0-rc.109",
+        "vuepress-plugin-md-enhance": "2.0.0-rc.109",
+        "vuepress-shared": "2.0.0-rc.109"
       },
       "engines": {
         "node": ">= 20.19.0",
@@ -9769,20 +9241,20 @@
         "yarn": ">=2"
       },
       "peerDependencies": {
-        "@vuepress/plugin-docsearch": "2.0.0-rc.130",
-        "@vuepress/plugin-feed": "2.0.0-rc.130",
-        "@vuepress/plugin-meilisearch": "2.0.0-rc.130",
-        "@vuepress/plugin-prismjs": "2.0.0-rc.130",
-        "@vuepress/plugin-pwa": "2.0.0-rc.130",
-        "@vuepress/plugin-revealjs": "2.0.0-rc.130",
-        "@vuepress/plugin-search": "2.0.0-rc.130",
-        "@vuepress/plugin-slimsearch": "2.0.0-rc.130",
-        "@vuepress/plugin-watermark": "2.0.0-rc.130",
-        "@vuepress/shiki-twoslash": "2.0.0-rc.130",
-        "sass": "^1.99.0",
-        "sass-embedded": "^1.99.0",
-        "sass-loader": "^16.0.8",
-        "vuepress": "2.0.0-rc.30"
+        "@vuepress/plugin-docsearch": "2.0.0-rc.134",
+        "@vuepress/plugin-feed": "2.0.0-rc.134",
+        "@vuepress/plugin-meilisearch": "2.0.0-rc.134",
+        "@vuepress/plugin-prismjs": "2.0.0-rc.134",
+        "@vuepress/plugin-pwa": "2.0.0-rc.134",
+        "@vuepress/plugin-revealjs": "2.0.0-rc.134",
+        "@vuepress/plugin-search": "2.0.0-rc.134",
+        "@vuepress/plugin-slimsearch": "2.0.0-rc.134",
+        "@vuepress/plugin-watermark": "2.0.0-rc.134",
+        "@vuepress/shiki-twoslash": "2.0.0-rc.134",
+        "sass": "^1.104.0",
+        "sass-embedded": "^1.104.0",
+        "sass-loader": "^17.0.1",
+        "vuepress": "2.0.0-rc.31"
       },
       "peerDependenciesMeta": {
         "@vuepress/plugin-docsearch": {
@@ -9822,33 +9294,6 @@
           "optional": true
         },
         "sass-loader": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vuepress-theme-hope/node_modules/@vuepress/helper": {
-      "version": "2.0.0-rc.130",
-      "resolved": "https://registry.npmjs.org/@vuepress/helper/-/helper-2.0.0-rc.130.tgz",
-      "integrity": "sha512-x6UG/9XJvBREeTocRWji8SRqa14S+Xa8cw9b7Jc/Yh3eRwN/hrexM7ZkFixSjyslvYUaxLkOtEUZW/EK8ArMFw==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/shared": "^3.5.34",
-        "@vueuse/core": "^14.3.0",
-        "cheerio": "^1.2.0",
-        "fflate": "^0.8.2",
-        "gray-matter": "^4.0.3",
-        "vue": "^3.5.34"
-      },
-      "peerDependencies": {
-        "@vuepress/bundler-vite": "2.0.0-rc.30",
-        "@vuepress/bundler-webpack": "2.0.0-rc.30",
-        "vuepress": "2.0.0-rc.30"
-      },
-      "peerDependenciesMeta": {
-        "@vuepress/bundler-vite": {
-          "optional": true
-        },
-        "@vuepress/bundler-webpack": {
           "optional": true
         }
       }
@@ -10125,9 +9570,9 @@
       }
     },
     "node_modules/yoctocolors": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
-      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+      "integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/website/package.json
+++ b/website/package.json
@@ -11,14 +11,14 @@
     "preview": "npm run docs:build && wrangler dev"
   },
   "dependencies": {
-    "@vuepress/bundler-vite": "2.0.0-rc.30",
+    "@vuepress/bundler-vite": "2.0.0-rc.31",
     "sass-embedded": "^1.100.0",
     "vue": "^3.5.40",
-    "vuepress": "2.0.0-rc.30",
-    "vuepress-theme-hope": "2.0.0-rc.107"
+    "vuepress": "2.0.0-rc.31",
+    "vuepress-theme-hope": "2.0.0-rc.109"
   },
   "devDependencies": {
-    "@vuepress/plugin-llms": "^2.0.0-rc.132",
+    "@vuepress/plugin-llms": "^2.0.0-rc.134",
     "@vuepress/plugin-slimsearch": "^2.0.0-rc.130",
     "wrangler": "^4.114.0"
   }

--- a/website/src/.vuepress/components/HomeHero.vue
+++ b/website/src/.vuepress/components/HomeHero.vue
@@ -33,6 +33,35 @@ const isMounted = ref(false)
 
 const donateAmounts = [5, 10, 25, 50]
 
+function detectArm64(): Promise<boolean> {
+  const uaData = (
+    navigator as Navigator & {
+      userAgentData?: {
+        getHighEntropyValues?: (hints: string[]) => Promise<{ architecture?: string }>
+      }
+    }
+  ).userAgentData
+  const uaFallback = (): boolean => /arm64|aarch64/i.test(navigator.userAgent)
+  if (uaData?.getHighEntropyValues) {
+    return uaData
+      .getHighEntropyValues(['architecture'])
+      .then((v) => v.architecture?.includes('arm') ?? false)
+      .catch(uaFallback)
+  }
+  return Promise.resolve(uaFallback())
+}
+
+// Picks the installer matching the client architecture. New dual-arch releases
+// ship `SoundSwitch_v<ver>_<state>_Installer.exe` (x64, unsuffixed) and
+// `..._Installer_arm64.exe`; old releases only have the unsuffixed x64 one.
+function pickInstallerAsset(assets: GitHubAsset[], isArm64: boolean): GitHubAsset | undefined {
+  const exes = assets.filter((a) => a.name.endsWith('.exe'))
+  if (isArm64) {
+    return exes.find((a) => a.name.includes('_arm64')) ?? exes.find((a) => !a.name.includes('_arm64')) ?? exes[0]
+  }
+  return exes.find((a) => !a.name.includes('_arm64')) ?? exes[0]
+}
+
 function buildDonateUrl(amount: number): string {
   const base = 'https://www.paypal.com/donate'
   // Fallback for uuidv4
@@ -100,12 +129,14 @@ onMounted(async () => {
       throw new Error('No stable release found')
     }
 
-    const exeAsset = stableRelease.assets.find((a) => a.name.endsWith('.exe'))
+    const isArm64 = await detectArm64()
+
+    const exeAsset = pickInstallerAsset(stableRelease.assets, isArm64)
 
     if (exeAsset) {
       downloadUrl.value = exeAsset.browser_download_url
     }
-    downloadText.value = `Download ${stableRelease.tag_name}`
+    downloadText.value = `Download ${stableRelease.tag_name} (${isArm64 ? 'arm64' : 'x64'})`
   } catch {
     // Fallback already set in refs
   } finally {

--- a/website/src/.vuepress/components/HomeHero.vue
+++ b/website/src/.vuepress/components/HomeHero.vue
@@ -136,7 +136,12 @@ onMounted(async () => {
     if (exeAsset) {
       downloadUrl.value = exeAsset.browser_download_url
     }
-    downloadText.value = `Download ${stableRelease.tag_name} (${isArm64 ? 'arm64' : 'x64'})`
+    // Label reflects the installer actually served: an arm64 client on an old
+    // release without an _arm64 asset gets the unsuffixed x64 installer.
+    const archTag = exeAsset
+      ? exeAsset.name.includes('_arm64') ? 'arm64' : 'x64'
+      : isArm64 ? 'arm64' : 'x64'
+    downloadText.value = `Download ${stableRelease.tag_name} (${archTag})`
   } catch {
     // Fallback already set in refs
   } finally {


### PR DESCRIPTION
## Root cause

The recurring `build-docs` CI failures (runs 34695174498 / 34695174550) come from an unresolvable peer graph: Renovate's separate PRs each moved **one** VuePress package, so e.g. `vuepress-theme-hope@2.0.0-rc.109` demands `vuepress@2.0.0-rc.31` while the repo still had `rc.30` → `npm error ERESOLVE` in `npm ci`.

## What this PR does

### 1. Align the VuePress stack (bumped together)
- `vuepress` rc.30 → **rc.31**
- `@vuepress/bundler-vite` rc.30 → **rc.31**
- `vuepress-theme-hope` rc.107 → **rc.109**
- `@vuepress/plugin-llms` ^rc.132 → ^rc.134 (rc.132 pins `vuepress@2.0.0-rc.30` as an exact peer, so it had to move too)
- `renovate.json`: added a packageRule grouping `vuepress`, `@vuepress/bundler-vite` and `vuepress-theme-hope` so they always update in one batch and this failure mode cannot recur.

### 2. Arch-aware download button (`HomeHero.vue`)
The homepage hero now picks the installer by browser architecture:

| Browser arch | Preferred asset | Fallback |
|---|---|---|
| arm64 | `*_Installer_arm64.exe` | unsuffixed/x64 `.exe`, then any `.exe` |
| x64 | `.exe` **not** containing `_arm64` | any `.exe` |

Detection is client-side only (inside `onMounted`): `navigator.userAgentData.getHighEntropyValues(['architecture'])` → contains `arm`, with a `/arm64|aarch64/i` UA regex fallback. Detection failure defaults to x64, which keeps old single-installer releases working.

The download telemetry label now carries the arch (e.g. `Download v7.3.3 (arm64)` / `(x64)`) so analytics can distinguish. `NightlyBuilds.vue` / `modules/nightlies.ts` were left untouched — they only consume the version.json `download_url` (nightlies are x64-only by design).

## Scope note

`website/src/getting-started.md` and `website/src/faq/*` are **intentionally NOT touched** — they are owned by the open PR #2442 (installer refactor) and touching them would cause merge conflicts.

## Verification

- Local (Linux): `cd website && npm ci && npm run docs:build` → exit 0.
- Superseded Renovate PRs #2312 / #2313 / #2431 will be closed once this is open.